### PR TITLE
Order sessions by messaging recency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+- **Message-recency session ordering.** Accepted input records a dedicated
+  per-session timestamp, and fresh dashboard loads show the most recently
+  messaged sessions first instead of following agent-output activity.
+
 - **Agent SDK refresh.** Claude bindings move to 2.1.234, Codex to 0.150.1,
   and Muse to 0.2.1. Claude transcript paths and Muse tool-result outcomes now
   use their SDK-owned typed APIs, and Claude's reported extended-thinking

--- a/backend/migrations/2026-08-29-213021_add_last_messaged_at_to_sessions/down.sql
+++ b/backend/migrations/2026-08-29-213021_add_last_messaged_at_to_sessions/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+DROP INDEX IF EXISTS idx_sessions_last_messaged_at;
+ALTER TABLE sessions DROP COLUMN last_messaged_at;

--- a/backend/migrations/2026-08-29-213021_add_last_messaged_at_to_sessions/up.sql
+++ b/backend/migrations/2026-08-29-213021_add_last_messaged_at_to_sessions/up.sql
@@ -1,0 +1,9 @@
+ALTER TABLE sessions
+ADD COLUMN last_messaged_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- Existing sessions predate this field, so creation is their truthful
+-- messaging-recency baseline.
+UPDATE sessions SET last_messaged_at = created_at;
+
+CREATE INDEX idx_sessions_last_messaged_at
+ON sessions(last_messaged_at DESC);

--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -54,7 +54,11 @@ pub async fn list_sessions(
         .filter(session_members::user_id.eq(current_user_id))
         .filter(sessions::status.ne(SessionStatus::Replaced.as_str()))
         .select((Session::as_select(), session_members::role))
-        .order(sessions::last_activity.desc())
+        .order((
+            sessions::last_messaged_at.desc(),
+            sessions::created_at.desc(),
+            sessions::id.asc(),
+        ))
         .load(&mut conn)?;
 
     let sessions_with_role = results
@@ -703,6 +707,7 @@ mod tests {
             fork_point_turn_id: None,
             fork_launch_pending: false,
             fork_create_worktree: false,
+            last_messaged_at: "2026-08-29T00:00:00".parse().unwrap(),
         }
     }
 

