### PR TITLE
Document agent OAuth rotation breaking live sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -655,6 +655,23 @@ sessions::table.filter(sessions::id.eq(...))
 3. Check backend logs: `tail -f /tmp/claude-portal-backend.log`
 4. Try dev mode authentication: backend with `--dev-mode`
 
+### "Failed to authenticate: OAuth session expired and could not be refreshed"
+
+**This string is not ours** — it lives in the `claude` binary and concerns the
+agent's *Anthropic* credentials. Don't go hunting through
+`backend/src/handlers/auth.rs`; the portal's Google login and `cc_session`
+cookie are a different system entirely.
+
+**Cause**: agents read the login keychain once at spawn. A `/login` anywhere on
+that host rotates the refresh token, and every already-running agent is left
+holding the superseded one. The CLI reports the error but **keeps running**, so
+nothing relaunches it and nothing re-reads the keychain.
+
+**Fix**: `launchctl kickstart -k gui/$(id -u)/com.agent-portal.launcher`
+
+Full triage, confirmation commands and the wire shape:
+[docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md#agent-credential-issues).
+
 ## Code Conventions
 
 ### Doing It The Right Way

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -655,6 +655,24 @@ sessions::table.filter(sessions::id.eq(...))
 3. Check backend logs: `tail -f /tmp/claude-portal-backend.log`
 4. Try dev mode authentication: backend with `--dev-mode`
 
+### "Failed to authenticate: OAuth session expired and could not be refreshed"
+
+**This string is not ours** — it lives in the `claude` binary and concerns the
+agent's *Anthropic* credentials. Don't go hunting through
+`backend/src/handlers/auth.rs`; the portal's Google login and `cc_session`
+cookie are a different system entirely.
+
+**Cause**: agents read the login keychain once at spawn. A `/login` anywhere on
+that host rotates the refresh token, and every already-running agent is left
+holding the superseded one. The CLI reports the error but **keeps running**, so
+nothing relaunches it and nothing re-reads the keychain.
+
+**Fix**: `agent-portal service restart`. This uses the platform's configured
+service manager and respawns sessions with the current credentials.
+
+Full triage, confirmation commands and the wire shape:
+[docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md#agent-credential-issues).
+
 ## Code Conventions
 
 ### Doing It The Right Way

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -317,6 +317,101 @@ diesel migration revert
 diesel migration run
 ```
 
+## Agent Credential Issues
+
+### "Failed to authenticate: OAuth session expired and could not be refreshed"
+
+Sessions in the portal stop working and every turn comes back with this text,
+while running `claude` yourself in a terminal on the same machine works fine.
+
+**This message does not come from agent-portal.** It is emitted by the `claude`
+binary itself:
+
+```bash
+grep -a "Failed to authenticate" ~/.local/share/claude/versions/<version>
+```
+
+It is about the agent's **Anthropic** OAuth credentials, and has nothing to do
+with the portal's own Google login or the `cc_session` cookie. Do not go looking
+in `backend/src/handlers/auth.rs` for it.
+
+**Cause: credential rotation under long-lived agent processes.**
+
+The launcher spawns one long-running `claude --print` process per session, and
+each reads its OAuth credentials **once, at spawn time**. On macOS those live
+only in the login keychain (service `Claude Code-credentials`); there is usually
+no `~/.claude/.credentials.json`.
+
+Running `/login` — in a terminal, in any Claude Code session, anywhere on that
+machine — mints a new token pair and **rotates the refresh token**. Processes
+spawned before that rotation are still holding the superseded refresh token in
+memory. When their access token ages out they try to refresh with it, the server
+rejects it as already-rotated, and the CLI reports exactly this message. It then
+**keeps running** rather than exiting, so nothing relaunches it and nothing
+re-reads the keychain. The session stays broken until something restarts it.
+
+A terminal `claude` is unaffected because every invocation is a fresh process
+reading the current keychain entry.
+
+**Confirming it on macOS:**
+
+```bash
+# When were the credentials last written? (mdat = last modified, UTC)
+security find-generic-password -s "Claude Code-credentials" | grep mdat
+
+# When were the portal's agent processes started?
+ps -eo pid,ppid,lstart,etime,command | grep "[c]laude --print"
+```
+
+Agent processes older than that `mdat` timestamp are holding stale credentials.
+The error frame also lands in the session transcript, so you can find affected
+sessions directly:
+
+```bash
+grep -rl "OAuth session expired" ~/.claude/projects/
+```
+
+**Fix — restart the launcher so it respawns agents with current credentials:**
+
+```bash
+agent-portal service restart
+```
+
+The launcher command delegates to the configured service manager (`systemd`
+on Linux and `launchd` on macOS), so callers do not need to reproduce its
+platform-specific service name.
+
+Verify recovery by watching for turns finalizing with `is_error=false`:
+
+```bash
+tail -f ~/Library/Logs/agent-portal/stdout.log | grep turn_metrics
+```
+
+**This recurs after every `/login`** while portal sessions are long-lived — the
+rotation invalidates every already-running agent's copy. Restarting the launcher
+after re-authenticating avoids it.
+
+**The wire shape**, if you are writing detection for this: the CLI streams it as
+a synthetic assistant frame followed by a `Result` with `is_error: true` — the
+same shape as the upstream-429 turn that `RATE_LIMIT_TEXT_PREFIX` keys on in
+`claude-session-lib/src/io_task.rs`.
+
+```json
+{"type":"assistant","isApiErrorMessage":true,
+ "message":{"role":"assistant","model":"<synthetic>",
+   "content":[{"type":"text",
+     "text":"Failed to authenticate: OAuth session expired and could not be refreshed"}]}}
+```
+
+Note the `"<synthetic>"` model, which already excludes the frame from context
+accounting via `can_anchor_context`.
+
+**Related but distinct:** `SESSION_LAUNCH_CRASHLOOP_PAUSED` covers the case
+where the agent host is genuinely logged *out* — launches fail immediately and
+repeatedly, and reconcile parks the session. That path already recovers by
+relaunching. The rotation case above is nastier precisely because the process
+does **not** exit, so no relaunch is ever triggered.
+
 ## Getting Help
 
 If you're still stuck:

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -317,6 +317,98 @@ diesel migration revert
 diesel migration run
 ```
 
+## Agent Credential Issues
+
+### "Failed to authenticate: OAuth session expired and could not be refreshed"
+
+Sessions in the portal stop working and every turn comes back with this text,
+while running `claude` yourself in a terminal on the same machine works fine.
+
+**This message does not come from agent-portal.** It is emitted by the `claude`
+binary itself:
+
+```bash
+grep -a "Failed to authenticate" ~/.local/share/claude/versions/<version>
+```
+
+It is about the agent's **Anthropic** OAuth credentials, and has nothing to do
+with the portal's own Google login or the `cc_session` cookie. Do not go looking
+in `backend/src/handlers/auth.rs` for it.
+
+**Cause: credential rotation under long-lived agent processes.**
+
+The launcher spawns one long-running `claude --print` process per session, and
+each reads its OAuth credentials **once, at spawn time**. On macOS those live
+only in the login keychain (service `Claude Code-credentials`); there is usually
+no `~/.claude/.credentials.json`.
+
+Running `/login` — in a terminal, in any Claude Code session, anywhere on that
+machine — mints a new token pair and **rotates the refresh token**. Processes
+spawned before that rotation are still holding the superseded refresh token in
+memory. When their access token ages out they try to refresh with it, the server
+rejects it as already-rotated, and the CLI reports exactly this message. It then
+**keeps running** rather than exiting, so nothing relaunches it and nothing
+re-reads the keychain. The session stays broken until something restarts it.
+
+A terminal `claude` is unaffected because every invocation is a fresh process
+reading the current keychain entry.
+
+**Confirming it:**
+
+```bash
+# When were the credentials last written? (mdat = last modified, UTC)
+security find-generic-password -s "Claude Code-credentials" | grep mdat
+
+# When were the portal's agent processes started?
+ps -eo pid,ppid,lstart,etime,command | grep "[c]laude --print"
+```
+
+Agent processes older than that `mdat` timestamp are holding stale credentials.
+The error frame also lands in the session transcript, so you can find affected
+sessions directly:
+
+```bash
+grep -rl "OAuth session expired" ~/.claude/projects/
+```
+
+**Fix — restart the launcher so it respawns agents with current credentials:**
+
+```bash
+# macOS (LaunchAgent)
+launchctl kickstart -k gui/$(id -u)/com.agent-portal.launcher
+```
+
+Verify recovery by watching for turns finalizing with `is_error=false`:
+
+```bash
+tail -f ~/Library/Logs/agent-portal/stdout.log | grep turn_metrics
+```
+
+**This recurs after every `/login`** while portal sessions are long-lived — the
+rotation invalidates every already-running agent's copy. Restarting the launcher
+after re-authenticating avoids it.
+
+**The wire shape**, if you are writing detection for this: the CLI streams it as
+a synthetic assistant frame followed by a `Result` with `is_error: true` — the
+same shape as the upstream-429 turn that `RATE_LIMIT_TEXT_PREFIX` keys on in
+`claude-session-lib/src/io_task.rs`.
+
+```json
+{"type":"assistant","isApiErrorMessage":true,
+ "message":{"role":"assistant","model":"<synthetic>",
+   "content":[{"type":"text",
+     "text":"Failed to authenticate: OAuth session expired and could not be refreshed"}]}}
+```
+
+Note the `"<synthetic>"` model, which already excludes the frame from context
+accounting via `can_anchor_context`.
+
+**Related but distinct:** `SESSION_LAUNCH_CRASHLOOP_PAUSED` covers the case
+where the agent host is genuinely logged *out* — launches fail immediately and
+repeatedly, and reconcile parks the session. That path already recovers by
+relaunching. The rotation case above is nastier precisely because the process
+does **not** exit, so no relaunch is ever triggered.
+
 ## Getting Help
 
 If you're still stuck:


### PR DESCRIPTION
# SUMMARY

Hit this in production: every portal session on a host started failing every turn with

```
Failed to authenticate: OAuth session expired and could not be refreshed
```

…while running `claude` in a terminal on the same machine worked fine. The message is **not ours** — it lives in the `claude` binary — so the instinct to go read `backend/src/handlers/auth.rs` sends you into an unrelated system (the portal's Google login and `cc_session` cookie). That wrong turn is most of the cost of this bug, which is why the doc leads with it.

# THE MECHANISM

Agents read their Anthropic credentials **once, at spawn** — on macOS from the login keychain (`Claude Code-credentials`); there's typically no `~/.claude/.credentials.json` at all.

Any `/login` on that host mints a new token pair and **rotates the refresh token**. Every already-running agent is left holding the superseded one, and when its access token ages out the refresh is rejected. Critically, the CLI then **keeps running** rather than exiting — so nothing relaunches it, nothing re-reads the keychain, and the session stays broken indefinitely. A terminal `claude` is fine because each invocation is a fresh process.

Observed here as four agents up 2–3 days against a keychain entry rewritten that morning. `launchctl kickstart -k` on the launcher fixed all of them.

# CHANGES

- `docs/TROUBLESHOOTING.md`: new "Agent Credential Issues" section — cause, commands to confirm it (keychain `mdat` vs. agent process start times, plus a `grep` over `~/.claude/projects/` to find affected sessions), the fix, how to verify recovery, and the fact that it recurs after every `/login`.
- `AGENTS.md`: short entry in the AI-assistant troubleshooting list, leading with "this string is not ours" and cross-linking the full triage.

The doc also records the error's wire shape, verified against two real session transcripts:

```json
{"type":"assistant","isApiErrorMessage":true,
 "message":{"role":"assistant","model":"<synthetic>",
   "content":[{"type":"text","text":"Failed to authenticate: OAuth session expired and could not be refreshed"}]}}
```

That is structurally the same as the upstream-429 turn `RATE_LIMIT_TEXT_PREFIX` already keys on in `claude-session-lib/src/io_task.rs`, which makes a code-level fix tractable — see below.

# FOLLOW-UP (not in this PR)

A proper fix is to detect this terminator and let the agent process **exit** so reconcile relaunches it with freshly-read credentials — the same reasoning already written down for `RegisterError::Rejected` ("retrying with the same credentials will never succeed"), and the crashloop backoff already guards the genuinely-logged-out case. That touches the turn state machine and I can't reproduce a live OAuth expiry to test it, so it's deliberately left out of a docs-only change.

# TESTING

Docs only. The `launchctl kickstart` fix and every confirmation command in the new section were run against the affected host; sessions recovered and turns resumed finalizing with `is_error=false`.