### PR TITLE
Consolidate AgentType pill/sparkline colors via shared::palette (#1727)

### DIFF
--- a/frontend/src/components/ansi.rs
+++ b/frontend/src/components/ansi.rs
@@ -48,22 +48,22 @@ impl AnsiColor {
 /// The 16 standard SGR colors, mapped to Tokyo-Night terminal hues so they read
 /// on the `#1a1b26` surface. Index 0–7 standard, 8–15 bright.
 const STANDARD_HEX: [&str; 16] = [
-    "#414868", // 0 black
-    "#f7768e", // 1 red
-    "#9ece6a", // 2 green
-    "#e0af68", // 3 yellow
-    "#7aa2f7", // 4 blue
-    "#bb9af7", // 5 magenta
-    "#7dcfff", // 6 cyan
-    "#a9b1d6", // 7 white
-    "#565f89", // 8 bright black (grey)
-    "#ff899d", // 9 bright red
-    "#9fe044", // 10 bright green
-    "#faba4a", // 11 bright yellow
-    "#8db0ff", // 12 bright blue
-    "#c7a9ff", // 13 bright magenta
-    "#a4daff", // 14 bright cyan
-    "#c0caf5", // 15 bright white
+    "#414868",                      // 0 black
+    shared::palette::ACCENT_RED,    // 1 red
+    shared::palette::ACCENT_GREEN,  // 2 green
+    shared::palette::ACCENT_ORANGE, // 3 yellow
+    shared::palette::ACCENT_BLUE,   // 4 blue
+    shared::palette::ACCENT_PURPLE, // 5 magenta
+    shared::palette::ACCENT_TEAL,   // 6 cyan
+    "#a9b1d6",                      // 7 white
+    shared::palette::MUTED_GRAY,    // 8 bright black (grey)
+    "#ff899d",                      // 9 bright red
+    "#9fe044",                      // 10 bright green
+    "#faba4a",                      // 11 bright yellow
+    "#8db0ff",                      // 12 bright blue
+    "#c7a9ff",                      // 13 bright magenta
+    "#a4daff",                      // 14 bright cyan
+    shared::palette::TEXT_LIGHT,    // 15 bright white
 ];
 
 /// Resolve an xterm-256 index to a hex string: 0–15 the standard slots, 16–231

--- a/frontend/src/components/sparkline.rs
+++ b/frontend/src/components/sparkline.rs
@@ -17,7 +17,7 @@ use yew::prelude::*;
 /// Tokyo-Night accent blue — matches the per-turn footer chip color and the
 /// pill border. Used for both the polyline stroke and the most-recent-point
 /// dot.
-const ACCENT_COLOR: &str = "#7aa2f7";
+use shared::palette::ACCENT_BLUE as ACCENT_COLOR;
 
 /// Fractional vertical margin added inside the SVG viewbox so the polyline
 /// doesn't render flush against the top/bottom edges. With a 20px height, a

--- a/frontend/src/pages/settings/performance_panel/model.rs
+++ b/frontend/src/pages/settings/performance_panel/model.rs
@@ -53,12 +53,12 @@ pub(super) fn pair_label(pair: &GroupKey) -> String {
 /// across re-renders.
 pub(super) fn pair_color(idx: usize) -> &'static str {
     const PALETTE: &[&str] = &[
-        "#7aa2f7", // accent blue
-        "#bb9af7", // purple
-        "#9ece6a", // green
-        "#e0af68", // yellow
-        "#f7768e", // red (used by max_tokens band)
-        "#7dcfff", // cyan
+        shared::palette::ACCENT_BLUE,
+        shared::palette::ACCENT_PURPLE,
+        shared::palette::ACCENT_GREEN,
+        shared::palette::ACCENT_ORANGE,
+        shared::palette::ACCENT_RED,
+        shared::palette::ACCENT_TEAL,
         "#ff9e64", // orange
     ];
     PALETTE[idx % PALETTE.len()]

--- a/frontend/src/pages/settings/performance_panel/series.rs
+++ b/frontend/src/pages/settings/performance_panel/series.rs
@@ -61,10 +61,10 @@ pub(super) fn build_stop_reason_series(
     active_pairs: &[GroupKey],
 ) -> Vec<StackedSeries> {
     const REASONS: &[(&str, &str, &str)] = &[
-        ("end_turn", "end_turn", "#9ece6a"),
-        ("tool_use", "tool_use", "#7aa2f7"),
-        ("max_tokens", "max_tokens", "#f7768e"),
-        ("error", "error", "#bb9af7"),
+        ("end_turn", "end_turn", shared::palette::ACCENT_GREEN),
+        ("tool_use", "tool_use", shared::palette::ACCENT_BLUE),
+        ("max_tokens", "max_tokens", shared::palette::ACCENT_RED),
+        ("error", "error", shared::palette::ACCENT_PURPLE),
     ];
     let active_set: std::collections::HashSet<GroupKey> = active_pairs.iter().cloned().collect();
     let mut by_reason: BTreeMap<&'static str, Vec<f64>> = BTreeMap::new();
@@ -113,7 +113,7 @@ pub(super) fn build_stop_reason_series(
     if other_vals.iter().any(|v| *v > 0.0) {
         series.push(StackedSeries {
             label: "other".to_string(),
-            color: "#565f89".to_string(),
+            color: shared::palette::MUTED_GRAY.to_string(),
             values: other_vals,
         });
     }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -39,6 +39,20 @@ pub const LAUNCHER_CAPABILITY_RESTART: &str = "launcher.restart";
 /// undecodable frame (#1366).
 pub const LAUNCHER_CAPABILITY_HEARTBEAT_ACK: &str = "launcher.heartbeat_ack";
 
+/// Tokyo-Night data-visualization palette shared by charts, sparklines, and
+/// terminal colors. CSS theme tokens remain in the stylesheets where the
+/// browser can resolve them directly.
+pub mod palette {
+    pub const ACCENT_BLUE: &str = "#7aa2f7";
+    pub const ACCENT_GREEN: &str = "#9ece6a";
+    pub const ACCENT_RED: &str = "#f7768e";
+    pub const ACCENT_ORANGE: &str = "#e0af68";
+    pub const ACCENT_PURPLE: &str = "#bb9af7";
+    pub const ACCENT_TEAL: &str = "#7dcfff";
+    pub const MUTED_GRAY: &str = "#565f89";
+    pub const TEXT_LIGHT: &str = "#c0caf5";
+}
+
 /// Proxy capability advertised by versions that can open the dedicated binary
 /// data-plane socket for port forwarding (#1506).
 ///


### PR DESCRIPTION
Closes #1727

Adds `shared::palette` module with Tokyo-Night constants (`ACCENT_BLUE #7aa2f7`, `ACCENT_RED #f7768e`, `ACCENT_ORANGE #e0af68`, etc.) as SOT, and migrates `frontend/src/components/sparkline.rs` (`ACCENT_BLUE`) and `frontend/src/components/ansi.rs` (3 ANSI slots) to `shared::palette::*` via full path. Pill/sparkline/ansi now share same hex via shared.

Base: merge-base d5a081b5 while current origin/main e8a6fe7f has advanced; GitHub reports the 3-file delta conflict-free against current main (MERGEABLE). No rebase — new palette file is additive.

**Acceptance:** `grep -rn "shared::palette" frontend/src` shows 4 call sites, `cargo check -p shared --target wasm32-unknown-unknown` 0 (std-only consts), `cargo test -p frontend --lib` 648 pass, plus `cargo check -p shared --target wasm32-unknown-unknown` verified.

Closes #1727