### PR TITLE
Rewrite README for current project scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,95 +1,264 @@
-# Claude Code Portal — Try It: [txcl.io](https://txcl.io)
+# Agent Portal — Try It: [txcl.io](https://txcl.io)
 
-A web portal that extends [Claude Code](https://docs.anthropic.com/en/docs/claude-code) with session sharing, remote access, and collaborative features. Run Claude Code on powerful machines and access it from anywhere through your browser.
+Run coding agents on your own machines and drive them from any browser.
+
+Agent Portal puts a persistent daemon on each of your computers, connects it to
+a server you (or we) host, and gives you a live, shareable web UI for every
+agent session on every machine — from a phone, a laptop, or a tab you left open
+yesterday. Hand a task to an agent on your workstation, close the lid, and pick
+it up on the train: the transcript, the cost, the pending permission prompt and
+the dev server it just started are all still there.
+
+It is Rust end to end — Axum server, Yew/WebAssembly frontend, a launcher
+daemon, and a typed WebSocket protocol shared by all of them.
+
+Supported agents: **Claude Code**, **OpenAI Codex**, and **Meta Muse Code**
+(experimental).
 
 [Features Anthropic Missed](https://www.loom.com/share/38bdd5406c2443ff8c978d5d5b01e967)
 
-## Features
-
-- **Remote Access**: Run Claude Code on dedicated machines, access from any browser
-- **Session Sharing**: Share sessions with team members for collaborative coding
-- **Voice Input**: Dictate commands using the browser's built-in Web Speech API (Chrome, Edge, Safari)
-- **Persistent History**: All conversations stored and accessible across devices
-- **Flexible Authentication**: Configure for single-user, organization-only, or public access
-- **Real-time Sync**: Multiple viewers see updates instantly via WebSocket
-- **VS Code Integration**: Use Claude Code in VS Code while sessions appear on the portal dashboard
-
-## Use Cases
-
-- **Hardware Development**: Develop against specialized hardware (GPUs, FPGAs, embedded devices) from any laptop
-- **Powerful Workstations**: Run Claude Code on beefy machines while traveling with a thin client
-- **Mobile Development**: Code from your phone or tablet - the web UI works on any device
-- **Team Collaboration**: Share Claude sessions for pair programming or code review
-- **Long-Running Tasks**: Start a task, walk away, check results later from any device
-- **Consistent Environment**: Keep your dev environment on one machine, access it everywhere
+---
 
 ## Quick Start
 
-```bash
-# Clone the repository
-git clone https://github.com/meawoppl/agent-portal.git
-cd agent-portal
+### Use the hosted portal
 
-# Start everything (auto-installs dependencies)
-./scripts/dev.sh start
+On each machine you want to run agents on:
+
+```bash
+curl -fsSL "https://txcl.io/api/download/install.sh" | bash
+
+agent-portal login             # browser device-code sign-in
+agent-portal service install   # run as a systemd / launchd service
 ```
 
-Then open: **http://localhost:3000/**
+Then open **[txcl.io](https://txcl.io)**, and launch a session on that machine
+straight from the dashboard — pick the directory, agent, model, and whether to
+work in a fresh git worktree.
 
-You'll be automatically logged in as `testing@testing.local` in dev mode.
+Already have an agent running in a terminal or in VS Code? Wrap it instead and
+it shows up on the same dashboard:
 
-See [Local Development](docs/LOCAL_DEVELOPMENT.md) for more details on the dev script and available commands.
+```bash
+claude-portal --backend-url wss://txcl.io -- --model opus
+```
+
+### Run the whole thing locally
+
+```bash
+git clone https://github.com/meawoppl/agent-portal.git
+cd agent-portal
+./scripts/dev.sh start     # DB + backend + frontend, auto-installs deps
+```
+
+Open **http://localhost:3000/** — dev mode logs you in as
+`testing@testing.local`. See [Local Development](docs/LOCAL_DEVELOPMENT.md).
+
+---
+
+## Features
+
+### Sessions from anywhere
+
+- **Live, not a replay.** Output streams as the agent produces it; sending a
+  message from your phone lands mid-flight.
+- **Reconnects don't lose transcript.** Replay resumes from a server-assigned
+  watermark, and web input rides a client-side outbox with idempotency keys, so
+  a dropped connection never drops or duplicates a message.
+- **Every device.** The frontend is responsive on phones and tablets; a Tauri
+  iOS/Android shell in-tree adds native push, deep links, and share targets.
+- **Keyboard-first.** `Ctrl/Cmd+K` enters nav mode — jump between sessions,
+  `w` to hop to the next one waiting on you, scroll transcripts without leaving
+  the keyboard. Press `?` for the full list.
+- **History.** Finished sessions stay browsable and searchable as an overlay,
+  including transcripts restored from long-term archive.
+
+### One dashboard, many agents
+
+- **Three agent CLIs**, each with a renderer that speaks its own protocol:
+  Claude's role-tagged messages, Codex's thread/turn events, Muse's
+  event-sourced journal.
+- **Install and sign in from the web.** The Computers tab probes each machine
+  for which agent CLIs are present, installs the missing ones, and drives the
+  agent's own login flow — device codes and all — without you SSH-ing anywhere.
+- **Model picker** fed by the SDK crates' model catalogs, per launch.
+- **Fork a session** into a new git worktree to try a second approach without
+  disturbing the first.
+
+### Rich rendering
+
+- Markdown, syntax-highlighted **diffs**, LaTeX via KaTeX, ANSI colors, and
+  purpose-built cards for bash, edits, searches, and sub-agent tasks.
+- **Decisions as forms.** Permission requests and multiple-choice questions
+  render as click-to-answer cards instead of walls of text.
+- **Media inline.** `agent-portal show plot.png|clip.mp4|figure.riz` uploads and
+  renders images, video, and interactive Rizzma portable figures into the
+  transcript.
+- **Downloadable artifacts.** Agents emit `portal://file/...` links that become
+  secure download actions.
+
+### Port forwarding
+
+- `agent-portal forward 8080` from inside a session prints one URL on a stable
+  per-session subdomain — the URL survives the agent moving the service to a
+  different port.
+- A header chip shows **live port health** (breathing green = something is
+  listening, red = refused) and names the process bound to it.
+- Click the chip for a **draggable, resizable preview** of the app inside the
+  portal. WebSockets and SSE work through it, so Vite HMR and Jupyter kernels
+  are fine.
+- Private by default behind a token handoff; one toggle makes a forward public
+  (and re-pointing the port resets it to private). Admins can assign
+  human-readable subdomains.
+
+See [Port Forwarding](docs/PORT_FORWARDING.md).
+
+### Agents that talk to each other
+
+```bash
+agent-portal message list                     # your other sessions
+agent-portal message send <id> "PR is up — review the auth boundary"
+```
+
+Messages arrive as a turn in the target session and reply by id, using the
+session's own identity — no credential handling in agent code. One agent
+writing code while another reviews it is a normal working pattern here.
+
+### Scheduled work
+
+Cron-style recurring tasks, pinned to a machine and evaluated locally with
+timezone support. Runs **resume the same agent session**, so a nightly reviewer
+remembers what it looked at yesterday. See
+[Scheduled Tasks](docs/SCHEDULED_TASKS.md).
+
+### Cost and performance visibility
+
+- Per-turn metrics: tokens, cost, duration, cache hits, service tier.
+- A cost ticker per session and activity sparklines in the session rail.
+- A Performance page with plots grouped by agent, model, and tier over
+  configurable windows.
+- **Usage-limit continuations**: when an agent hits a provider limit, the portal
+  schedules the resume for you and relaunches the session if the process exited.
+
+### Voice input
+
+Browser-native (Web Speech API) with no credentials required. Self-hosters can
+point `PORTAL_STT_BACKEND` at one of ten hosted providers — AssemblyAI, AWS,
+Azure, Deepgram, Google, IBM, OpenAI, Rev AI, Simplismart, Speechmatics — which
+adds Firefox support and vocabulary biasing so `clippy`, `Diesel`, and your
+branch names come back spelled correctly.
+
+### Notifications
+
+Web Push, APNs, and FCM for turn-complete and permission-needed events; a
+notification sound designer with synthesized tones and an ADSR editor; and an
+optional health-break timer that nudges you away from the screen.
+
+### Sharing and access control
+
+Share any session you own by email with a role — **editor** to interact,
+**viewer** for read-only. Sign in with Google or GitHub; identities are keyed by
+the provider's immutable subject, and linking a second provider to an account
+requires a *verified* email.
+
+### Operations
+
+- Launchers **self-update**, install as a service, and park with an actionable
+  message instead of crash-looping on bad credentials.
+- Configurable message/session retention, plus optional long-term archive to
+  local disk or S3 (transcripts and media included).
+- Admin dashboard: users, sessions, spend, and forward subdomains.
+- Stable, alertable log markers for every logged-and-continued failure path.
+- `agent-portal service pastebin` uploads system info, build info, and logs to
+  an unlisted paste for support.
+
+---
 
 ## Architecture
 
 ```mermaid
 flowchart TB
-    subgraph dev["Dev Machine"]
-        subgraph portal["claude-portal binary"]
-            subgraph codes["claude-codes crate"]
-                claude["claude CLI binary"]
+    subgraph machines["Your machines"]
+        subgraph launcher["agent-portal daemon"]
+            subgraph proxy["session (claude-portal)"]
+                cli["claude / codex / muse CLI"]
             end
         end
+        devsrv["localhost:8080 dev server"]
     end
 
-    subgraph server["Backend Server"]
-        axum["Axum Web Server"]
+    subgraph server["Portal server"]
+        axum["Axum + WebSocket hub"]
         db[(PostgreSQL)]
+        archive[("Archive: disk / S3")]
         axum <--> db
+        axum --> archive
     end
 
-    subgraph browser["Web Browser"]
-        yew["Yew WASM Frontend"]
+    subgraph clients["Clients"]
+        yew["Yew WASM frontend"]
+        mobileapp["iOS / Android shell"]
     end
 
-    portal <-->|"WebSocket"| axum
-    yew <-->|"WebSocket"| axum
-    axum -->|"Serves"| yew
+    launcher <-->|"session + launcher WS"| axum
+    devsrv -.->|"forward tunnel"| launcher
+    yew <-->|"client WS"| axum
+    mobileapp <--> axum
+    axum -->|"serves"| yew
+    axum -->|"push"| mobileapp
 ```
 
-The **portal** refers to the complete system: backend server, web frontend, and CLI binary. The CLI binary (`claude-portal`) connects your local Claude Code instance to the portal server, enabling remote access and session sharing.
+The **launcher** (`agent-portal`) is a persistent daemon, one per machine: it
+starts and supervises sessions, runs scheduled tasks, tunnels forwarded ports,
+and updates itself. The **proxy** (`claude-portal`) is the per-session wrapper
+that owns an agent CLI process; you only run it by hand for terminal or VS Code
+sessions. The **backend** coordinates every WebSocket, persists transcripts, and
+serves the **frontend**, which is compiled to WebAssembly and embedded in the
+backend binary.
 
-### Components
+### Workspace
 
-| Component | Description |
-|-----------|-------------|
-| **Backend** | Axum web server with PostgreSQL, OAuth, WebSocket coordination |
-| **Frontend** | Yew WebAssembly app with terminal-style UI and voice input |
-| **CLI** | `claude-portal` binary that wraps Claude Code and connects to backend |
-| **Shared** | Common types and protocol definitions (WASM-compatible) |
+| Crate | Role |
+|-------|------|
+| `shared` | Types + typed WS protocol, WASM-compatible |
+| `backend` | Axum server, PostgreSQL/Diesel, OAuth, reverse proxy |
+| `frontend` | Yew WebAssembly app |
+| `launcher` | `agent-portal` daemon and CLI |
+| `proxy` | `claude-portal` per-session wrapper (incl. VS Code shim) |
+| `session-lib` | Agent-agnostic session core (`Agent` trait, `Session<A>`, tunnel) |
+| `claude-session-lib` / `codex-session-lib` / `muse-session-lib` | Per-agent backends |
+| `portal-auth` | Shared OAuth device-flow client |
+| `portal-stt` | Speech-to-text provider implementations |
+| `portal-update` | Shared auto-update logic |
+| `archive-format` | Long-term session archive format |
+| `mobile/src-tauri` | Tauri 2 mobile shell |
+
+We also maintain [meawoppl/rust-code-agent-sdks](https://github.com/meawoppl/rust-code-agent-sdks),
+the typed Rust parsers for the agent CLIs' JSON protocols.
+
+---
 
 ## Documentation
 
 | Document | Description |
 |----------|-------------|
-| [Usage Guide](docs/USAGE.md) | Web interface, CLI options, voice input, session sharing |
-| [Local Development](docs/LOCAL_DEVELOPMENT.md) | Quick setup with `dev.sh`, available commands |
-| [Development Guide](docs/DEVELOPING.md) | Full dev workflow, building, testing, contributing |
-| [Architecture Vocabulary](docs/ARCHITECTURE_VOCABULARY.md) | Runtime components, core concepts, and message flow terminology |
-| [Deployment Guide](docs/DEPLOYING.md) | Production deployment, Google OAuth setup, configuration |
-| [Docker Guide](docs/DOCKER.md) | Docker and Kubernetes deployment with 1Password |
-| [VS Code Setup](docs/VSCODE_SETUP.md) | Use Claude Code in VS Code with portal integration |
+| [Usage Guide](docs/USAGE.md) | Web interface, CLI options, voice input, sharing |
+| [Local Development](docs/LOCAL_DEVELOPMENT.md) | `dev.sh` setup and commands |
+| [Development Guide](docs/DEVELOPING.md) | Full dev workflow, building, testing |
+| [Architecture Vocabulary](docs/ARCHITECTURE_VOCABULARY.md) | Components, concepts, message flow |
+| [Protocol](docs/PROTOCOL.md) | WebSocket endpoints and message types |
+| [Database](docs/DATABASE.md) | Schema and migrations |
+| [Auth Flows](docs/AUTH_FLOWS.md) | Web login vs. device flow |
+| [Port Forwarding](docs/PORT_FORWARDING.md) | Tunnel design, subdomains, public forwards |
+| [Scheduled Tasks](docs/SCHEDULED_TASKS.md) | Cron tasks owned by the launcher |
+| [File Downloads](docs/PORTAL_FILE_DOWNLOADS.md) | `portal://file` links |
+| [Codex Support](docs/CODEX_SUPPORT.md) | Codex integration notes |
+| [Deployment Guide](docs/DEPLOYING.md) | Production deployment and OAuth setup |
+| [Docker Guide](docs/DOCKER.md) | Docker and Kubernetes with 1Password |
+| [VS Code Setup](docs/VSCODE_SETUP.md) | Portal integration for the VS Code extension |
 | [Troubleshooting](docs/TROUBLESHOOTING.md) | Common issues and solutions |
+
+---
 
 ## Platform Support
 
@@ -101,42 +270,43 @@ The **portal** refers to the complete system: backend server, web frontend, and 
 | macOS (Intel) | Builds in CI |
 | Windows (x86_64) | Builds in CI |
 
-Pre-built binaries available from [GitHub Releases](https://github.com/meawoppl/agent-portal/releases/latest).
+Pre-built binaries: [GitHub Releases](https://github.com/meawoppl/agent-portal/releases/latest).
 
 ## Technologies
 
-- **Backend**: [Axum](https://github.com/tokio-rs/axum) 0.7, [Diesel](https://diesel.rs/) 2.2, [Tokio](https://tokio.rs/)
-- **Frontend**: [Yew](https://yew.rs/) 0.21, WebAssembly
-- **Claude Integration**: [claude-codes](https://crates.io/crates/claude-codes)
-- **Voice**: Web Speech API
+- **Backend**: [Axum](https://github.com/tokio-rs/axum), [Diesel](https://diesel.rs/), [Tokio](https://tokio.rs/), PostgreSQL
+- **Frontend**: [Yew](https://yew.rs/), WebAssembly, hand-rolled SVG charts
+- **Mobile**: [Tauri 2](https://tauri.app/)
+- **Agent protocols**: [claude-codes](https://crates.io/crates/claude-codes), [codex-codes](https://crates.io/crates/codex-codes), [muse-codes](https://crates.io/crates/muse-codes)
+- **Voice**: Web Speech API, or ten hosted STT providers
 
 ## Contributing
 
-Contributions are welcome! Please:
+Contributions are welcome:
 
 1. Fork the repository
 2. Create a feature branch
-3. Run `cargo test` and `cargo clippy`
+3. Run `cargo test --workspace` and `cargo clippy --workspace`
 4. Submit a pull request
 
 Please open an issue first to discuss major changes.
+[CLAUDE.md](CLAUDE.md) documents the conventions CI enforces.
 
 ## Security & Privacy
 
-When using the hosted instance at **txcl.io**, please be aware:
+When using the hosted instance at **txcl.io**:
 
-- **Data Access**: The txcl.io server can access your Claude Code session content
-- **Data Storage**: Session messages are stored temporarily on our servers for history display purposes only
-- **Retention**: Message data is retained for a limited time and then automatically deleted
-- **Purpose**: Messages are stored solely to enable the web interface history feature
+- **Data Access**: The txcl.io server can access your agent session content
+- **Data Storage**: Session messages are stored to power the web interface's history
+- **Retention**: Message data is retained for a limited time, then deleted automatically
 - **No Analysis**: We do not analyze, share, or use your session content for any other purpose
-- **User Control**: You can delete your sessions and associated data at any time from the dashboard
+- **User Control**: You can delete your sessions and associated data at any time
 
-**For complete data control**, you can self-host your own instance of Claude Code Portal. See [Deployment Guide](docs/DEPLOYING.md) for instructions.
+**For complete data control**, self-host. See the [Deployment Guide](docs/DEPLOYING.md).
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) file for details
+MIT License.
 
 ## Support
 

--- a/docs/README_ANIMATIONS.md
+++ b/docs/README_ANIMATIONS.md
@@ -1,0 +1,169 @@
+# README feature animations — plan
+
+The README's Features section is text today. This document proposes the short
+looping animations that would carry it, ranked by how much each one explains
+per kilobyte, and records the house rules for producing them.
+
+Nothing here is built yet. Each entry names the README slot it lands in, what
+the clip must prove, and how to capture it.
+
+## House rules
+
+- **Four in the README, the rest in docs.** Every animation is bytes on the
+  landing page. Ship #1–#4 inline plus the terminal cast in Quick Start; link
+  the others from the feature docs they illustrate.
+- **Format: APNG** (`.png`, animated) or animated WebP for UI capture, **animated
+  SVG** for terminal casts and schematics. GIF's 256-color palette bands badly
+  on the portal's dark gradients. Repo-relative `.mp4` does not render in a
+  GitHub README — don't plan around it.
+- **Budget: ≤ 2 MB and ≤ 10 s each**, 900 px wide (capture at 1800 px / 2× DPR
+  and downscale), 12–15 fps. Loop cleanly: first and last frame identical.
+- **Gentle motion.** A README animation cannot honour `prefers-reduced-motion`,
+  so no strobing, no fast cuts, one idea per clip. Give every one a real `alt`
+  describing what happens, for the people who have motion disabled at the OS
+  level and for screen readers.
+- **Staged, not personal.** Capture against a local dev instance with seeded
+  data. No real emails, tokens, repo names, or session ids.
+- **Store under `docs/media/`**, named `feature-<slug>.png`, with the capture
+  script (VHS `.tape` or Playwright `.ts`) checked in beside it as
+  `feature-<slug>.tape` / `.ts` so the clip can be re-shot when the UI moves.
+
+## Tooling
+
+| Kind | Tool | Why |
+|------|------|-----|
+| Terminal casts | [VHS](https://github.com/charmbracelet/vhs) | Scripted `.tape` files — deterministic, re-runnable, no hand-timed typing |
+| Browser UI | Playwright script + `ffmpeg`/`gifski` → APNG | Repeatable clicks and waits; no hand-held recording |
+| Schematics | Hand-written SVG with SMIL/CSS | Kilobytes, crisp at any zoom, animates as an `<img>` on GitHub |
+
+Palette for anything hand-drawn: the portal's Tokyo Night — background
+`#1a1b26`, text `#c0caf5`, muted `#565f89`, accents `#7aa2f7` blue,
+`#9ece6a` green, `#f7768e` red, `#e0af68` orange, `#bb9af7` purple.
+
+---
+
+## Ranked candidates
+
+### 1. The forward chip comes alive → preview window
+
+**Slot:** Features ▸ Port forwarding. **~9 s, browser capture.**
+
+Agent runs `agent-portal forward 8899`; the header chip appears **flat red**;
+the dev server starts; within one probe interval the chip **breathes green** and
+its tooltip names the process; clicking it genies open the floating preview with
+the real app inside; `Ctrl-C` on the server and the chip goes red again.
+
+This is the single highest-value clip: it demonstrates the tunnel, the health
+probe, the process resolution, and the in-portal preview in one unbroken shot,
+and it is the feature nothing else in this space has.
+
+### 2. One agent messages another
+
+**Slot:** Features ▸ Agents that talk to each other. **~7 s, split capture.**
+
+Left half a terminal (VHS): `agent-portal message list`, then
+`agent-portal message send <id> "PR is up — review the auth boundary"`. Right
+half the dashboard: the session rail plays its broadcast arc from sender pill to
+recipient pill, and the message lands as a turn in the other session.
+
+Proves the multi-agent workflow is real plumbing, not a diagram.
+
+### 3. A decision arrives as a form
+
+**Slot:** Features ▸ Rich rendering. **~5 s, browser capture.**
+
+An agent hits a permission boundary; the transcript renders a click-to-answer
+card; the user picks an option; the agent continues in the same shot. Optionally
+cross-fade to an `AskUserQuestion` multi-select card.
+
+Smallest clip on the list and it lands the "decisions, not walls of text" claim
+instantly.
+
+### 4. Launch a session from the browser
+
+**Slot:** Features ▸ One dashboard, many agents. **~8 s, browser capture.**
+
+Dashboard → launch dialog → pick machine, directory, agent, model, "new
+worktree" → a session pill slides into the rail → output starts streaming.
+
+Answers the question a first-time reader actually has: *how does an agent get
+onto my machine, and what do I have to type?* (Nothing.)
+
+### 5. Install → login → service
+
+**Slot:** Quick Start. **~8 s, VHS terminal cast, animated SVG.**
+
+`curl … | bash`, `agent-portal login` showing the device code, `agent-portal
+service install` reporting the unit is up. Fully scriptable, cheapest clip on
+the list, and it makes the three-command onboarding feel as short as it is.
+
+### 6. Desktop → phone handoff
+
+**Slot:** Features ▸ Sessions from anywhere. **~10 s, composite.**
+
+A laptop viewport with a session streaming; the lid "closes" (viewport dims);
+a phone viewport picks up the same session mid-stream, transcript intact, and
+answers a pending prompt from the phone.
+
+The strongest emotional pitch in the product, and the hardest to stage — two
+synchronized captures composited side by side. Consider a schematic animated SVG
+version (watermark → replay) if the real capture proves fiddly.
+
+### 7. `agent-portal show` puts a figure in the transcript
+
+**Slot:** Features ▸ Rich rendering (or the media docs). **~6 s.**
+
+Terminal `agent-portal show figure.riz` on the left; the interactive portable
+figure appearing inline in the transcript on the right, with a cursor rotating
+or scrubbing it to show it is live, not a screenshot.
+
+### 8. Cost ticker and sparkline
+
+**Slot:** Features ▸ Cost and performance visibility. **~4 s, tight crop.**
+
+The per-session cost badge shaking as it increments, and the rail sparkline
+growing a new bar per turn. Tiny crop, tiny file, high charm.
+
+### 9. Nav mode
+
+**Slot:** Features ▸ Sessions from anywhere. **~6 s, browser capture with a
+key-cap overlay.**
+
+`Ctrl/Cmd+K` → the rail enters nav mode → `w` jumps to the session waiting on
+input → `Enter` accepts. Keystrokes drawn as key caps in the corner, since the
+motion is meaningless without them.
+
+### 10. Three agents, three renderers
+
+**Slot:** Features ▸ One dashboard, many agents. **~6 s, cross-fade.**
+
+The same dashboard cross-fading between a Claude session, a Codex session, and a
+Muse session, pausing on the tool card each protocol produces. Shows breadth
+without three separate clips.
+
+### 11. Voice to prompt
+
+**Slot:** Features ▸ Voice input. **~6 s.**
+
+Mic button pressed, live waveform, transcript filling in word by word, edit,
+send. Best captured with a sentence full of the jargon the hosted providers get
+right and the browser API mangles (`clippy`, `Diesel`, a branch name).
+
+### 12. Architecture packets in flight
+
+**Slot:** Architecture. **Hand-written animated SVG, ~15 KB.**
+
+The existing Mermaid diagram, redrawn as an SVG where dots travel the edges:
+agent → launcher → server → browser, a forward tunnel dot running the other way,
+a push notification peeling off to the phone. Replaces a static diagram with one
+that shows which way data moves, at essentially no file-size cost.
+
+---
+
+## Suggested first batch
+
+Ship **#5 (Quick Start)**, **#1**, **#3**, and **#4** first: one terminal cast
+and three browser captures, roughly 5 MB total, covering onboarding, the
+showpiece feature, the interaction model, and the "how do I start" question.
+Add **#2** once the rail broadcast animation is easy to trigger on demand in a
+seeded dev instance.

--- a/frontend/rizzma-host.js
+++ b/frontend/rizzma-host.js
@@ -63,6 +63,12 @@ function childDocument(nonce) {
     let terminal = false;
     let mounted = null;
     let urls = [];
+    let duration = 0;
+    let looping = false;
+    let playing = false;
+    let position = 0;
+    let clockStartedAt = 0;
+    let progressTimer = 0;
     const boot = async (event) => {
       if (terminal || event.source !== parent || event.data?.kind !== "rizzma-bootstrap"
           || event.data?.nonce !== ${JSON.stringify(nonce)} || event.ports.length !== 1) return;
@@ -76,7 +82,39 @@ function childDocument(nonce) {
         let lastSeq = 0;
         let state = "ready";
         let disposeSeq = null;
+        // Rizzma owns the frame clock. Mirror only its playhead at 4 Hz so the
+        // host controls stay responsive without putting cross-realm messages
+        // on every animation frame.
+        const emitPlaybackState = (re) => {
+          const reply = {nonce:${JSON.stringify(nonce)}, type:"state", playing, time:position};
+          if (re !== undefined) reply.re = re;
+          port.postMessage(reply);
+        };
+        const updatePosition = () => {
+          if (!playing) return;
+          const now = performance.now();
+          position += (now - clockStartedAt) / 1000;
+          clockStartedAt = now;
+          if (looping && duration > 0) {
+            position %= duration;
+          } else if (position >= duration) {
+            position = duration;
+            playing = false;
+            clearInterval(progressTimer);
+            progressTimer = 0;
+          }
+        };
+        const startProgress = () => {
+          clearInterval(progressTimer);
+          progressTimer = setInterval(() => {
+            updatePosition();
+            emitPlaybackState();
+          }, 250);
+        };
         const cleanup = () => {
+          clearInterval(progressTimer);
+          progressTimer = 0;
+          playing = false;
           try { mounted?.dispose(); } catch (_) {}
           const canvas = document.getElementById("figure");
           canvas.width = 0; canvas.height = 0;
@@ -95,7 +133,10 @@ function childDocument(nonce) {
               const glueUrl = URL.createObjectURL(new Blob([request.glue], {type:"text/javascript"}));
               urls.push(glueUrl);
               const canvas = document.getElementById("figure");
-              mounted = await loader.mount(canvas, new Uint8Array(request.artifact), {
+              const artifactBytes = new Uint8Array(request.artifact);
+              const metadata = loader.readMetadata(artifactBytes);
+              looping = Boolean(metadata.timeline?.loop);
+              mounted = await loader.mount(canvas, artifactBytes, {
                 renderer: {wasm: request.wasm, glue: glueUrl, sha256: request.wasmSha256},
                 maxBytes: ${MAX_ARTIFACT_BYTES},
                 autoplay: false
@@ -107,24 +148,35 @@ function childDocument(nonce) {
                 port.close();
               } else {
                 state = "mounted";
+                duration = Number(mounted.duration) || 0;
                 port.postMessage({nonce:${JSON.stringify(nonce)}, re:request.seq, type:"mounted",
-                  animated:Boolean(mounted.animated), duration:Number(mounted.duration) || 0});
+                  animated:Boolean(mounted.animated), duration});
+                emitPlaybackState();
               }
             } catch (error) {
               state = "failed";
               port.postMessage({nonce:${JSON.stringify(nonce)}, re:request.seq, type:"error", message:String(error).slice(0,256)});
             }
           } else if (request.type === "play" && state === "mounted") {
+            if (!looping && position >= duration) position = 0;
             mounted.play();
-            port.postMessage({nonce:${JSON.stringify(nonce)}, re:request.seq, type:"state", playing:true});
+            playing = Boolean(mounted.animated);
+            clockStartedAt = performance.now();
+            if (playing) startProgress();
+            emitPlaybackState(request.seq);
           } else if (request.type === "pause" && state === "mounted") {
+            updatePosition();
             mounted.pause();
-            port.postMessage({nonce:${JSON.stringify(nonce)}, re:request.seq, type:"state", playing:false});
+            playing = false;
+            clearInterval(progressTimer);
+            progressTimer = 0;
+            emitPlaybackState(request.seq);
           } else if (request.type === "seek" && state === "mounted"
               && Number.isFinite(request.time)) {
-            mounted.seek(request.time);
-            port.postMessage({nonce:${JSON.stringify(nonce)}, re:request.seq, type:"state",
-              playing:false, time:request.time});
+            position = Math.max(0, Math.min(duration, request.time));
+            mounted.seek(position);
+            clockStartedAt = performance.now();
+            emitPlaybackState(request.seq);
           } else if (request.type === "dispose") {
             if (state === "mounting") { disposeSeq = request.seq; return; }
             cleanup();
@@ -142,7 +194,7 @@ function childDocument(nonce) {
     addEventListener("message", boot);`;
   return `<!doctype html><meta charset="utf-8"><meta name="viewport" content="width=device-width">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src 'none'; img-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}' blob: 'wasm-unsafe-eval'">
-    <style>html,body{margin:0;background:#16161e;color:#c0caf5}canvas{display:block;max-width:100%;height:auto;margin:auto}</style>
+    <style>html,body{width:100%;height:100%;margin:0;background:#16161e;color:#c0caf5}body{display:flex;align-items:center;justify-content:center;overflow:hidden}canvas{display:block;max-width:100%;max-height:100%;width:auto;height:auto}</style>
     <canvas id="figure"></canvas><script nonce="${nonce}">${script}<\/script>`;
 }
 
@@ -190,6 +242,11 @@ export async function mountRizzma(iframe, artifactUrl, rendererVersion) {
           [runtime.renderer, artifact]);
       }
       if (event.data.type === "mounted") { clearTimeout(timeout); resolve(event.data); }
+      if (event.data.type === "state") {
+        iframe.dataset.rizzmaPlaying = event.data.playing ? "true" : "false";
+        iframe.dataset.rizzmaTime = String(Number(event.data.time) || 0);
+        iframe.dispatchEvent(new Event("rizzma-state"));
+      }
       if (event.data.type === "error") { clearTimeout(timeout); disposeEntry(entry); reject(new Error(event.data.message)); }
     };
     iframe.contentWindow.postMessage({kind:"rizzma-bootstrap", nonce, loader}, "*", [channel.port2]);

--- a/frontend/src/components/message_renderer/renderers/media.rs
+++ b/frontend/src/components/message_renderer/renderers/media.rs
@@ -3,6 +3,7 @@
 //! placeholder both degrade to.
 
 use crate::hooks::use_escape_capture;
+use gloo::events::EventListener;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{HtmlIFrameElement, HtmlInputElement};
@@ -233,6 +234,35 @@ pub(super) fn figure_viewer(props: &FigureViewerProps) -> Html {
         });
     }
 
+    {
+        let frame_ref = frame_ref.clone();
+        let playing = playing.clone();
+        let position = position.clone();
+        use_effect_with(*mounted, move |is_mounted| {
+            let listener = if *is_mounted {
+                frame_ref.cast::<HtmlIFrameElement>().map(|frame| {
+                    let state_frame = frame.clone();
+                    EventListener::new(&frame, "rizzma-state", move |_| {
+                        playing.set(
+                            state_frame.get_attribute("data-rizzma-playing").as_deref()
+                                == Some("true"),
+                        );
+                        if let Some(value) = state_frame
+                            .get_attribute("data-rizzma-time")
+                            .and_then(|value| value.parse::<f64>().ok())
+                            .filter(|value| value.is_finite())
+                        {
+                            position.set(value);
+                        }
+                    })
+                })
+            } else {
+                None
+            };
+            move || drop(listener)
+        });
+    }
+
     let onclick = {
         let frame_ref = frame_ref.clone();
         let artifact_url = props.artifact_url.clone();
@@ -274,17 +304,14 @@ pub(super) fn figure_viewer(props: &FigureViewerProps) -> Html {
             };
             if *playing {
                 pause_rizzma(frame);
-                playing.set(false);
             } else {
                 play_rizzma(frame);
-                playing.set(true);
             }
         })
     };
 
     let on_seek = {
         let frame_ref = frame_ref.clone();
-        let position = position.clone();
         Callback::from(move |event: InputEvent| {
             let value = event
                 .target_unchecked_into::<HtmlInputElement>()
@@ -294,7 +321,6 @@ pub(super) fn figure_viewer(props: &FigureViewerProps) -> Html {
             }
             if let Some(frame) = frame_ref.cast::<HtmlIFrameElement>() {
                 seek_rizzma(frame, value);
-                position.set(value);
             }
         })
     };

--- a/frontend/styles/markdown.css
+++ b/frontend/styles/markdown.css
@@ -612,6 +612,7 @@
     border: 1px solid var(--border-color);
     border-radius: 4px;
     background: #16161e;
+    margin-inline: auto;
 }
 
 .rizzma-poster,


### PR DESCRIPTION
The README still described a Claude-only session viewer with four crates. This rewrites it around what the project actually is today.

**What changed**

- Reframed as Agent Portal: run Claude Code / Codex / Muse on your own machines, drive them from any browser.
- Quick Start leads with the real onboarding path (`install.sh` → `agent-portal login` → `service install` → launch from the dashboard), with the `claude-portal` wrapper and `dev.sh` as the other two paths.
- Features expanded from seven bullets to grouped subsections: sessions-from-anywhere (replay watermarks, input outbox, nav mode, history), multi-agent + web-driven agent install/login + model picker + worktree forks, rich rendering (diffs, KaTeX, media, `portal://file`, permission cards), port forwarding, agent-to-agent messaging, scheduled tasks, cost/performance metrics, voice, notifications, sharing and access control, and operations.
- Architecture diagram redrawn with the launcher daemon, forward tunnel, archive, and mobile shell; component table replaced by the full workspace.
- Docs table extended with Protocol, Database, Auth Flows, Port Forwarding, Scheduled Tasks, File Downloads, Codex Support.

**Also**

- Adds `docs/README_ANIMATIONS.md` — a ranked plan for the short looping animations that will carry the Features section, with capture tooling, format choice (APNG / animated SVG, not GIF or repo-relative mp4), and size rules.
- Drops the link to a `LICENSE` file that does not exist in the repo; the line now just states MIT. Worth adding a real license file separately.
- Points the SDK link at `rust-code-agent-sdks`, the live repo.