### PR TITLE
Delete revoked credentials instead of keeping them forever

### DIFF
--- a/backend/src/background.rs
+++ b/backend/src/background.rs
@@ -1031,6 +1031,34 @@ pub async fn run_expired_token_cleanup(app_state: Arc<AppState>) {
         }
     }
 
+    // Delete revoked credentials past the same window. Neither pass around this
+    // one collects them: launcher-spawned tokens carry no expiry, and
+    // `expires_at < cutoff` is never true for NULL, so every session that ever
+    // ran left a revoked row behind forever — June credentials were still
+    // listed in late August. A revoked token cannot authenticate, so it is kept
+    // only long enough to stay visible in the UI after the fact.
+    //
+    // Aged on `created_at` because there is no `revoked_at` column. A token
+    // revoked long after it was minted is therefore collected sooner than seven
+    // days, which is harmless for a credential that can no longer be used — and
+    // `created_at` is NOT NULL, so this cannot repeat the NULL-comparison bug it
+    // exists to fix.
+    match diesel::delete(
+        schema::proxy_auth_tokens::table
+            .filter(schema::proxy_auth_tokens::revoked.eq(true))
+            .filter(schema::proxy_auth_tokens::created_at.lt(token_cutoff)),
+    )
+    .execute(&mut conn)
+    {
+        Ok(0) => {}
+        Ok(count) => {
+            tracing::info!("Revoked token cleanup: deleted {} tokens", count);
+        }
+        Err(e) => {
+            tracing::error!("Failed to delete revoked tokens: {}", e);
+        }
+    }
+
     // Delete leaked launcher-spawned tokens (#1045). These are minted per
     // launch and only ever bound to a session on a *successful* proxy
     // registration; a launch whose proxy never registers leaves a

--- a/frontend/src/pages/settings/tokens_panel.rs
+++ b/frontend/src/pages/settings/tokens_panel.rs
@@ -473,7 +473,7 @@ pub fn tokens_panel(props: &TokensPanelProps) -> Html {
                         </table>
                     </div>
                     <p class="section-note">
-                        { "Credentials expired for more than 7 days are automatically deleted." }
+                        { "Credentials revoked or expired more than 7 days ago are automatically deleted." }
                     </p>
                 }
             </section>


### PR DESCRIPTION
Session credentials from June were still listed in late August, under a footer promising they'd be deleted.

## Why nothing collected them

Two sweeps run, and a revoked launcher credential falls through both:

- **Expiry sweep** filters `expires_at < cutoff`. Launcher-spawned tokens have no expiry, and in SQL `NULL < x` is NULL — never true. A credential with expiry **Never** can never *be* expired.
- **Leaked-launch-token sweep** only matches `session_id IS NULL`. These were bound to a session on successful registration, then revoked when it ended.

And `revoke_tokens_for_session` runs whenever a session terminates or is deleted — so *every session that has ever run* leaves one of these behind, permanently.

## Fix

A third pass deleting revoked tokens past the same seven-day window.

Aged on `created_at` because there's no `revoked_at` column. That means a token revoked long after it was minted gets collected sooner than seven days — harmless for a credential that can no longer authenticate, and `created_at` is NOT NULL, so it can't repeat the NULL-comparison bug it exists to fix.

Only rows with `revoked = true` can match, so a live credential is never touched.

The settings footer said "expired for more than 7 days"; it now says revoked or expired, which is what actually happens.

## No test

The two existing sweeps have none, and the backend's DB-gated test modules aren't in the CI lane, so a test here wouldn't run. The predicate is two filters over a NOT NULL bool and a NOT NULL timestamp; the blast radius is bounded to rows already marked dead. Flagging rather than hiding it.

308 backend tests, 652 frontend, clippy clean.