### PR TITLE
Add the visual-pr skill: code-grounded before/after PR summary SVGs

### DIFF
--- a/.claude/skills/visual-pr/SKILL.md
+++ b/.claude/skills/visual-pr/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: visual-pr
+description: Render a before/after visual summary SVG for a PR and show it inline in the session. Use when a PR is ready (right after creating it), when the user asks for a "visual PR" / "visual PR review", or to illustrate an existing PR or commit by number.
+---
+
+# Visual PR summary
+
+Produce **one SVG** that argues the PR's thesis visually: what was wrong or missing
+before, what mechanism the PR adds, and what guarantee holds after. The output is
+shown inline in the session with `agent-portal show` the moment the PR is ready.
+
+## Rule zero: the diagram is grounded in the code
+
+**If you didn't read it, don't draw it.** Every box title, field name, function,
+filter expression, and claim in the diagram must come from the actual diff and the
+surrounding code — never from the PR description alone, and never invented.
+
+Gather ground truth first:
+
+```bash
+gh pr diff <N>                     # or: git diff main...HEAD
+gh pr view <N> --json title,body   # intent, not truth — verify claims against code
+git show main:<file>               # the BEFORE side of a touched file
+```
+
+Then read enough of the surrounding code (callers, the enclosing function, the
+schema) to state *why* the before behavior was wrong and *how* the after behavior
+holds. Use exact identifiers: `run_expired_token_cleanup`, `expires_at < cutoff`,
+`proxy_auth_tokens` — a reviewer cross-checking symbols against the diff must find
+every one. If a claim can't be verified from the code, it goes in the footer as an
+explicit caveat or it doesn't appear.
+
+## The thesis
+
+One or two lines of large near-white text directly under the header. It states the
+**claim** of the PR — the behavioral change and its consequence — not a description
+of the diff. Formula that works:
+
+> *X used to ⟨flaw, stated concretely⟩; now ⟨mechanism⟩, so ⟨guarantee⟩.*
+
+Bad: "Refactors token cleanup and updates the settings footer."
+Good: "Revoked credentials slipped past both cleanup sweeps and lived forever; a
+third pass now ages them out through the same seven-day window."
+
+## Canvas and layout
+
+Start from [template.svg](template.svg) in this directory. Fixed geometry:
+
+- `viewBox="0 0 2000 1200"`, full-bleed background `#16161e`, 55px side margins.
+- **Header** (y≈52): `PR #NNNN · <title>` — 24px, `#565f89`, letter-spacing 1.
+- **Thesis** (y≈100, second line y≈140): 34px, `#e6e9f5`. Hairline `#3d4666`
+  underneath at y≈165.
+- **Split**: `BEFORE` label (22px bold, letter-spacing 4, `#f7768e`) at x=55,
+  y≈212; `AFTER` (same, `#9ece6a`) at x=1040. Dashed vertical divider
+  (`#3d4666`, dash `2 6`) at x=1000 from y≈190 to y≈1135.
+- Each panel is ~890px wide: BEFORE spans x 55–945, AFTER spans x 1040–1945.
+- **Footer** (y≈1172): one muted 22px `#565f89` line — the scope caveat: what the
+  PR deliberately does *not* do, or the sharpest limitation. Always present.
+
+## Palette (Tokyo Night) — semantic, not decorative
+
+| Color | Hex | Means |
+|---|---|---|
+| red | `#f7768e` | defect, dead-end, rejected path, the BEFORE label |
+| green | `#9ece6a` | new component, fixed behavior, guarantee, the AFTER label |
+| orange | `#e0af68` | caveat, gate, partially-addressed item |
+| blue | `#7aa2f7` | component/type/function names in box titles |
+| teal | `#7dcfff` | sparing secondary accent (data payloads, links) |
+| purple | `#bb9af7` | sparing tertiary accent |
+| bright | `#c0caf5` | box titles that aren't code identifiers |
+| body | `#a9b1d6` | detail lines inside boxes |
+| near-white | `#e6e9f5` | thesis only |
+| muted | `#565f89` | annotations, sub-details, footer, labels on arrows |
+| border | `#3d4666` | neutral box borders, hairlines, dividers |
+| box fill | `#1e202e` | interior of boxes (or `none`) |
+| background | `#16161e` | canvas |
+
+Structure that is *unchanged* between the two panels stays neutral (border
+`#3d4666` / `#565f89`, body text) — the reader's eye must be pulled only to what
+the PR changed. The same box appearing on both sides should look identical except
+where the PR touched it.
+
+## Archetypes — pick one per PR
+
+- **Dataflow** (most PRs): boxes = components/tables/functions, arrows = data or
+  control flow. BEFORE arrows dead-end in red annotations; AFTER flows through a
+  green new box to a green outcome box.
+- **Sequence** (locking, ordering, protocol changes): lifelines with activation
+  bars, horizontal call/return arrows (solid call, dashed return), red bar for the
+  interleaving hazard, green single call replacing two.
+- **Timeline** (latency, delays, retention windows): a horizontal axis with ticks,
+  events placed on it, shaded windows, ⊗ for the wrong anchor point, ✓ for the
+  right one.
+- **Checklist verdict** (validation/health-check logic): BEFORE as red `–` items
+  ("never checked", "not counted"), AFTER as green `✓` items, each with a muted
+  one-line justification, converging on a result box.
+
+Mixing is fine (a dataflow panel ending in a checklist box), but each panel should
+read top-to-bottom or left-to-right in one pass.
+
+## Text fitting — budgets, not vibes
+
+This font averages ~0.5×font-size per character. Hard budgets:
+
+| Text | Size | Max chars |
+|---|---|---|
+| Thesis line (full width, 1890px) | 34px | 105 |
+| Box title (870px panel box, 24px padding) | 26px | 62 |
+| Box detail line | 23px | 71 |
+| Arrow label / annotation | 22px | fits its gap — keep ≤ 40 |
+| Footer (full width) | 22px | 165 |
+
+Never let text touch a box edge; 24px interior padding. Split long lines rather
+than shrinking the font below 21px. Line spacing inside a box: 36–40px.
+
+Free-floating labels must not cross an arrow's path: compute the label's span
+(chars × 0.5 × size from its x) and keep it inside the horizontal gap between
+arrows. When in doubt, rasterize and look:
+`convert /tmp/visual-pr-<N>.svg /tmp/check.png` then Read the PNG.
+
+## Procedure
+
+1. **Ground truth**: read the diff and surrounding code (rule zero above).
+2. **Thesis**: write it as text first; if you can't state the claim in two lines,
+   you don't understand the PR yet — go back to the code.
+3. **Pick the archetype** and sketch the box list for each panel: BEFORE must show
+   *why* it was wrong (the mechanism of the flaw), AFTER *why* it now holds.
+4. **Fill the template**: copy `template.svg`, replace the placeholder panels.
+   Real identifiers in blue/monospace-flavored titles; semantic colors per the
+   table; footer caveat last.
+5. **Validate**: `python3 .claude/skills/visual-pr/check_svg.py <file.svg>` —
+   fixes anything it flags (parse errors and off-palette colors are hard errors,
+   overflow estimates are warnings to eyeball).
+6. **Show it**: save as `/tmp/visual-pr-<N>.svg` (keep the repo clean — do not
+   commit generated SVGs) and run `agent-portal show /tmp/visual-pr-<N>.svg`.
+
+## Quality bar
+
+- Every identifier in the diagram appears in the diff or the touched files.
+- The two panels are structurally parallel — the reader diffs them by eye.
+- Red only where something is genuinely wrong; green only where the PR makes it
+  right; a diagram that is all green is marketing, not review.
+- The footer names a real limitation, not a humble-brag.
+- Validator passes clean.

