### PR TITLE
Show reply reminders on typed agent messages

### DIFF
--- a/frontend/src/components/markdown/mod.rs
+++ b/frontend/src/components/markdown/mod.rs
@@ -50,6 +50,12 @@ pub fn render_markdown_for_session(text: &str, session_id: Uuid) -> Html {
     }
 }
 
+/// Render one machine-authored reminder using the same collapsed treatment as
+/// a `<system-reminder>` block embedded in markdown.
+pub(crate) fn render_system_reminder(body: &str) -> Html {
+    html! { <SystemReminderBar body={body.to_string()} /> }
+}
+
 #[derive(Properties, PartialEq)]
 struct MarkdownViewProps {
     text: String,

--- a/frontend/src/components/message_renderer/renderers/portal.rs
+++ b/frontend/src/components/message_renderer/renderers/portal.rs
@@ -211,6 +211,7 @@ fn render_agent_message_event_card(
         .next()
         .unwrap_or(&event.from_session_id);
     let label = agent_label(&event.from_agent_type);
+    let reply_reminder = agent_message_reply_reminder(event);
     html! {
         <div class="claude-message user-message other-agent-message agent-message-event">
             <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
@@ -222,9 +223,20 @@ fn render_agent_message_event_card(
             </div>
             <div class="message-body">
                 { render_agent_message_body(&event.text, session_id) }
+                {
+                    reply_reminder
+                        .as_deref()
+                        .map(crate::components::markdown::render_system_reminder)
+                        .unwrap_or_default()
+                }
             </div>
         </div>
     }
+}
+
+fn agent_message_reply_reminder(event: &AgentMessageEvent) -> Option<String> {
+    (!shared::system_reminder::has_system_reminder(&event.text))
+        .then(|| shared::agent_message_reply_reminder(&event.from_session_id))
 }
 
 pub(crate) fn render_agent_message_body(text: &str, session_id: Uuid) -> Html {
@@ -511,6 +523,20 @@ This message came from another agent.\n\
         // instruction the recipient acted on instead of hiding it.
         assert!(event.text.starts_with("Will do."));
         assert!(event.text.contains("<system-reminder>"));
+        assert!(agent_message_reply_reminder(&event).is_none());
+    }
+
+    #[test]
+    fn typed_agent_message_adds_reply_reminder_for_synthetic_echoes() {
+        let event = AgentMessageEvent {
+            from_agent_type: "claude".to_string(),
+            from_session_id: "11111111-1111-1111-1111-111111111111".to_string(),
+            text: "hello from typed display event".to_string(),
+        };
+
+        let reminder = agent_message_reply_reminder(&event).expect("reply reminder");
+        assert!(reminder.contains("Reply to that agent, not the user"));
+        assert!(reminder.contains("agent-portal message send 11111111"));
     }
 
     #[test]

--- a/frontend/src/components/message_renderer/renderers/portal.rs
+++ b/frontend/src/components/message_renderer/renderers/portal.rs
@@ -174,6 +174,7 @@ fn render_agent_message_event_card(
         .next()
         .unwrap_or(&event.from_session_id);
     let label = agent_label(&event.from_agent_type);
+    let reply_reminder = agent_message_reply_reminder(event);
     html! {
         <div class="claude-message user-message other-agent-message agent-message-event">
             <div class="message-header" title={timestamp.unwrap_or_default().to_string()}>
@@ -185,9 +186,20 @@ fn render_agent_message_event_card(
             </div>
             <div class="message-body">
                 { render_agent_message_body(&event.text, session_id) }
+                {
+                    reply_reminder
+                        .as_deref()
+                        .map(crate::components::markdown::render_system_reminder)
+                        .unwrap_or_default()
+                }
             </div>
         </div>
     }
+}
+
+fn agent_message_reply_reminder(event: &AgentMessageEvent) -> Option<String> {
+    (!shared::system_reminder::has_system_reminder(&event.text))
+        .then(|| shared::agent_message_reply_reminder(&event.from_session_id))
 }
 
 pub(crate) fn render_agent_message_body(text: &str, session_id: Uuid) -> Html {
@@ -474,6 +486,20 @@ This message came from another agent.\n\
         // instruction the recipient acted on instead of hiding it.
         assert!(event.text.starts_with("Will do."));
         assert!(event.text.contains("<system-reminder>"));
+        assert!(agent_message_reply_reminder(&event).is_none());
+    }
+
+    #[test]
+    fn typed_agent_message_adds_reply_reminder_for_synthetic_echoes() {
+        let event = AgentMessageEvent {
+            from_agent_type: "claude".to_string(),
+            from_session_id: "11111111-1111-1111-1111-111111111111".to_string(),
+            text: "hello from typed display event".to_string(),
+        };
+
+        let reminder = agent_message_reply_reminder(&event).expect("reply reminder");
+        assert!(reminder.contains("Reply to that agent, not the user"));
+        assert!(reminder.contains("agent-portal message send 11111111"));
     }
 
     #[test]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -811,14 +811,11 @@ impl PortalMessage {
         else {
             return None;
         };
-        let reply_session_id = short_reply_session_id(from_session_id);
+        let reminder = agent_message_reply_reminder(from_session_id);
         Some(format!(
             "[message from {from_agent_type} {from_session_id}]\n{text}\n\n\
 <system-reminder>\n\
-This message came from another agent. Reply to that agent, not the user.\n\
-Sender session id: {from_session_id}\n\
-Reply with:\n\
-agent-portal message send {reply_session_id} \"your reply\"\n\
+{reminder}\n\
 </system-reminder>"
         ))
     }
@@ -826,6 +823,21 @@ agent-portal message send {reply_session_id} \"your reply\"\n\
     pub fn to_json(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap_or_default()
     }
+}
+
+/// Body of the reminder shown and sent with an inter-agent message.
+///
+/// The agent-facing prompt and the typed transcript card share this text so
+/// Claude's echoed-input path and Codex's synthetic-input path explain the
+/// same reply workflow without maintaining two copies.
+pub fn agent_message_reply_reminder(from_session_id: &str) -> String {
+    let reply_session_id = short_reply_session_id(from_session_id);
+    format!(
+        "This message came from another agent. Reply to that agent, not the user.\n\
+Sender session id: {from_session_id}\n\
+Reply with:\n\
+agent-portal message send {reply_session_id} \"your reply\""
+    )
 }
 
 fn short_reply_session_id(session_id: &str) -> String {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -808,14 +808,11 @@ impl PortalMessage {
         else {
             return None;
         };
-        let reply_session_id = short_reply_session_id(from_session_id);
+        let reminder = agent_message_reply_reminder(from_session_id);
         Some(format!(
             "[message from {from_agent_type} {from_session_id}]\n{text}\n\n\
 <system-reminder>\n\
-This message came from another agent. Reply to that agent, not the user.\n\
-Sender session id: {from_session_id}\n\
-Reply with:\n\
-agent-portal message send {reply_session_id} \"your reply\"\n\
+{reminder}\n\
 </system-reminder>"
         ))
     }
@@ -823,6 +820,21 @@ agent-portal message send {reply_session_id} \"your reply\"\n\
     pub fn to_json(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap_or_default()
     }
