### PR TITLE
Separate Rizzma canvas from transport controls

### DIFF
--- a/frontend/src/components/message_renderer/renderers/media.rs
+++ b/frontend/src/components/message_renderer/renderers/media.rs
@@ -337,33 +337,38 @@ pub(super) fn figure_viewer(props: &FigureViewerProps) -> Html {
         .unwrap_or_else(|| "Portable figure".to_string());
 
     html! {
-        <div class="rizzma-figure" style={format!("aspect-ratio: {aspect_ratio}")}>
-            if !*mounted {
-                if let Some(src) = poster {
-                    <img class="rizzma-poster" {src} alt={label.clone()} />
-                } else {
-                    <div class="rizzma-poster-missing">{ label.clone() }</div>
-                }
-            }
-            <iframe
-                ref={frame_ref}
-                class={classes!("rizzma-frame", (!*mounted).then_some("hidden"))}
-                sandbox="allow-scripts"
-                title={label}
-            />
-            if !*mounted {
-                <button class="rizzma-mount" {onclick} disabled={*loading || !props.live_supported}>
-                    if !props.live_supported {
-                        { "Poster (runtime unavailable)" }
-                    } else if *loading {
-                        { "Loading interactive figure…" }
-                    } else if props.animated {
-                        { "Play interactive figure" }
+        <div class="rizzma-figure">
+            <div class="rizzma-viewport" style={format!("aspect-ratio: {aspect_ratio}")}>
+                if !*mounted {
+                    if let Some(src) = poster {
+                        <img class="rizzma-poster" {src} alt={label.clone()} />
                     } else {
-                        { "Open interactive figure" }
+                        <div class="rizzma-poster-missing">{ label.clone() }</div>
                     }
-                </button>
-            }
+                }
+                <iframe
+                    ref={frame_ref}
+                    class={classes!("rizzma-frame", (!*mounted).then_some("hidden"))}
+                    sandbox="allow-scripts"
+                    title={label}
+                />
+                if !*mounted {
+                    <button class="rizzma-mount" {onclick} disabled={*loading || !props.live_supported}>
+                        if !props.live_supported {
+                            { "Poster (runtime unavailable)" }
+                        } else if *loading {
+                            { "Loading interactive figure…" }
+                        } else if props.animated {
+                            { "Play interactive figure" }
+                        } else {
+                            { "Open interactive figure" }
+                        }
+                    </button>
+                }
+                if let Some(message) = &*error {
+                    <div class="rizzma-error">{ message }</div>
+                }
+            </div>
             if *mounted && props.animated {
                 <div class="rizzma-controls">
                     <button type="button" onclick={on_play_pause}>
@@ -380,9 +385,6 @@ pub(super) fn figure_viewer(props: &FigureViewerProps) -> Html {
                     />
                     <span>{ format!("{:.1}s / {:.1}s", *position, props.duration.max(0.0)) }</span>
                 </div>
-            }
-            if let Some(message) = &*error {
-                <div class="rizzma-error">{ message }</div>
             }
         </div>
     }

--- a/frontend/styles/markdown.css
+++ b/frontend/styles/markdown.css
@@ -605,9 +605,7 @@
 /* Portable figures are poster-first. A live renderer replaces the poster only
    after the artifact and every executable runtime asset have been verified. */
 .rizzma-figure {
-    position: relative;
     width: min(100%, 960px);
-    max-height: 72vh;
     overflow: hidden;
     border: 1px solid var(--border-color);
     border-radius: 4px;
@@ -615,24 +613,39 @@
     margin-inline: auto;
 }
 
+.rizzma-viewport {
+    position: relative;
+    width: 100%;
+    max-height: 72vh;
+    overflow: hidden;
+}
+
 .rizzma-poster,
 .rizzma-frame {
-    display: block;
+    position: absolute;
+    inset: 0;
     width: 100%;
     height: 100%;
     border: 0;
     object-fit: contain;
 }
 
+.rizzma-poster {
+    z-index: 0;
+}
+
+.rizzma-frame {
+    z-index: 1;
+}
+
 .rizzma-frame.hidden {
     visibility: hidden;
-    position: absolute;
-    inset: 0;
 }
 
 .rizzma-poster-missing {
+    position: absolute;
+    inset: 0;
     display: grid;
-    height: 100%;
     place-items: center;
     color: var(--text-muted);
 }
@@ -648,6 +661,7 @@
     background: rgba(26, 27, 38, 0.92);
     color: #c0caf5;
     cursor: pointer;
+    z-index: 2;
 }
 
 .rizzma-mount:disabled {
@@ -662,11 +676,10 @@
     background: rgba(247, 118, 142, 0.16);
     color: #f7768e;
     font-size: 0.78rem;
+    z-index: 3;
 }
 
 .rizzma-controls {
-    position: absolute;
-    inset: auto 0 0;
     display: flex;
     align-items: center;
     gap: 0.55rem;


### PR DESCRIPTION
Fix the portable-figure stacked layout by giving the poster, iframe, mount action, and error explicit viewport layers while keeping play/pause/seek controls in normal flow below the canvas. This prevents the live iframe from covering or intercepting its transport controls.\n\nAuthor checks: cargo fmt --check; frontend figure tests; frontend clippy -D warnings; git diff --check.