--- a/.claude/skills/visual-pr/check_svg.py
+++ b/.claude/skills/visual-pr/check_svg.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Validate a visual-pr SVG against the style spec in SKILL.md.
+
+Hard errors (exit 1): unparseable XML, wrong canvas, off-palette color.
+Warnings (exit 0): text that looks like it overflows the canvas or its panel,
+missing font-size. Overflow estimates use ~0.5 x font-size per character, the
+same budget the spec quotes — eyeball anything flagged.
+"""
+
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+PALETTE = {
+    "#16161e",  # background
+    "#1e202e",  # box fill
+    "#3d4666",  # neutral border / hairline
+    "#565f89",  # muted
+    "#a9b1d6",  # body
+    "#c0caf5",  # bright
+    "#e6e9f5",  # near-white (thesis)
+    "#7aa2f7",  # blue
+    "#9ece6a",  # green
+    "#f7768e",  # red
+    "#e0af68",  # orange
+    "#bb9af7",  # purple
+    "#7dcfff",  # teal
+    "none",
+}
+
+CANVAS_W, CANVAS_H = 2000, 1200
+MARGIN = 40  # a little tighter than the layout margin; past this is an escape
+CHAR_FACTOR = 0.5
+
+errors: list[str] = []
+warnings: list[str] = []
+
+
+def strip_ns(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def check_colors(elem: ET.Element) -> None:
+    for attr in ("fill", "stroke"):
+        val = elem.get(attr)
+        if val is None:
+            continue
+        v = val.strip().lower()
+        if v.startswith("url(") or v in ("currentcolor", "inherit"):
+            continue
+        if v not in PALETTE:
+            errors.append(
+                f"<{strip_ns(elem.tag)}> {attr}='{val}' is off-palette "
+                f"(allowed: see SKILL.md palette table)"
+            )
+
+
+def text_content(elem: ET.Element) -> str:
+    return "".join(elem.itertext()).strip()
+
+
+def check_text(elem: ET.Element, inherited_size: float) -> None:
+    size = elem.get("font-size")
+    if size is None and strip_ns(elem.tag) == "text":
+        warnings.append(f"<text> '{text_content(elem)[:40]}' has no font-size")
+    fs = float(re.sub(r"[a-z%]+$", "", size)) if size else inherited_size
+
+    content = text_content(elem)
+    if not content:
+        return
+    x = elem.get("x")
+    if x is None:
+        return
+    try:
+        x = float(x)
+    except ValueError:
+        return
+
+    est_w = len(content) * fs * CHAR_FACTOR
+    anchor = elem.get("text-anchor", "start")
+    if anchor == "middle":
+        left, right = x - est_w / 2, x + est_w / 2
+    elif anchor == "end":
+        left, right = x - est_w, x
+    else:
+        left, right = x, x + est_w
+
+    if right > CANVAS_W - MARGIN or left < 0:
+        warnings.append(
+            f"text likely overflows canvas (est {left:.0f}..{right:.0f}): "
+            f"'{content[:60]}'"
+        )
+    # Panel-divider crossing: text starting in one panel shouldn't cross x=1000.
+    if left < 990 and right > 1010 and fs < 30:  # thesis/footer (>=30 or footer y) span freely
+        y = elem.get("y")
+        yv = float(y) if y and re.fullmatch(r"[\d.]+", y) else 0.0
+        if 190 < yv < 1140:
+            warnings.append(
+                f"text crosses the BEFORE/AFTER divider (est {left:.0f}..{right:.0f}): "
+                f"'{content[:60]}'"
+            )
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <file.svg>", file=sys.stderr)
+        return 2
+
+    try:
+        tree = ET.parse(sys.argv[1])
+    except ET.ParseError as e:
+        print(f"ERROR: not well-formed XML: {e}", file=sys.stderr)
+        return 1
+
+    root = tree.getroot()
+    viewbox = (root.get("viewBox") or "").split()
+    if viewbox != ["0", "0", str(CANVAS_W), str(CANVAS_H)]:
+        errors.append(
+            f"viewBox is '{root.get('viewBox')}', spec requires '0 0 {CANVAS_W} {CANVAS_H}'"
+        )
+
+    for elem in root.iter():
+        check_colors(elem)
+        if strip_ns(elem.tag) in ("text", "tspan"):
+            check_text(elem, inherited_size=23.0)
+
+    for w in warnings:
+        print(f"warning: {w}")
+    for e in errors:
+        print(f"ERROR: {e}", file=sys.stderr)
+
+    if errors:
+        return 1
+    print(f"ok: palette + canvas clean, {len(warnings)} warning(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/visual-pr/template.svg
+++ b/.claude/skills/visual-pr/template.svg
@@ -1,0 +1,105 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <!-- ============================================================
+       visual-pr template — see SKILL.md in this directory.
+       Replace everything marked REPLACE. Keep geometry + palette.
+       ============================================================ -->
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-blue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#7aa2f7"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+    <marker id="arr-red" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#f7768e"/>
+    </marker>
+    <marker id="arr-orange" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#e0af68"/>
+    </marker>
+  </defs>
+
+  <!-- Header: REPLACE pr number + title -->
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #0000 · Title of the pull request</text>
+
+  <!-- Thesis: REPLACE — the claim, 1–2 lines, ≤105 chars each -->
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">First thesis line — what was wrong, stated concretely;</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">second thesis line — the mechanism and the guarantee that now holds.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <!-- Panel labels + center divider (keep) -->
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <!-- ==================== BEFORE panel: x 55–945 ====================
+       REPLACE the sample components below with the real diagram. -->
+
+  <!-- sample: neutral box (unchanged structure) -->
+  <g>
+    <rect x="80" y="250" width="480" height="150" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="104" y="290" font-size="26" fill="#7aa2f7">ComponentOrTypeName</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">detail line — a real field or behavior</text>
+    <text x="104" y="366" font-size="22" fill="#565f89">muted sub-detail or provenance</text>
+  </g>
+
+  <!-- sample: flow arrow with label -->
+  <line x1="320" y1="400" x2="320" y2="490" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+  <text x="336" y="450" font-size="22" fill="#565f89">payload or call</text>
+
+  <!-- sample: red dead-end (the defect) -->
+  <line x1="260" y1="505" x2="380" y2="505" stroke="#f7768e" stroke-width="3"/>
+  <text x="320" y="545" font-size="23" fill="#f7768e" text-anchor="middle">what goes wrong, concretely</text>
+  <text x="320" y="577" font-size="22" fill="#565f89" text-anchor="middle">why — one muted line</text>
+
+  <!-- sample: red outcome box -->
+  <g>
+    <rect x="80" y="960" width="860" height="120" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="1006" font-size="26" fill="#c0caf5">observable bad outcome</text>
+    <text x="104" y="1046" font-size="23" fill="#f7768e">its consequence, in red</text>
+  </g>
+
+  <!-- ==================== AFTER panel: x 1040–1945 ====================
+       Mirror the BEFORE structure; highlight only what changed. -->
+
+  <!-- sample: unchanged box (identical to BEFORE twin) -->
+  <g>
+    <rect x="1065" y="250" width="480" height="150" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="1089" y="290" font-size="26" fill="#7aa2f7">ComponentOrTypeName</text>
+    <text x="1089" y="330" font-size="23" fill="#a9b1d6">detail line — a real field or behavior</text>
+    <text x="1089" y="366" font-size="22" fill="#565f89">muted sub-detail or provenance</text>
+  </g>
+
+  <!-- sample: green flow into the new mechanism -->
+  <line x1="1305" y1="400" x2="1305" y2="490" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <!-- sample: green box (the new mechanism) -->
+  <g>
+    <rect x="1065" y="495" width="620" height="160" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1089" y="535" font-size="26" fill="#9ece6a">new_function_or_component</text>
+    <text x="1089" y="575" font-size="23" fill="#a9b1d6">what it does — exact filter / expression</text>
+    <text x="1089" y="611" font-size="22" fill="#565f89">invariant that makes it safe</text>
+  </g>
+
+  <!-- sample: orange caveat/gate box -->
+  <g>
+    <rect x="1065" y="700" width="620" height="100" fill="#1e202e" stroke="#e0af68" stroke-width="1.5"/>
+    <text x="1089" y="740" font-size="24" fill="#e0af68">gate or caveat</text>
+    <text x="1089" y="776" font-size="22" fill="#a9b1d6">what it protects against</text>
+  </g>
+
+  <!-- sample: green outcome box -->
+  <g>
+    <rect x="1065" y="960" width="860" height="120" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="1006" font-size="26" fill="#c0caf5">observable fixed outcome</text>
+    <text x="1089" y="1046" font-size="23" fill="#9ece6a">the guarantee, in green</text>
+  </g>
+
+  <!-- Footer: REPLACE — one muted scope-caveat line, ≤165 chars -->
+  <text x="55" y="1172" font-size="22" fill="#565f89">What this PR deliberately does not do, or its sharpest real limitation.</text>
+</svg>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1052,6 +1052,11 @@ use uuid::Uuid;
 - **Titles**: describe the change, not the ticket. Don't reference issue/PR numbers — they're noise in the title.
 - **Bodies**: focus on *what* the change does and *why*. Keep it concise — no commit-by-commit play-by-play.
 - **No attribution footer**: don't add "Generated with Claude Code" (or similar) to PR titles or bodies.
+- **Visual PR summary**: when a PR is ready (right after `gh pr create`), invoke
+  the `visual-pr` skill (`.claude/skills/visual-pr/SKILL.md`). It reads the
+  actual diff and surrounding code, renders a before/after SVG in the house
+  style, validates it, and shows it inline via `agent-portal show`. Generated
+  SVGs live in `/tmp` — never commit them.
 
 ## SHIP Workflow
 


### PR DESCRIPTION
Adds a committed project skill (`.claude/skills/visual-pr/`) so any agent working in this repo renders a visual summary of a PR the moment it's ready, and shows it inline in the session via `agent-portal show`.

**What's in it**
- `SKILL.md` — the full style spec (Tokyo Night palette with semantic color rules, 2000×1200 canvas geometry, thesis formula, four diagram archetypes, text-fit budgets) and the procedure. Rule zero: the diagram is grounded in the actual diff and surrounding code — every identifier drawn must exist in the code, so the picture is an accurate review artifact, not marketing.
- `template.svg` — a validated skeleton with the header/thesis/BEFORE-AFTER frame and a component library (boxes, arrows, dead-ends, caveat gates) to copy from.
- `check_svg.py` — stdlib-only validator: well-formed XML, exact canvas, palette-only colors (hard errors), plus text-overflow and divider-crossing heuristics (warnings).
- AGENTS.md PR conventions now instruct agents to invoke the skill right after `gh pr create`. Generated SVGs live in `/tmp` and are never committed.

Demoed end-to-end on PR #1755 (revoked-credential cleanup): the generated SVG validates clean and renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)