+}
+
+/// Body of the reminder shown and sent with an inter-agent message.
+///
+/// The agent-facing prompt and the typed transcript card share this text so
+/// Claude's echoed-input path and Codex's synthetic-input path explain the
+/// same reply workflow without maintaining two copies.
+pub fn agent_message_reply_reminder(from_session_id: &str) -> String {
+    let reply_session_id = short_reply_session_id(from_session_id);
+    format!(
+        "This message came from another agent. Reply to that agent, not the user.\n\
+Sender session id: {from_session_id}\n\
+Reply with:\n\
+agent-portal message send {reply_session_id} \"your reply\""
+    )
 }
 
 fn short_reply_session_id(session_id: &str) -> String {


### PR DESCRIPTION
## Summary
- share the inter-agent reply-reminder body between agent-facing prompts and transcript rendering
- add the collapsed reminder bumper when a typed synthetic display event lacks the embedded wrapper
- detect echoed Claude/legacy wrappers and avoid rendering a duplicate bumper

## Root cause
Claude echoes the full agent-facing prompt, including its `<system-reminder>`. Codex does not echo input, so its transcript uses the typed display event whose message text intentionally contains only the sender body. The shared card renderer now restores the same explanatory UI for that typed path.

## Validation
- focused shared and frontend regression tests
- `cargo clippy -p shared -p frontend --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`