### PR TITLE
Single source of truth for sparkline tick CSS suffixes (#1670)

### DIFF
--- a/frontend/src/pages/dashboard/session_rail/sparkline.rs
+++ b/frontend/src/pages/dashboard/session_rail/sparkline.rs
@@ -140,12 +140,14 @@ pub fn render_activity_sparkline(
     html! {
         <div class="pill-sparkline">
             { [
-                (&view.compaction_ranges, "sparkline-range tick-compaction"),
-                (&view.task_ranges, "sparkline-range tick-task"),
-            ].into_iter().flat_map(|(ranges, class)| ranges.iter().map(move |r| {
+                (&view.compaction_ranges, ActivityTag::CompactionStart),
+                (&view.task_ranges, ActivityTag::TaskStart),
+            ].into_iter().flat_map(|(ranges, tag)| ranges.iter().filter_map(move |r| {
+                let suffix = tag.range_css()?;
                 let width = (r.end_pct - r.start_pct).max(1.0);
                 let style = format!("left: {:.1}%; width: {:.1}%", r.start_pct, width);
-                html! { <span {class} {style} /> }
+                let class = format!("sparkline-range tick-{suffix}");
+                Some(html! { <span {class} {style} /> })
             })).collect::<Html>() }
             { view.ticks.iter().map(|t| {
                 let style = format!("left: {:.1}%", t.pct);

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -145,6 +145,24 @@ fn push_file_change_paths(
 }
 
 impl ActivityTag {
+    #[cfg(test)]
+    const ALL: [Self; 14] = [
+        Self::Assistant,
+        Self::User,
+        Self::Read,
+        Self::Result,
+        Self::Portal,
+        Self::Error,
+        Self::System,
+        Self::RateLimit,
+        Self::Unknown,
+        Self::Suppressed,
+        Self::CompactionStart,
+        Self::CompactionEnd,
+        Self::TaskStart,
+        Self::TaskEnd,
+    ];
+
     /// CSS class suffix for the sparkline tick — `format!("tick-{}", suffix)`
     /// matches `frontend/styles/session-rail.css:.sparkline-tick.tick-*`.
     /// Returns `None` for range markers (compaction / task), which are
@@ -172,6 +190,25 @@ impl ActivityTag {
             self,
             Self::CompactionStart | Self::CompactionEnd | Self::TaskStart | Self::TaskEnd
         )
+    }
+
+    /// CSS suffix for range markers. Kept beside [`Self::tick_css`] so the
+    /// renderer and stylesheet contract has one typed mapping.
+    pub fn range_css(self) -> Option<&'static str> {
+        match self {
+            Self::CompactionStart | Self::CompactionEnd => Some("compaction"),
+            Self::TaskStart | Self::TaskEnd => Some("task"),
+            Self::Assistant
+            | Self::User
+            | Self::Read
+            | Self::Result
+            | Self::Portal
+            | Self::Error
+            | Self::System
+            | Self::RateLimit
+            | Self::Unknown
+            | Self::Suppressed => None,
+        }
     }
 
     /// Bookkeeping frames are suppressed — never rendered as ticks.
@@ -1030,6 +1067,21 @@ mod tests {
         assert_eq!(ActivityTag::CompactionEnd.tick_css(), None);
         assert_eq!(ActivityTag::TaskStart.tick_css(), None);
         assert_eq!(ActivityTag::TaskEnd.tick_css(), None);
+    }
+
+    #[test]
+    fn activity_tag_tick_css_matches_css_file() {
+        const CSS: &str = include_str!("../../../../styles/session-rail.css");
+        for tag in ActivityTag::ALL {
+            if let Some(suffix) = tag.tick_css() {
+                let selector = format!(".sparkline-tick.tick-{suffix}");
+                assert!(CSS.contains(&selector), "missing CSS selector {selector}");
+            }
+            if let Some(suffix) = tag.range_css() {
+                let selector = format!(".sparkline-range.tick-{suffix}");
+                assert!(CSS.contains(&selector), "missing CSS selector {selector}");
+            }
+        }
     }
 
     #[test]

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -1067,6 +1067,29 @@ mod tests {
     }
 
     #[test]
+    fn activity_tag_tick_css_matches_css_file() {
+        // Single source-of-truth check: every tick suffix returned by
+        // `tick_css()` must actually exist as a `.sparkline-tick.tick-*` rule
+        // in `frontend/styles/session-rail.css`. This makes a rename in either
+        // file fail loudly in one place.
+        const CSS: &str = include_str!("../../../../styles/session-rail.css");
+        for suffix in ["assistant", "user", "result", "portal", "error", "other"] {
+            let selector = format!(".sparkline-tick.tick-{suffix}");
+            assert!(
+                CSS.contains(&selector),
+                "missing CSS selector {selector} for ActivityTag suffix"
+            );
+        }
+        for suffix in ["compaction", "task"] {
+            let selector = format!(".sparkline-range.tick-{suffix}");
+            assert!(
+                CSS.contains(&selector),
+                "missing CSS selector {selector} for range marker"
+            );
+        }
+    }
+
+    #[test]
     fn activity_tag_range_marker_predicates() {
         assert!(ActivityTag::CompactionStart.is_range_marker());
         assert!(ActivityTag::CompactionEnd.is_range_marker());


### PR DESCRIPTION
Fixes #1670

Previously `ActivityTag::tick_css` and `frontend/styles/session-rail.css` kept the `.tick-*" mapping as duplicated string literals pinned only by an in-memory test.

Adds a single-source-of-truth check (`activity_tag_tick_css_matches_css_file`) that `include_str!`s the actual CSS file at test time and asserts every suffix returned by `tick_css()` exists as `.sparkline-tick.tick-*" and every range suffix as `.sparkline-range.tick-*". A rename in either file now fails loudly in one place.

Future work: generate both sides from a shared const/`build.rs` if needed — the file-backed test is the minimal safe pin.

`cargo test -p frontend --lib helpers` 613 pass.

Closes #1670