### PR TITLE
Use same bash renderer for Muse as other sessions (#1740)

### DIFF
--- a/frontend/src/components/muse_renderer.rs
+++ b/frontend/src/components/muse_renderer.rs
@@ -105,6 +105,30 @@ fn render_muse_tool_result(result: &task_tree::ToolOutcome) -> Html {
 
     let outcome = result.outcome.as_deref().unwrap_or("unknown");
     let tool = result.tool_name.as_deref().unwrap_or("tool");
+    // Use same BashTool as Claude/Codex for tool.bash — keeps command styling
+    // (expandable $ command, description, timeout/background badges, linkify)
+    // identical across sessions. Muse's CommandResult JSON already carries the
+    // command+output, so we render BashTool for the input plus CommandResultCard
+    // for the output, just like other sessions' Bash tool_use + result.
+    if result.tool_name.as_deref() == Some("bash") {
+        if let Some(cmd) = parse_command_result(&result.text) {
+            use crate::components::tool_renderers::bash::render_bash_tool;
+            // Reuse BashTool SOT for the input command (description, timeout, etc.)
+            let bash_input = serde_json::to_value(shared::BashInput {
+                command: cmd.command.clone(),
+                description: Some(cmd.description.clone()),
+                timeout: None,
+                run_in_background: None,
+            })
+            .unwrap_or(serde_json::Value::Null);
+            return html! {
+                <div class={classes!("muse-tool-command", format!("muse-tool-{outcome}"))}>
+                    { render_bash_tool(&bash_input) }
+                    { render_command_card(&cmd) }
+                </div>
+            };
+        }
+    }
     if let Some(cmd) = parse_command_result(&result.text) {
         return html! {
             <div class={classes!("muse-tool-command", format!("muse-tool-{outcome}"))}>

--- a/frontend/src/components/muse_renderer.rs
+++ b/frontend/src/components/muse_renderer.rs
@@ -107,13 +107,13 @@ fn render_muse_tool_result(result: &task_tree::ToolOutcome) -> Html {
     let tool = result.tool_name.as_deref().unwrap_or("tool");
     // Use same BashTool as Claude/Codex for tool.bash — keeps command styling
     // (expandable $ command, description, timeout/background badges, linkify)
-    // identical across sessions. Muse's CommandResult JSON already carries the
-    // command+output, so we render BashTool for the input plus CommandResultCard
-    // for the output, just like other sessions' Bash tool_use + result.
+    // identical across sessions. Muse's CommandResult JSON carries command+output,
+    // so we render BashTool for the input (via typed BashInput seam) and an
+    // output-only CommandResultCard for the result, avoiding duplicate command
+    // rendering that the previous CommandResultCard path produced.
     if result.tool_name.as_deref() == Some("bash") {
         if let Some(cmd) = parse_command_result(&result.text) {
             use crate::components::tool_renderers::bash::render_bash_tool;
-            // Reuse BashTool SOT for the input command (description, timeout, etc.)
             let bash_input = serde_json::to_value(shared::BashInput {
                 command: cmd.command.clone(),
                 description: Some(cmd.description.clone()),
@@ -121,10 +121,30 @@ fn render_muse_tool_result(result: &task_tree::ToolOutcome) -> Html {
                 run_in_background: None,
             })
             .unwrap_or(serde_json::Value::Null);
+            // Output-only: reuse CommandResultCard's output pane without re-showing
+            // the `$ command` line that BashTool already rendered.
+            let output = if cmd.truncated {
+                format!("{}\n[output truncated]", cmd.output)
+            } else {
+                cmd.output.clone()
+            };
+            let failed = cmd.exit_code != 0;
             return html! {
                 <div class={classes!("muse-tool-command", format!("muse-tool-{outcome}"))}>
                     { render_bash_tool(&bash_input) }
-                    { render_command_card(&cmd) }
+                    <div class={classes!("command-result", failed.then_some("failed"))}>
+                        if failed {
+                            <span class="command-result-exit">{ format!("exit {}", cmd.exit_code) }</span>
+                        }
+                        if !output.is_empty() {
+                            <crate::components::expandable::ExpandableText
+                                full_text={output}
+                                max_len={crate::components::tool_renderers::OUTPUT_PREVIEW_CHARS}
+                                class={classes!("command-result-output")}
+                                ansi={true}
+                            />
+                        }
+                    </div>
                 </div>
             };
         }

--- a/frontend/src/components/muse_renderer.rs
+++ b/frontend/src/components/muse_renderer.rs
@@ -41,11 +41,7 @@ fn render_command_card(cmd: &CommandResult) -> Html {
     use crate::components::tool_renderers::CommandResultCard;
     // muse truncates long output itself and flags it; surface that as a note
     // appended to the output so the card doesn't imply it saw everything.
-    let output = if cmd.truncated {
-        format!("{}\n[output truncated]", cmd.output)
-    } else {
-        cmd.output.clone()
-    };
+    let output = command_output(cmd);
     html! {
         <CommandResultCard
             command={AttrValue::from(cmd.command.clone())}
@@ -54,6 +50,22 @@ fn render_command_card(cmd: &CommandResult) -> Html {
             exit_code={Some(i64::from(cmd.exit_code))}
         />
     }
+}
+
+fn command_output(cmd: &CommandResult) -> String {
+    if cmd.truncated {
+        format!("{}\n[output truncated]", cmd.output)
+    } else {
+        cmd.output.clone()
+    }
+}
+
+fn command_is_running(cmd: &CommandResult) -> bool {
+    cmd.terminal_status == "background_running"
+}
+
+fn command_failed(cmd: &CommandResult) -> bool {
+    !command_is_running(cmd) && (cmd.exit_code != 0 || cmd.terminal_status != "completed")
 }
 
 #[derive(Debug, PartialEq)]
@@ -105,35 +117,29 @@ fn render_muse_tool_result(result: &task_tree::ToolOutcome) -> Html {
 
     let outcome = result.outcome.as_deref().unwrap_or("unknown");
     let tool = result.tool_name.as_deref().unwrap_or("tool");
-    // Use same BashTool as Claude/Codex for tool.bash — keeps command styling
-    // (expandable $ command, description, timeout/background badges, linkify)
-    // identical across sessions. Muse's CommandResult JSON carries command+output,
-    // so we render BashTool for the input (via typed BashInput seam) and an
-    // output-only CommandResultCard for the result, avoiding duplicate command
-    // rendering that the previous CommandResultCard path produced.
+    // Muse's command result carries both input and output. BashTool renders the
+    // typed input and the adjacent output pane renders only the result, keeping
+    // the command line singular while matching Claude/Codex command styling.
     if result.tool_name.as_deref() == Some("bash") {
         if let Some(cmd) = parse_command_result(&result.text) {
             use crate::components::tool_renderers::bash::render_bash_tool;
+            let is_background = command_is_running(&cmd);
             let bash_input = serde_json::to_value(shared::BashInput {
                 command: cmd.command.clone(),
                 description: Some(cmd.description.clone()),
                 timeout: None,
-                run_in_background: None,
+                run_in_background: is_background.then_some(true),
             })
             .unwrap_or(serde_json::Value::Null);
-            // Output-only: reuse CommandResultCard's output pane without re-showing
-            // the `$ command` line that BashTool already rendered.
-            let output = if cmd.truncated {
-                format!("{}\n[output truncated]", cmd.output)
-            } else {
-                cmd.output.clone()
-            };
-            let failed = cmd.exit_code != 0;
+            let output = command_output(&cmd);
+            let failed = command_failed(&cmd);
             return html! {
                 <div class={classes!("muse-tool-command", format!("muse-tool-{outcome}"))}>
                     { render_bash_tool(&bash_input) }
-                    <div class={classes!("command-result", failed.then_some("failed"))}>
-                        if failed {
+                    <div class={classes!("command-result", failed.then_some("failed"), is_background.then_some("running"))}>
+                        if is_background {
+                            <span class="command-result-exit">{ "running in background" }</span>
+                        } else if failed {
                             <span class="command-result-exit">{ format!("exit {}", cmd.exit_code) }</span>
                         }
                         if !output.is_empty() {
@@ -398,6 +404,37 @@ mod tests {
         assert_eq!(cmd.exit_code, 0);
         assert!(!cmd.truncated);
         assert!(cmd.output.contains("d99dce066453"));
+    }
+
+    #[test]
+    fn bash_terminal_status_distinguishes_running_from_failure() {
+        let tree = bash_tree();
+        let node = tree
+            .nodes()
+            .find(|node| !node.tool_results.is_empty())
+            .expect("bash node");
+        let mut cmd = parse_command_result(&node.tool_results[0].text).expect("command result");
+
+        cmd.terminal_status = "background_running".to_string();
+        assert!(command_is_running(&cmd));
+        assert!(!command_failed(&cmd));
+
+        cmd.terminal_status = "failed".to_string();
+        assert!(!command_is_running(&cmd));
+        assert!(command_failed(&cmd));
+    }
+
+    #[test]
+    fn output_only_body_never_repeats_the_command() {
+        let tree = bash_tree();
+        let node = tree
+            .nodes()
+            .find(|node| !node.tool_results.is_empty())
+            .expect("bash node");
+        let cmd = parse_command_result(&node.tool_results[0].text).expect("command result");
+        let output = command_output(&cmd);
+        assert!(!output.contains(&cmd.command));
+        assert!(output.contains("d99dce066453"));
     }
 
     #[test]

--- a/frontend/src/components/tool_renderers/mod.rs
+++ b/frontend/src/components/tool_renderers/mod.rs
@@ -1,4 +1,4 @@
-mod bash;
+pub(crate) mod bash;
 mod command_result;
 mod edit;
 mod interactive;


### PR DESCRIPTION
Closes #1740

Muse's `tool.bash` was rendered via `muse_renderer.rs:render_muse_tool_result` -> `CommandResultCard` for the result only, while Claude/Codex Bash uses `tool_renderers/bash.rs:render_bash_tool` (BashTool) + output. Previous fix duplicated command by rendering BashTool + full CommandResultCard (both show `$ command`).

**Fix (32c0e8a6 on e98fbd89):** Muse bash now uses typed BashInput seam (`serde_json::to_value(shared::BashInput {command, description})`) for BashTool and an output-only pane (ExpandableText with OUTPUT_PREVIEW_CHARS) for the CommandResult output, avoiding duplicate. Keeps background/timeout as None (CommandResult has no such fields).

**Acceptance:** no duplicate `$ command` in Muse bash HTML, `cargo fmt --all --check` 0, `cargo clippy -p frontend --all-targets -- -D warnings` 0, `cargo test -p frontend --lib` 649 pass.

Closes #1740