### PR TITLE
Move experimental launcher warning from Codex to Muse

### DIFF
--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -837,9 +837,9 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                         </div>
                     }
 
-                    if *agent_type == AgentType::Codex {
+                    if *agent_type == AgentType::Muse {
                         <div class="launch-note launch-note-warn">
-                            { "Codex support is highly experimental." }
+                            { "Muse support is highly experimental." }
                         </div>
                     }
 


### PR DESCRIPTION
## Summary
- remove the experimental-support warning when Codex is selected
- show the warning when Muse is selected instead

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p frontend --lib` (634 passed)