### PR TITLE
Add illustrator pipeline tooling

### DIFF
--- a/scripts/illustrator/README.md
+++ b/scripts/illustrator/README.md
@@ -1,0 +1,77 @@
+# Illustrator pipeline
+
+Tooling around [`docs/prompts/illustrate-change.md`](../../docs/prompts/illustrate-change.md),
+which has a Fable session read a PR and compose an SVG explaining what the
+change does. These scripts are the parts worth automating: checking that the
+output follows the canonical layout, and assembling many diagrams into one
+sheet.
+
+The diagram itself is deliberately **not** automated. An earlier attempt
+generated diagrams from git statistics and could only ever draw where bytes
+moved — file-churn treemaps that explained nothing. Deciding what a change
+*means* is the whole job, and it is the part a script cannot do.
+
+## Generate
+
+Run the prompt in a Fable session per PR, writing each SVG to a directory:
+
+```
+/tmp/diagrams/pr-1643.svg
+/tmp/diagrams/pr-1659.svg
+...
+```
+
+## Check
+
+```sh
+./check-layout.py '/tmp/diagrams/pr-*.svg'
+```
+
+Verifies the canonical layout mechanically — canvas, background rect, header
+and subtitle baselines, `PR #n · title` heading format, the rule, the dashed
+divider, that content actually fills the panel band, and that every `id` is
+prefixed with its PR number. Prints a table and a failure tally.
+
+Sessions are independent and cannot see each other's output, so "they all
+looked consistent" is not something to take on faith across a dozen of them.
+
+Pair it with [`../check-svg-glyphs.py`](../check-svg-glyphs.py), which catches
+characters the rendering font cannot draw — those appear as empty boxes rather
+than raising an error.
+
+## Assemble
+
+```sh
+./make-contact-sheet.py 1643,1659,1611,1639,1649,1650,1576,1568,1613,1612,1661,1660 \
+    /tmp/diagrams /tmp/diagrams/contact-sheet.svg
+```
+
+Tiles twelve diagrams 3×4 with rules between them.
+
+**It namespaces every `id` per tile**, which is the non-obvious part. Bare ids
+like `arrow-green` collide across files — three of twelve diagrams defined
+exactly that — and on collision the first definition in document order wins, so
+later tiles silently draw the wrong marker. Nothing errors; the arrowheads are
+just the wrong colour.
+
+## Export
+
+```sh
+cairosvg contact-sheet.svg -o sheet-4k.png --output-width 3840
+```
+
+Verify opacity by rendering over white and sampling a corner — on a dark
+viewer a transparent background and an opaque one look identical:
+
+```sh
+cairosvg sheet.svg -o /tmp/check.png --background "#ffffff"
+python3 -c "from PIL import Image; print(Image.open('/tmp/check.png').convert('RGB').getpixel((3,3)))"
+# expect (26, 27, 38)
+```
+
+## One caution
+
+These sessions write a draft, rasterize it, look at it, and revise. A file
+appearing on disk does **not** mean the session is finished, so assembling on
+file existence can capture a superseded tile. Wait for the session to report
+completion; this bit twice, and only comparing mtimes afterwards caught it.

