### PR TITLE
Collapse Claude task notification injections

### DIFF
--- a/frontend/src/components/markdown/mod.rs
+++ b/frontend/src/components/markdown/mod.rs
@@ -19,8 +19,8 @@ mod system_reminder;
 pub use links::linkify_urls;
 use parser::parse_markdown_events;
 use renderer::render_events;
-use shared::system_reminder::{has_system_reminder, split_system_reminders, Segment};
-use system_reminder::SystemReminderBar;
+use shared::system_reminder::{has_collapsible_notice, split_collapsible_notices, Segment};
+use system_reminder::{SystemReminderBar, TaskNotificationBar};
 
 #[cfg(test)]
 use links::{find_next_url, is_valid_url};
@@ -59,17 +59,20 @@ struct MarkdownViewProps {
 
 #[function_component(MarkdownView)]
 fn markdown_view(props: &MarkdownViewProps) -> Html {
-    // `<system-reminder>` blocks collapse into a clickable bar. Doing it here
+    // Machine-authored notice blocks collapse into a clickable bar. Doing it here
     // rather than in each agent's renderer is the point: every session type's
     // text already flows through this component, so claude, codex and muse all
     // get the same treatment from one place.
-    if has_system_reminder(&props.text) {
-        let parts: Vec<Html> = split_system_reminders(&props.text)
+    if has_collapsible_notice(&props.text) {
+        let parts: Vec<Html> = split_collapsible_notices(&props.text)
             .into_iter()
             .map(|segment| match segment {
                 Segment::Text(text) => render_markdown_body(&text, props.session_id),
                 Segment::Reminder(body) => html! {
                     <SystemReminderBar body={body} />
+                },
+                Segment::TaskNotification(body) => html! {
+                    <TaskNotificationBar body={body} />
                 },
             })
             .collect();

--- a/frontend/src/components/markdown/system_reminder.rs
+++ b/frontend/src/components/markdown/system_reminder.rs
@@ -1,4 +1,4 @@
-//! `<system-reminder>` blocks, rendered as a collapsed bar you can click into.
+//! Machine-authored notice blocks, rendered as collapsed bars you can click.
 //!
 //! These blocks are out-of-band context for the agent — the portal-features
 //! reminder, the inter-agent "reply to that agent, not the user" bumper, the
@@ -6,7 +6,9 @@
 //! why an agent did something), but they are noise inline: several are longer
 //! than the message carrying them.
 //!
-//! The splitting itself lives in [`shared::system_reminder`] (#1654), because
+//! System reminders and Claude's `<task-notification>` injections share this
+//! treatment. The splitting itself lives in [`shared::system_reminder`]
+//! (#1654), because
 //! the backend has to strip the same blocks before classifying message text and
 //! a splitter that disagreed with itself across the wire would show the user one
 //! thing and feed the classifier another. This module is only the rendering half.
@@ -30,6 +32,44 @@ pub(super) struct SystemReminderBarProps {
 
 #[function_component(SystemReminderBar)]
 pub(super) fn system_reminder_bar(props: &SystemReminderBarProps) -> Html {
+    html! {
+        <CollapsibleNoticeBar title="System reminder" body={props.body.clone()} />
+    }
+}
+
+#[derive(Properties, PartialEq)]
+pub(super) struct TaskNotificationBarProps {
+    /// Notification contents, outer tags already stripped.
+    pub body: AttrValue,
+}
+
+#[function_component(TaskNotificationBar)]
+pub(super) fn task_notification_bar(props: &TaskNotificationBarProps) -> Html {
+    let status = xml_field(&props.body, "status").unwrap_or("updated");
+    let title = xml_field(&props.body, "summary")
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("Background task {status}"));
+    html! {
+        <CollapsibleNoticeBar {title} body={props.body.clone()} />
+    }
+}
+
+fn xml_field<'a>(body: &'a str, field: &str) -> Option<&'a str> {
+    let open = format!("<{field}>");
+    let close = format!("</{field}>");
+    let start = body.find(&open)? + open.len();
+    let end = body[start..].find(&close)? + start;
+    Some(body[start..end].trim())
+}
+
+#[derive(Properties, PartialEq)]
+struct CollapsibleNoticeBarProps {
+    title: AttrValue,
+    body: AttrValue,
+}
+
+#[function_component(CollapsibleNoticeBar)]
+fn collapsible_notice_bar(props: &CollapsibleNoticeBarProps) -> Html {
     let expanded = use_state(|| false);
     let on_toggle = {
         let expanded = expanded.clone();
@@ -45,7 +85,7 @@ pub(super) fn system_reminder_bar(props: &SystemReminderBarProps) -> Html {
         <div class="portal-reminder system-reminder-bar">
             <button type="button" class={header_class} onclick={on_toggle}>
                 <span class="portal-reminder-icon">{ "\u{24D8}" }</span>
-                <span class="portal-reminder-title">{ "System reminder" }</span>
+                <span class="portal-reminder-title">{ &props.title }</span>
                 <span class="portal-reminder-toggle">
                     { if *expanded { "\u{25BE}" } else { "\u{25B8}" } }
                 </span>
@@ -57,5 +97,21 @@ pub(super) fn system_reminder_bar(props: &SystemReminderBarProps) -> Html {
                 <div class="portal-reminder-body system-reminder-body">{ &props.body }</div>
             }
         </div>
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::xml_field;
+
+    #[test]
+    fn extracts_task_notification_summary_and_status() {
+        let body = "<task-id>bmq5w2fik</task-id> <status>completed</status> <summary>Background command &quot;Watch CI checks&quot; completed (exit code 0)</summary>";
+        assert_eq!(xml_field(body, "status"), Some("completed"));
+        assert_eq!(
+            xml_field(body, "summary"),
+            Some("Background command &quot;Watch CI checks&quot; completed (exit code 0)")
+        );
+        assert_eq!(xml_field(body, "output-file"), None);
     }
 }

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -1777,7 +1777,7 @@
     color: var(--text-muted);
 }
 
-/* `<system-reminder>` blocks lifted out of any agent's message text (see
+/* Machine-authored notice blocks lifted out of agent message text (see
    markdown/system_reminder.rs). It reuses `.portal-reminder*` for the bar
    itself so every collapsed notice in the transcript reads as one family;
    only the body differs, because reminder text is machine-authored and holds

--- a/shared/src/system_reminder.rs
+++ b/shared/src/system_reminder.rs
@@ -1,4 +1,4 @@
-//! Splitting `<system-reminder>` blocks out of message text.
+//! Splitting machine-authored notice blocks out of message text.
 //!
 //! These blocks are out-of-band context for the agent — the portal-features
 //! reminder, the inter-agent "reply to that agent, not the user" bumper, the
@@ -23,10 +23,43 @@
 pub enum Segment {
     Text(String),
     Reminder(String),
+    TaskNotification(String),
 }
 
 const OPEN_TAG: &str = "<system-reminder>";
 const CLOSE_TAG: &str = "</system-reminder>";
+const TASK_OPEN_TAG: &str = "<task-notification>";
+const TASK_CLOSE_TAG: &str = "</task-notification>";
+
+#[derive(Clone, Copy)]
+enum NoticeKind {
+    Reminder,
+    TaskNotification,
+}
+
+impl NoticeKind {
+    fn tags(self) -> (&'static str, &'static str) {
+        match self {
+            Self::Reminder => (OPEN_TAG, CLOSE_TAG),
+            Self::TaskNotification => (TASK_OPEN_TAG, TASK_CLOSE_TAG),
+        }
+    }
+
+    fn segment(self, body: String) -> Segment {
+        match self {
+            Self::Reminder => Segment::Reminder(body),
+            Self::TaskNotification => Segment::TaskNotification(body),
+        }
+    }
+}
+
+fn next_notice(text: &str, include_task_notifications: bool) -> Option<(usize, NoticeKind)> {
+    [NoticeKind::Reminder, NoticeKind::TaskNotification]
+        .into_iter()
+        .filter(|kind| include_task_notifications || matches!(kind, &NoticeKind::Reminder))
+        .filter_map(|kind| text.find(kind.tags().0).map(|offset| (offset, kind)))
+        .min_by_key(|(offset, _)| *offset)
+}
 
 /// Split `text` on `<system-reminder>` blocks.
 ///
@@ -34,12 +67,26 @@ const CLOSE_TAG: &str = "</system-reminder>";
 /// the end of the message: a truncated or malformed block should read as the
 /// literal text it is rather than swallowing everything after it into a bar.
 pub fn split_system_reminders(text: &str) -> Vec<Segment> {
+    split_notices(text, false)
+}
+
+/// Split prose from complete system-reminder and task-notification blocks.
+///
+/// Claude injects both shapes into otherwise ordinary message text. Keeping
+/// their parsing together ensures the frontend never renders raw XML while
+/// classifier-side consumers can remove the same out-of-band material.
+pub fn split_collapsible_notices(text: &str) -> Vec<Segment> {
+    split_notices(text, true)
+}
+
+fn split_notices(text: &str, include_task_notifications: bool) -> Vec<Segment> {
     let mut segments = Vec::new();
     let mut rest = text;
 
-    while let Some(open) = rest.find(OPEN_TAG) {
-        let after_open = open + OPEN_TAG.len();
-        let Some(close_rel) = rest[after_open..].find(CLOSE_TAG) else {
+    while let Some((open, kind)) = next_notice(rest, include_task_notifications) {
+        let (open_tag, close_tag) = kind.tags();
+        let after_open = open + open_tag.len();
+        let Some(close_rel) = rest[after_open..].find(close_tag) else {
             break;
         };
         let close = after_open + close_rel;
@@ -48,16 +95,25 @@ pub fn split_system_reminders(text: &str) -> Vec<Segment> {
         if !before.trim().is_empty() {
             segments.push(Segment::Text(before.to_string()));
         }
-        segments.push(Segment::Reminder(
-            rest[after_open..close].trim().to_string(),
-        ));
-        rest = &rest[close + CLOSE_TAG.len()..];
+        segments.push(kind.segment(rest[after_open..close].trim().to_string()));
+        rest = &rest[close + close_tag.len()..];
     }
 
     if !rest.trim().is_empty() {
         segments.push(Segment::Text(rest.to_string()));
     }
     segments
+}
+
+/// True when `text` holds a complete collapsible notice of either kind.
+pub fn has_collapsible_notice(text: &str) -> bool {
+    [NoticeKind::Reminder, NoticeKind::TaskNotification]
+        .into_iter()
+        .any(|kind| {
+            let (open_tag, close_tag) = kind.tags();
+            text.find(open_tag)
+                .is_some_and(|open| text[open + open_tag.len()..].contains(close_tag))
+        })
 }
 
 /// True when `text` holds at least one complete reminder block — lets the
@@ -81,6 +137,22 @@ pub fn strip_system_reminders(text: &str) -> String {
         .filter_map(|segment| match segment {
             Segment::Text(text) => Some(text),
             Segment::Reminder(_) => None,
+            Segment::TaskNotification(_) => unreachable!("system-reminder-only split"),
+        })
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+/// The prose of `text` with every complete collapsible notice removed.
+pub fn strip_collapsible_notices(text: &str) -> String {
+    if !has_collapsible_notice(text) {
+        return text.to_string();
+    }
+    split_collapsible_notices(text)
+        .into_iter()
+        .filter_map(|segment| match segment {
+            Segment::Text(text) => Some(text),
+            Segment::Reminder(_) | Segment::TaskNotification(_) => None,
         })
         .collect::<Vec<_>>()
         .join("")
@@ -148,6 +220,37 @@ mod tests {
         assert_eq!(
             split_system_reminders("<system-reminder>solo</system-reminder>"),
             vec![Segment::Reminder("solo".to_string())]
+        );
+    }
+
+    #[test]
+    fn splits_task_notification_from_surrounding_prose() {
+        let notification = "<task-notification> <task-id>bmq5w2fik</task-id> <status>completed</status> <summary>Background command completed</summary> </task-notification>";
+        assert_eq!(
+            split_collapsible_notices(&format!("before {notification} after")),
+            vec![
+                Segment::Text("before ".to_string()),
+                Segment::TaskNotification(
+                    "<task-id>bmq5w2fik</task-id> <status>completed</status> <summary>Background command completed</summary>".to_string(),
+                ),
+                Segment::Text(" after".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn strips_both_notice_kinds_from_prose() {
+        let text = "say <system-reminder>context</system-reminder> hello <task-notification><status>completed</status></task-notification> now";
+        assert_eq!(strip_collapsible_notices(text), "say  hello  now");
+    }
+
+    #[test]
+    fn unterminated_task_notification_stays_prose() {
+        let text = "visible <task-notification><status>running</status>";
+        assert!(!has_collapsible_notice(text));
+        assert_eq!(
+            split_collapsible_notices(text),
+            vec![Segment::Text(text.to_string())]
         );
     }
 


### PR DESCRIPTION
## Summary
- split complete `<task-notification>` blocks from surrounding Claude message prose
- render them with the existing collapsed notice treatment
- keep the task summary visible in the bumper while hiding IDs and output paths until expanded
- leave malformed or unterminated XML visible rather than swallowing message text

## Verification
- `cargo test -p shared system_reminder`
- `cargo test -p frontend markdown::system_reminder --lib`
- `cargo clippy -p shared -p frontend --all-targets -- -D warnings`
- `cargo fmt --all --check`