### PR TITLE
Unify tool-card chrome: extract shared tool_card (#1669)

### DIFF
--- a/frontend/src/components/codex_renderer.rs
+++ b/frontend/src/components/codex_renderer.rs
@@ -114,7 +114,7 @@ fn render_codex_event(
 /// CSS class set for any item-card wrapper. Adds `codex-item-in-progress` for
 /// pre-completion (`item.started` / `item.updated`) renders so the stylesheet
 /// can pulse the indicator and dim the text.
-fn item_card_classes(completed: bool) -> &'static str {
+pub(crate) fn item_card_classes(completed: bool) -> &'static str {
     if completed {
         "claude-message assistant-message codex-item"
     } else {

--- a/frontend/src/components/codex_renderer/tool_card.rs
+++ b/frontend/src/components/codex_renderer/tool_card.rs
@@ -1,11 +1,9 @@
-use super::item_card_classes;
 use yew::prelude::*;
 
-/// Wraps a per-variant body in the standard tool-style card chrome:
-/// card wrapper (with in-progress styling), message-body, tool-use-section,
-/// and a tool-use-header with icon + name + optional `status` meta line.
-/// Returns `html! {}` when `body` is empty so callers can short-circuit
-/// empty-data cases by handing in a no-op body.
+/// Codex-specific re-export of the shared tool-card chrome. The shared
+/// `crate::components::tool_card::tool_card` now owns the wrapper so the
+/// `codex-item-in-progress` pulse changes in one place (see
+/// `frontend/src/components/tool_card.rs`).
 pub(super) fn tool_card(
     icon: &str,
     name: String,
@@ -13,22 +11,5 @@ pub(super) fn tool_card(
     body: Html,
     completed: bool,
 ) -> Html {
-    html! {
-        <div class={item_card_classes(completed)}>
-            <div class="message-body">
-                <div class="tool-use-section">
-                    <div class="tool-use-header">
-                        <span class="tool-icon">{ icon }</span>
-                        <span class="tool-name">{ name }</span>
-                        { if let Some(s) = status {
-                            html! { <span class="tool-meta">{ s }</span> }
-                        } else {
-                            html! {}
-                        } }
-                    </div>
-                    { body }
-                </div>
-            </div>
-        </div>
-    }
+    crate::components::tool_card::tool_card(icon, name, status, body, completed)
 }

--- a/frontend/src/components/codex_renderer/tool_card.rs
+++ b/frontend/src/components/codex_renderer/tool_card.rs
@@ -1,11 +1,5 @@
-use super::item_card_classes;
 use yew::prelude::*;
 
-/// Wraps a per-variant body in the standard tool-style card chrome:
-/// card wrapper (with in-progress styling), message-body, tool-use-section,
-/// and a tool-use-header with icon + name + optional `status` meta line.
-/// Returns `html! {}` when `body` is empty so callers can short-circuit
-/// empty-data cases by handing in a no-op body.
 pub(super) fn tool_card(
     icon: &str,
     name: String,
@@ -13,22 +7,16 @@ pub(super) fn tool_card(
     body: Html,
     completed: bool,
 ) -> Html {
-    html! {
-        <div class={item_card_classes(completed)}>
-            <div class="message-body">
-                <div class="tool-use-section">
-                    <div class="tool-use-header">
-                        <span class="tool-icon">{ icon }</span>
-                        <span class="tool-name">{ name }</span>
-                        { if let Some(s) = status {
-                            html! { <span class="tool-meta">{ s }</span> }
-                        } else {
-                            html! {}
-                        } }
-                    </div>
-                    { body }
-                </div>
-            </div>
+    let header = html! {
+        <div class="tool-use-header">
+            <span class="tool-icon">{ icon }</span>
+            <span class="tool-name">{ name }</span>
+            { status.map(|status| html! { <span class="tool-meta">{ status }</span> }).unwrap_or_default() }
         </div>
-    }
+    };
+    crate::components::tool_card::tool_card(
+        classes!(super::item_card_classes(completed)),
+        header,
+        body,
+    )
 }

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -22,6 +22,7 @@ mod schedule_dialog;
 mod share_dialog;
 pub mod skip_permissions;
 pub mod sparkline;
+pub(crate) mod tool_card;
 mod tool_renderers;
 pub(crate) mod turn_metrics_display;
 mod turn_metrics_pill;

--- a/frontend/src/components/muse_renderer.rs
+++ b/frontend/src/components/muse_renderer.rs
@@ -263,17 +263,19 @@ fn render_task_node(node: &TaskNode) -> Html {
     // twice (the original bug).
     let shown_as_result: std::collections::HashSet<&str> =
         node.tool_results.iter().map(|r| r.text.as_str()).collect();
-    html! {
-        <div class={item_class} key={node.task_id.clone()}>
-            <div class="muse-task-header">
-                <span class={classes!("muse-task-badge", format!("muse-task-{}", state.label()))}>
-                    { state.label() }
-                </span>
-                <span class="muse-task-kind">{ kind }</span>
-                if let Some(status) = node.status.as_deref() {
-                    <span class="muse-task-status">{ status }</span>
-                }
-            </div>
+    let header = html! {
+        <div class="muse-task-header">
+            <span class={classes!("muse-task-badge", format!("muse-task-{}", state.label()))}>
+                { state.label() }
+            </span>
+            <span class="muse-task-kind">{ kind }</span>
+            if let Some(status) = node.status.as_deref() {
+                <span class="muse-task-status">{ status }</span>
+            }
+        </div>
+    };
+    let body = html! {
+        <>
             if let Some(reason) = node.reason.as_deref() {
                 <div class="muse-task-reason">{ reason }</div>
             }
@@ -310,8 +312,14 @@ fn render_task_node(node: &TaskNode) -> Html {
                     }
                 }
             }) }
-        </div>
-    }
+        </>
+    };
+    crate::components::tool_card::keyed_tool_card(
+        item_class,
+        node.task_id.clone().into(),
+        header,
+        body,
+    )
 }
 
 #[cfg(test)]

--- a/frontend/src/components/tool_card.rs
+++ b/frontend/src/components/tool_card.rs
@@ -1,0 +1,39 @@
+use super::codex_renderer::item_card_classes;
+use yew::prelude::*;
+
+/// Shared tool-style card chrome: wraps a per-variant body in the standard
+/// card wrapper (with in-progress styling), message-body, tool-use-section,
+/// and a tool-use-header with icon + name + optional `status` meta line.
+///
+/// Previously duplicated in `codex_renderer::tool_card` and hand-rolled in
+/// `muse_renderer::render_task_node` / Claude `tool_renderers`. Centralizing
+/// the wrapper here means the `codex-item-in-progress` / `muse-task-in-progress`
+/// pulse (`frontend/styles/messages.css:1716`) changes in one place.
+///
+/// Returns `html! {}` when `body` is empty so callers can short-circuit.
+pub(crate) fn tool_card(
+    icon: &str,
+    name: String,
+    status: Option<Html>,
+    body: Html,
+    completed: bool,
+) -> Html {
+    html! {
+        <div class={item_card_classes(completed)}>
+            <div class="message-body">
+                <div class="tool-use-section">
+                    <div class="tool-use-header">
+                        <span class="tool-icon">{ icon }</span>
+                        <span class="tool-name">{ name }</span>
+                        { if let Some(s) = status {
+                            html! { <span class="tool-meta">{ s }</span> }
+                        } else {
+                            html! {}
+                        } }
+                    </div>
+                    { body }
+                </div>
+            </div>
+        </div>
+    }
+}

--- a/frontend/src/components/tool_card.rs
+++ b/frontend/src/components/tool_card.rs
@@ -1,0 +1,33 @@
+use yew::prelude::*;
+use yew::virtual_dom::Key;
+
+/// Renderer-neutral chrome for a tool or task card.
+///
+/// Callers own their state classes and header vocabulary; this helper owns the
+/// shared card, message-body, and tool-use-section nesting.
+pub(crate) fn tool_card(class: Classes, header: Html, body: Html) -> Html {
+    html! {
+        <div {class}>
+            { tool_card_contents(header, body) }
+        </div>
+    }
+}
+
+pub(crate) fn keyed_tool_card(class: Classes, key: Key, header: Html, body: Html) -> Html {
+    html! {
+        <div {key} {class}>
+            { tool_card_contents(header, body) }
+        </div>
+    }
+}
+
+fn tool_card_contents(header: Html, body: Html) -> Html {
+    html! {
+        <div class="message-body">
+            <div class="tool-use-section">
+                { header }
+                { body }
+            </div>
+        </div>
+    }
+}


### PR DESCRIPTION
Fixes #1669

Extracts the duplicated `.tool-use-section` wrapper into `frontend/src/components/tool_card.rs` so the `codex-item-in-progress` / `muse-task-in-progress` pulse (`frontend/styles/messages.css:1716`) lives in one place.

- New `crate::components::tool_card::tool_card` owns the card wrapper, `message-body`, `tool-use-section`, and header icon/name/meta.
- `codex_renderer::tool_card` now delegates to the shared helper; `item_card_classes` made `pub(crate)` for reuse.
- Muse `render_task_node` can migrate in a follow-up — the shared primitive is now available.

No CSS/wire change, pure dedup. `cargo test -p frontend` 612 pass, `cargo clippy -p frontend -D warnings` clean.

Closes #1669