--- a/scripts/illustrator/check-layout.py
+++ b/scripts/illustrator/check-layout.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Check generated diagrams against the canonical layout.
+
+Usage: check-layout.py '/tmp/diagrams/pr-*.svg'
+
+Sessions run independently and cannot see each other's output, so consistency
+across a dozen diagrams is not something to eyeball. Prints a table plus a
+failure tally; exit status is informational.
+"""
+import xml.etree.ElementTree as ET, glob, os, re, sys
+
+NS='{http://www.w3.org/2000/svg}'
+def check(f):
+    pr = re.search(r'pr-(\d+)', f).group(1)
+    r = ET.parse(f).getroot()
+    kids = list(r)
+    out = {}
+    out['viewBox'] = r.get('viewBox') == '0 0 1200 720'
+    # <defs>/<title>/<desc>/<style> paint nothing, so a background rect that
+    # follows them is still behind every visible element.
+    NONRENDER = {NS+'defs', NS+'title', NS+'desc', NS+'style', NS+'metadata'}
+    rest = [k for k in kids if k.tag not in NONRENDER]
+    bg = rest[0] if rest else None
+    out['bg_first'] = (bg is not None and bg.tag==NS+'rect'
+                       and (bg.get('fill') or '').lower()=='#1a1b26'
+                       and bg.get('width')=='1200')
+    ys = lambda v: [e for e in r.iter(NS+'text') if e.get('y')==v]
+    out['head_y36'] = bool(ys('36'))
+    out['sub_y66'] = bool(ys('66'))
+    heads = ys('36')
+    txt = ''.join(heads[0].itertext()) if heads else ''
+    out['head_fmt'] = txt.startswith(f'PR #{pr}') and '·' in txt
+    out['rule_y96'] = any(e.get('y1')=='96' and e.get('y2')=='96' for e in r.iter(NS+'line'))
+    div = [e for e in r.iter(NS+'line') if e.get('x1')=='600' and e.get('x2')=='600']
+    out['divider'] = (not div) or any(e.get('stroke-dasharray') for e in div)
+    # deepest drawn y
+    maxy=0
+    for e in r.iter():
+        for a in ('y','y1','y2','cy'):
+            v=e.get(a)
+            if v:
+                try:
+                    n=float(v)
+                    if n<=760: maxy=max(maxy,n)
+                except ValueError: pass
+        if e.tag==NS+'rect' and e.get('y') and e.get('height') and e.get('fill','').lower()!='#1a1b26':
+            try: maxy=max(maxy,float(e.get('y'))+float(e.get('height')))
+            except ValueError: pass
+    out['fills_band'] = maxy >= 600
+    ids=[e.get('id') for e in r.iter() if e.get('id')]
+    out['ids_prefixed'] = all(i.startswith(f'pr{pr}') for i in ids) if ids else True
+    return pr, out, round(maxy)
+
+files = sorted(glob.glob(sys.argv[1]))
+keys = ['viewBox','bg_first','head_y36','sub_y66','head_fmt','rule_y96','divider','fills_band','ids_prefixed']
+print(f"{'PR':6}" + ''.join(f'{k[:9]:>11}' for k in keys) + '   maxY')
+fails={k:0 for k in keys}
+for f in files:
+    pr,o,my = check(f)
+    print(f"{pr:6}" + ''.join(f"{'ok' if o[k] else 'FAIL':>11}" for k in keys) + f"   {my}")
+    for k in keys:
+        if not o[k]: fails[k]+=1
+print(f"\n{len(files)} file(s). failures:", {k:v for k,v in fails.items() if v} or 'none')

--- a/scripts/illustrator/make-contact-sheet.py
+++ b/scripts/illustrator/make-contact-sheet.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Merge PR diagrams into a tiled contact sheet.
+
+Namespaces every `id` per tile: bare ids like `arrow-green` collide across
+files, and on collision the first definition in document order wins, so later
+tiles silently draw the wrong marker.
+"""
+import re, sys, pathlib
+
+order = [int(x) for x in sys.argv[1].split(",")]
+src = pathlib.Path(sys.argv[2]); dest = pathlib.Path(sys.argv[3])
+COLS, ROWS = 3, 4
+BG, MUTED = "#1a1b26", "#565f89"
+
+first = (src / f"pr-{order[0]}.svg").read_text()
+TW = int(re.search(r'viewBox="0 0 (\d+) (\d+)"', first).group(1))
+TH = int(re.search(r'viewBox="0 0 (\d+) (\d+)"', first).group(2))
+
+tiles = []
+for idx, pr in enumerate(order):
+    t = (src / f"pr-{pr}.svg").read_text()
+    inner = t[t.index(">", t.index("<svg")) + 1 : t.rindex("</svg>")]
+    for i in sorted(set(re.findall(r'id="([^"]+)"', inner)), key=len, reverse=True):
+        new = f"t{pr}-{i}"
+        inner = (inner.replace(f'id="{i}"', f'id="{new}"')
+                      .replace(f"url(#{i})", f"url(#{new})")
+                      .replace(f'href="#{i}"', f'href="#{new}"'))
+    c, r = idx % COLS, idx // COLS
+    tiles.append(f'<svg x="{c*TW}" y="{r*TH}" width="{TW}" height="{TH}" viewBox="0 0 {TW} {TH}">{inner}</svg>')
+
+W, H = COLS * TW, ROWS * TH
+rules = "".join(
+    [f'<line x1="{c*TW}" y1="0" x2="{c*TW}" y2="{H}" stroke="{MUTED}" stroke-opacity="0.55" stroke-width="2"/>' for c in range(1, COLS)]
+    + [f'<line x1="0" y1="{r*TH}" x2="{W}" y2="{r*TH}" stroke="{MUTED}" stroke-opacity="0.55" stroke-width="2"/>' for r in range(1, ROWS)]
+)
+dest.write_text(
+    f'<svg xmlns="http://www.w3.org/2000/svg" width="{W}" height="{H}" viewBox="0 0 {W} {H}">'
+    f'<rect x="0" y="0" width="{W}" height="{H}" fill="{BG}"/>' + "".join(tiles) + rules + "</svg>"
+)
+print(f"{dest.name}: {W}x{H}, {len(tiles)} tiles, {dest.stat().st_size//1024} KB")


### PR DESCRIPTION
Tooling around `docs/prompts/illustrate-change.md`, extracted from generating 36 diagrams across two repositories. **Draft** — the prompt and the glyph checker landed separately (#1664, #1666, #1667); this is the surrounding pipeline.

- **`check-layout.py`** — verifies the canonical layout mechanically: canvas, background rect, header and subtitle baselines, `PR #n · title` heading format, the rule, the dashed divider, that content actually fills the panel band, and per-PR `id` prefixing. Sessions run independently and cannot see each other's output, so consistency across a dozen is not something to take on faith.
- **`make-contact-sheet.py`** — tiles diagrams 3x4 with rules between them, **namespacing every `id` per tile**. Bare ids like `arrow-green` collide across files (three of twelve diagrams defined exactly that), and on collision the first definition in document order wins, so later tiles silently draw the wrong marker with nothing erroring.
- **`README.md`** — the generate/check/assemble/export flow, including verifying background opacity by rendering over white, since on a dark viewer transparent and opaque look identical.

Deliberately **not** automated: the diagram itself. An earlier attempt generated them from git statistics and could only ever draw where bytes moved.

One caveat documented in the README: these sessions write a draft, rasterize, look at it, and revise — so a file appearing on disk does not mean the session finished. Assembling on file existence captured a superseded tile twice.