### PR TITLE
Move experimental launch warning to Muse

### DIFF
--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -826,9 +826,9 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                         </div>
                     }
 
-                    if *agent_type == AgentType::Codex {
+                    if *agent_type == AgentType::Muse {
                         <div class="launch-note launch-note-warn">
-                            { "Codex support is highly experimental." }
+                            { "Muse support is highly experimental." }
                         </div>
                     }
 


### PR DESCRIPTION
Moves the highly-experimental warning from Codex to Muse in the agent/model launch dialog. No other launch behavior changes.