--- a/backend/src/handlers/websocket/session_manager/input_queue.rs
+++ b/backend/src/handlers/websocket/session_manager/input_queue.rs
@@ -56,8 +56,13 @@ impl SessionManager {
         let mut persisted = false;
         let seq = match db_pool.get() {
             Ok(mut conn) => {
+                // The same accepted input owns both values: sequence assignment
+                // and recency ordering cannot drift across separate writes.
                 let next_seq: i64 = match diesel::update(sessions::table.find(session_id))
-                    .set(sessions::input_seq.eq(sessions::input_seq + 1))
+                    .set((
+                        sessions::input_seq.eq(sessions::input_seq + 1),
+                        sessions::last_messaged_at.eq(diesel::dsl::now),
+                    ))
                     .returning(sessions::input_seq)
                     .get_result(&mut conn)
                 {

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -123,6 +123,9 @@ pub struct Session {
     /// fork recipe while this is true rather than resume the empty new id.
     pub fork_launch_pending: bool,
     pub fork_create_worktree: bool,
+    /// Most recent accepted input sent into this session. Unlike
+    /// `last_activity`, agent output does not advance this timestamp.
+    pub last_messaged_at: NaiveDateTime,
 }
 
 /// Insertable session that specifies the ID (so we can use Claude's session ID)

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -230,6 +230,7 @@ diesel::table! {
         fork_point_turn_id -> Nullable<Text>,
         fork_launch_pending -> Bool,
         fork_create_worktree -> Bool,
+        last_messaged_at -> Timestamp,
     }
 }
 

--- a/frontend/src/pages/dashboard/session_order.rs
+++ b/frontend/src/pages/dashboard/session_order.rs
@@ -1,19 +1,9 @@
 //! Deterministic session display ordering + focus resolution (issue #1094).
 //!
-//! Why this exists: the dashboard polls `/api/sessions` every few seconds, and
-//! the backend orders rows by `last_activity DESC` — an activity-sensitive
-//! order that reshuffles between polls. The rail previously sorted only on
-//! folder name then hostname, so multiple agents in the *same* repo/worktree
-//! family (identical folder + host) compared **equal**, and Rust's `sort_by`
-//! gives no order guarantee for equal keys. Combined with focus being tracked
-//! by array *index*, a reshuffled poll could slide the focused index onto a
-//! different session — the "focus bounce" users saw with several same-repo
-//! agents running.
-//!
-//! Fix: a **total** comparator whose final tie-breaker is the unique session
-//! `id`, so the displayed order is a pure function of the *set* of sessions
-//! (independent of the source/poll order), plus focus tracked by `id` and
-//! resolved to an index only at render time via [`resolve_focus_index`].
+//! The rail orders sessions by the user's own messaging recency, then uses
+//! stable identity fields and the unique session id as deterministic
+//! tie-breakers. Focus is tracked by id, so a recency reorder never changes
+//! which session is active.
 
 use std::cmp::Ordering;
 use std::collections::HashSet;
@@ -23,16 +13,13 @@ use uuid::Uuid;
 
 /// Total, deterministic display-order key for a session.
 ///
-/// Lexicographic tuple, coarsest discriminant first:
-/// 1. top-level folder name (lowercased) — groups sessions by repo
-/// 2. agent type — orders the agents working that repo (e.g. claude, codex)
-/// 3. `id` — unique final tie-breaker, so no two sessions ever compare equal
+/// Sessions sort by `last_messaged_at` newest first, then by folder and agent
+/// with `id` as the unique final tie-breaker.
 ///
-/// Deliberately **does not** key on `git_branch` (or working_directory /
-/// hostname / timestamps). Branch is derived by best-effort detection that can
-/// flap between polls (and is wrong under worktrees — see #1067); keying on it
-/// made pills reorder when the branch reading changed. Folder + agent + id is
-/// the stable identity that doesn't move when branch detection wobbles.
+/// Deliberately **does not** key on `git_branch`, full working directory,
+/// hostname, or agent-driven `last_activity`. Those values may change while
+/// the user is reading another session. Only an accepted input intentionally
+/// advances the recency key.
 ///
 /// Because the key ends in the unique `id`, the order is *total*: the same set
 /// of sessions always sorts identically no matter what order the poll returned
@@ -47,7 +34,9 @@ fn display_sort_key(s: &SessionInfo) -> (String, String, Uuid) {
 
 /// Total ordering comparator for the session rail. See [`display_sort_key`].
 pub(super) fn session_display_cmp(a: &SessionInfo, b: &SessionInfo) -> Ordering {
-    display_sort_key(a).cmp(&display_sort_key(b))
+    b.last_messaged_at
+        .cmp(&a.last_messaged_at)
+        .then_with(|| display_sort_key(a).cmp(&display_sort_key(b)))
 }
 
 /// Label shown for the "no hostname" bucket in the grouped rail.
@@ -81,7 +70,7 @@ fn host_group_key(s: &SessionInfo) -> (bool, String) {
 ///
 /// - host sections are alphabetical, with the empty/unknown-host bucket last;
 /// - sessions **within** a section keep the exact relative order they'd have
-///   ungrouped (so activity-driven polls don't reshuffle within a group);
+///   ungrouped (agent output cannot reshuffle them; accepted input can);
 /// - the order stays *total* (the inner key ends in the unique `id`), so — like
 ///   [`session_display_cmp`] — the displayed sequence is a pure function of the
 ///   session set. That totality is what lets nav-mode numbering, `j`/`k`
@@ -155,6 +144,7 @@ mod tests {
             working_directory: dir.to_string(),
             status: SessionStatus::Active,
             last_activity: String::new(),
+            last_messaged_at: "2026-08-29T00:00:00Z".to_string(),
             created_at: String::new(),
             updated_at: String::new(),
             git_branch: branch.map(|b| b.to_string()),
@@ -174,6 +164,23 @@ mod tests {
             forked_from_session_id: None,
             fork_point_turn_id: None,
         }
+    }
+
+    #[test]
+    fn most_recently_messaged_session_sorts_first() {
+        let mut older = session(Uuid::from_u128(1), "/z/repo", "host", None);
+        older.last_messaged_at = "2026-08-29T10:00:00Z".to_string();
+        let mut newer = session(Uuid::from_u128(2), "/a/repo", "host", None);
+        newer.last_messaged_at = "2026-08-29T11:00:00Z".to_string();
+        let baseline = session(Uuid::from_u128(3), "/0/repo", "host", None);
+
+        let baseline_id = baseline.id;
+        let mut sessions = [older.clone(), baseline, newer.clone()];
+        sessions.sort_by(session_display_cmp);
+
+        assert_eq!(sessions[0].id, newer.id);
+        assert_eq!(sessions[1].id, older.id);
+        assert_eq!(sessions[2].id, baseline_id);
     }
 
     /// The unique-id tie-breaker makes ordering independent of input order:

--- a/frontend/src/pages/demo.rs
+++ b/frontend/src/pages/demo.rs
@@ -268,6 +268,7 @@ fn demo_session(spec: DemoSessionSpec) -> SessionInfo {
         working_directory: spec.cwd.to_string(),
         status: SessionStatus::Active,
         last_activity: "2026-07-20T04:00:00.000000Z".to_string(),
+        last_messaged_at: "2026-07-20T03:59:00.000000Z".to_string(),
         created_at: "2026-07-20T03:55:00.000000Z".to_string(),
         updated_at: "2026-07-20T04:00:00.000000Z".to_string(),
         git_branch: Some(spec.branch.to_string()),

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -602,6 +602,10 @@ pub struct SessionInfo {
     pub working_directory: String,
     pub status: SessionStatus,
     pub last_activity: String,
+    /// Most recent accepted input sent into this session, initialized to the
+    /// session creation time.
+    #[serde(default)]
+    pub last_messaged_at: String,
     pub created_at: String,
     pub updated_at: String,
     #[serde(default)]


### PR DESCRIPTION
## Summary
- add a non-null `sessions.last_messaged_at` timestamp, initialized from session creation time
- update it atomically whenever accepted session input receives its sequence number
- order fresh session lists and the dashboard rail by newest user messaging activity, with stable deterministic fallbacks
- keep agent output on `last_activity` so busy agents do not steal recency

## Verification
- cargo check --workspace --all-targets
- cargo test -p frontend session_order
- cargo test -p backend sessions_response_roundtrips_with_launcher_version_present
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- ./scripts/check-migration-names.sh
- git diff --check