### PR TITLE
Make persisted input send mode explicit

### DIFF
--- a/backend/migrations/2026-08-29-215200_make_pending_input_send_mode_required/down.sql
+++ b/backend/migrations/2026-08-29-215200_make_pending_input_send_mode_required/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE pending_inputs
+ALTER COLUMN send_mode DROP NOT NULL,
+ALTER COLUMN send_mode DROP DEFAULT;

--- a/backend/migrations/2026-08-29-215200_make_pending_input_send_mode_required/up.sql
+++ b/backend/migrations/2026-08-29-215200_make_pending_input_send_mode_required/up.sql
@@ -1,0 +1,7 @@
+UPDATE pending_inputs
+SET send_mode = 'normal'
+WHERE send_mode IS NULL;
+
+ALTER TABLE pending_inputs
+ALTER COLUMN send_mode SET DEFAULT 'normal',
+ALTER COLUMN send_mode SET NOT NULL;

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -841,7 +841,7 @@ fn handle_launcher_message(
                     session_id,
                     seq_num: next_seq,
                     content: serde_json::to_string(&content_value).unwrap_or_default(),
-                    send_mode: None,
+                    send_mode: shared::SendMode::Normal.as_str().to_string(),
                     client_msg_id: None,
                 };
                 let _ = diesel::insert_into(pending_inputs::table)

--- a/backend/src/handlers/websocket/message_handlers.rs
+++ b/backend/src/handlers/websocket/message_handlers.rs
@@ -98,7 +98,7 @@ pub fn replay_pending_inputs_from_db(
             session_id,
             seq: input.seq_num,
             content,
-            send_mode: input.send_mode.as_deref().and_then(parse_send_mode),
+            send_mode: parse_send_mode(&input.send_mode),
             // Persisted with the row (#1236) so replay keeps delivery
             // tracking: the proxy's InputProgressAck still resolves the
             // browser's outbox entry, and the idempotency gate keeps

--- a/backend/src/handlers/websocket/session_manager/input_queue.rs
+++ b/backend/src/handlers/websocket/session_manager/input_queue.rs
@@ -77,7 +77,7 @@ impl SessionManager {
                     session_id,
                     seq_num: next_seq,
                     content: serde_json::to_string(&content).unwrap_or_default(),
-                    send_mode: send_mode.as_ref().map(|m| m.as_str().to_string()),
+                    send_mode: send_mode.unwrap_or_default().as_str().to_string(),
                     client_msg_id,
                 };
                 match diesel::insert_into(pending_inputs::table)

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -398,7 +398,7 @@ pub struct PendingInput {
     pub seq_num: i64,
     pub content: String,
     pub created_at: NaiveDateTime,
-    pub send_mode: Option<String>,
+    pub send_mode: String,
     /// Browser outbox delivery-tracking id (#1236). Persisted so replay
     /// keeps delivery tracking and resends can be deduplicated across a
     /// backend restart. `None` for non-browser inputs.
@@ -411,7 +411,7 @@ pub struct NewPendingInput {
     pub session_id: Uuid,
     pub seq_num: i64,
     pub content: String,
-    pub send_mode: Option<String>,
+    pub send_mode: String,
     pub client_msg_id: Option<Uuid>,
 }
 

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -59,7 +59,7 @@ diesel::table! {
         content -> Text,
         created_at -> Timestamp,
         #[max_length = 32]
-        send_mode -> Nullable<Varchar>,
+        send_mode -> Varchar,
         client_msg_id -> Nullable<Uuid>,
     }
 }


### PR DESCRIPTION
## Summary
- audit database models and shared wire types for unnecessary `Option<T>` fields
- make `pending_inputs.send_mode` non-null because absence already means exactly `normal`
- backfill existing rows, give the column a database default, and persist `normal` explicitly
- preserve options that represent real domain states or rolling-version field presence

## Audit outcome
The remaining nullable database columns encode genuine absence (provider metadata, fork lineage, archive/lease lifecycle, conditional push credentials, incomplete metrics, and optional browser delivery ids). Shared response options likewise encode conditional data or field presence needed for rolling upgrades.

## Verification
- cargo check --workspace --all-targets
- cargo test -p backend parse_send_mode
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- ./scripts/check-migration-names.sh
- git diff --check