### PR TITLE
Add an admin Visual PRs tab: list open PRs, generate previews, approve

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -980,6 +980,8 @@ When making changes, verify:
 | `PORTAL_APNS_TEAM_ID` | Apple Developer Team ID for native iOS push | Required with other `PORTAL_APNS_*` vars |
 | `PORTAL_APNS_BUNDLE_ID` | App bundle id used as the APNs topic | Required with other `PORTAL_APNS_*` vars |
 | `PORTAL_FCM_SERVICE_ACCOUNT_PATH` | Google service-account JSON path for FCM v1 native Android push | Optional (FCM disabled when unset) |
+| `PORTAL_VISUAL_PR_REPO_DIR` | Git checkout that the admin Visual-PRs tab runs `gh`/`claude` in (testing feature; the checkout needs `gh` auth and the `visual-pr` skill) | Optional (tab disabled when unset) |
+| `PORTAL_VISUAL_PR_CLAUDE_BIN` | Binary invoked for visual-PR generation | Optional (default: `claude`) |
 
 Note: Dev mode is enabled via `--dev-mode` CLI flag, not an environment variable. Voice input is browser-native (Web Speech API on Chromium / Safari) unless `PORTAL_STT_BACKEND` is configured — see below.
 

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -30,4 +30,5 @@ pub mod sessions;
 pub mod sound_settings;
 pub mod stt;
 pub mod turn_metrics;
+pub mod visual_pr;
 pub mod websocket;

--- a/backend/src/handlers/visual_pr.rs
+++ b/backend/src/handlers/visual_pr.rs
@@ -1,0 +1,391 @@
+//! Admin ▸ Visual PRs: list open pull requests and generate before/after
+//! summary SVGs in the `.claude/skills/visual-pr` house style.
+//!
+//! Generation shells out to a headless `claude` run (driven through the
+//! `claude-codes` protocol types) inside a configured git checkout
+//! (`PORTAL_VISUAL_PR_REPO_DIR`); PR listing and approval shell out to `gh`
+//! in the same checkout, reusing its ambient auth. This is an admin-only
+//! testing feature: previews are held in memory and do not survive a backend
+//! restart — regeneration is one click.
+
+use axum::{
+    extract::{Path, State},
+    http::{header, HeaderMap, StatusCode},
+    response::IntoResponse,
+    Json,
+};
+use claude_codes::ClaudeOutput;
+use serde::Deserialize;
+use shared::api::{
+    VisualPrApproveResponse, VisualPrItem, VisualPrListResponse, VisualPrPreviewState,
+};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use tower_cookies::Cookies;
+use tracing::{error, info};
+
+use crate::{errors::AppError, handlers::admin::require_admin, AppState};
+
+/// Ceiling on one headless generation run. A typical run is 1–3 minutes;
+/// past ten something is wedged and the slot should free up.
+const GENERATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
+
+// ============================================================================
+// State
+// ============================================================================
+
+/// One PR's preview lifecycle. SVGs are small (≈10 KB) so they live inline.
+#[derive(Debug, Clone)]
+enum PreviewEntry {
+    Generating,
+    Ready { svg: String },
+    Failed { error: String },
+}
+
+/// In-memory visual-PR runtime hung off [`AppState`]. Cloning shares the
+/// entry map (AppState itself derives `Clone`).
+#[derive(Clone)]
+pub struct VisualPrState {
+    /// Git checkout that `gh` and `claude` run in. `None` = feature disabled
+    /// (the list endpoint reports why; everything else 503s).
+    pub repo_dir: Option<PathBuf>,
+    /// Binary to invoke for generation (default `claude`).
+    pub claude_bin: String,
+    entries: Arc<Mutex<HashMap<i64, PreviewEntry>>>,
+}
+
+impl VisualPrState {
+    pub fn from_env() -> Self {
+        let repo_dir = std::env::var("PORTAL_VISUAL_PR_REPO_DIR")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .map(PathBuf::from);
+        let claude_bin = std::env::var("PORTAL_VISUAL_PR_CLAUDE_BIN")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or_else(|| "claude".to_string());
+        match &repo_dir {
+            Some(dir) => info!("Visual PRs: enabled, repo dir {}", dir.display()),
+            None => info!("Visual PRs: disabled (PORTAL_VISUAL_PR_REPO_DIR unset)"),
+        }
+        Self {
+            repo_dir,
+            claude_bin,
+            entries: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    fn repo_dir(&self) -> Result<&PathBuf, AppError> {
+        self.repo_dir.as_ref().ok_or(AppError::ServiceUnavailable(
+            "visual PRs disabled: set PORTAL_VISUAL_PR_REPO_DIR",
+        ))
+    }
+
+    fn entry(&self, number: i64) -> Option<PreviewEntry> {
+        self.entries.lock().expect("poisoned").get(&number).cloned()
+    }
+
+    fn set_entry(&self, number: i64, entry: PreviewEntry) {
+        self.entries.lock().expect("poisoned").insert(number, entry);
+    }
+}
+
+// ============================================================================
+// GET /api/admin/visual-prs — open PRs merged with preview state
+// ============================================================================
+
+/// Shape of one element of `gh pr list --json ...`.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhPr {
+    number: i64,
+    title: String,
+    head_ref_name: String,
+    updated_at: String,
+    is_draft: bool,
+    url: String,
+    author: GhAuthor,
+}
+
+#[derive(Deserialize)]
+struct GhAuthor {
+    login: String,
+}
+
+pub async fn list_visual_prs(
+    State(app_state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    cookies: Cookies,
+) -> Result<Json<VisualPrListResponse>, AppError> {
+    require_admin(&app_state, &headers, &cookies)?;
+
+    let Some(repo_dir) = app_state.visual_prs.repo_dir.clone() else {
+        return Ok(Json(VisualPrListResponse {
+            enabled: false,
+            disabled_reason: Some(
+                "Set PORTAL_VISUAL_PR_REPO_DIR to a git checkout with gh auth to enable."
+                    .to_string(),
+            ),
+            prs: vec![],
+        }));
+    };
+
+    let output = tokio::process::Command::new("gh")
+        .args([
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--limit",
+            "50",
+            "--json",
+            "number,title,headRefName,updatedAt,isDraft,url,author",
+        ])
+        .current_dir(&repo_dir)
+        .output()
+        .await
+        .map_err(|e| AppError::Internal(format!("failed to spawn gh: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        error!("gh pr list failed: {}", stderr.trim());
+        return Err(AppError::BadGatewayMessage(format!(
+            "gh pr list failed: {}",
+            stderr.trim()
+        )));
+    }
+
+    let gh_prs: Vec<GhPr> = serde_json::from_slice(&output.stdout)
+        .map_err(|e| AppError::Internal(format!("unparseable gh pr list output: {e}")))?;
+
+    let prs = gh_prs
+        .into_iter()
+        .map(|pr| {
+            let (preview, preview_error) = match app_state.visual_prs.entry(pr.number) {
+                None => (VisualPrPreviewState::None, None),
+                Some(PreviewEntry::Generating) => (VisualPrPreviewState::Generating, None),
+                Some(PreviewEntry::Ready { .. }) => (VisualPrPreviewState::Ready, None),
+                Some(PreviewEntry::Failed { error }) => (VisualPrPreviewState::Failed, Some(error)),
+            };
+            VisualPrItem {
+                number: pr.number,
+                title: pr.title,
+                head_ref: pr.head_ref_name,
+                author: pr.author.login,
+                updated_at: pr.updated_at,
+                draft: pr.is_draft,
+                url: pr.url,
+                preview,
+                preview_error,
+            }
+        })
+        .collect();
+
+    Ok(Json(VisualPrListResponse {
+        enabled: true,
+        disabled_reason: None,
+        prs,
+    }))
+}
+
+// ============================================================================
+// POST /api/admin/visual-prs/{number}/generate — kick off a background run
+// ============================================================================
+
+pub async fn generate_visual_pr(
+    State(app_state): State<Arc<AppState>>,
+    Path(number): Path<i64>,
+    headers: HeaderMap,
+    cookies: Cookies,
+) -> Result<StatusCode, AppError> {
+    let admin = require_admin(&app_state, &headers, &cookies)?;
+    app_state.visual_prs.repo_dir()?;
+
+    if matches!(
+        app_state.visual_prs.entry(number),
+        Some(PreviewEntry::Generating)
+    ) {
+        return Err(AppError::Conflict("a generation is already running"));
+    }
+
+    info!("Visual PR #{number}: generation started by {}", admin.email);
+    app_state
+        .visual_prs
+        .set_entry(number, PreviewEntry::Generating);
+    tokio::spawn(run_generation(app_state.clone(), number));
+    Ok(StatusCode::ACCEPTED)
+}
+
+/// The background generation task: headless `claude` follows the committed
+/// `visual-pr` skill and writes the SVG to a temp path; we parse its final
+/// `ResultMessage` (via `claude-codes`) for success, then lift the file into
+/// memory.
+async fn run_generation(app_state: Arc<AppState>, number: i64) {
+    let result = generate_svg(&app_state, number).await;
+    match result {
+        Ok(svg) => {
+            info!("Visual PR #{number}: preview ready ({} bytes)", svg.len());
+            app_state
+                .visual_prs
+                .set_entry(number, PreviewEntry::Ready { svg });
+        }
+        Err(e) => {
+            error!("Visual PR #{number}: generation failed: {e}");
+            app_state
+                .visual_prs
+                .set_entry(number, PreviewEntry::Failed { error: e });
+        }
+    }
+}
+
+async fn generate_svg(app_state: &Arc<AppState>, number: i64) -> Result<String, String> {
+    let repo_dir = app_state
+        .visual_prs
+        .repo_dir
+        .clone()
+        .ok_or("visual PRs disabled")?;
+    let out_path = std::env::temp_dir().join(format!("visual-pr-{number}.svg"));
+    // A stale file from an earlier run must not be mistaken for this run's output.
+    let _ = tokio::fs::remove_file(&out_path).await;
+
+    let prompt = format!(
+        "Generate the visual PR summary for PR #{number} of this repository by following \
+         .claude/skills/visual-pr/SKILL.md exactly. Read the real diff first \
+         (`gh pr view {number}`, `gh pr diff {number}`) and ground every identifier in the \
+         code — do not invent names. Write the final SVG to {out} and validate it with \
+         `python3 .claude/skills/visual-pr/check_svg.py {out}`. Do NOT run `agent-portal show`, \
+         do NOT check out branches, do NOT commit, push, or modify the repository.",
+        out = out_path.display(),
+    );
+
+    let child = tokio::process::Command::new(&app_state.visual_prs.claude_bin)
+        .args([
+            "-p",
+            &prompt,
+            "--output-format",
+            "json",
+            "--dangerously-skip-permissions",
+        ])
+        .current_dir(&repo_dir)
+        .stdin(std::process::Stdio::null())
+        .output();
+
+    let output = tokio::time::timeout(GENERATION_TIMEOUT, child)
+        .await
+        .map_err(|_| format!("timed out after {}s", GENERATION_TIMEOUT.as_secs()))?
+        .map_err(|e| format!("failed to spawn claude: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let tail: String = stderr
+            .chars()
+            .rev()
+            .take(400)
+            .collect::<Vec<_>>()
+            .iter()
+            .rev()
+            .collect();
+        return Err(format!(
+            "claude exited with {}: {}",
+            output.status,
+            tail.trim()
+        ));
+    }
+
+    // `--output-format json` prints a single ResultMessage object.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    match serde_json::from_str::<ClaudeOutput>(stdout.trim()) {
+        Ok(ClaudeOutput::Result(result)) if result.is_error => {
+            return Err(format!(
+                "claude reported an error: {}",
+                result.result.unwrap_or_else(|| "(no detail)".to_string())
+            ));
+        }
+        Ok(_) => {}
+        Err(e) => {
+            // The run may still have produced the file; note the parse failure
+            // only if it didn't.
+            if !out_path.exists() {
+                return Err(format!("unparseable claude output ({e})"));
+            }
+        }
+    }
+
+    let svg = tokio::fs::read_to_string(&out_path).await.map_err(|e| {
+        format!(
+            "claude finished but wrote no SVG at {}: {e}",
+            out_path.display()
+        )
+    })?;
+    if !svg.trim_start().starts_with("<svg") {
+        return Err("output file does not start with <svg".to_string());
+    }
+    Ok(svg)
+}
+
+// ============================================================================
+// GET /api/admin/visual-prs/{number}/preview.svg — serve a ready preview
+// ============================================================================
+
+pub async fn get_visual_pr_svg(
+    State(app_state): State<Arc<AppState>>,
+    Path(number): Path<i64>,
+    headers: HeaderMap,
+    cookies: Cookies,
+) -> Result<impl IntoResponse, AppError> {
+    require_admin(&app_state, &headers, &cookies)?;
+    match app_state.visual_prs.entry(number) {
+        Some(PreviewEntry::Ready { svg }) => Ok((
+            [
+                (header::CONTENT_TYPE, "image/svg+xml"),
+                (header::CACHE_CONTROL, "no-store"),
+            ],
+            svg,
+        )),
+        _ => Err(AppError::NotFound("no preview for this PR")),
+    }
+}
+
+// ============================================================================
+// POST /api/admin/visual-prs/{number}/approve — squash-merge via gh
+// ============================================================================
+
+pub async fn approve_visual_pr(
+    State(app_state): State<Arc<AppState>>,
+    Path(number): Path<i64>,
+    headers: HeaderMap,
+    cookies: Cookies,
+) -> Result<Json<VisualPrApproveResponse>, AppError> {
+    let admin = require_admin(&app_state, &headers, &cookies)?;
+    let repo_dir = app_state.visual_prs.repo_dir()?.clone();
+
+    info!("Visual PR #{number}: approve requested by {}", admin.email);
+    // `--auto` merges immediately when requirements are already met and
+    // otherwise arms auto-merge for when CI goes green — either way one call.
+    let output = tokio::process::Command::new("gh")
+        .args([
+            "pr",
+            "merge",
+            &number.to_string(),
+            "--squash",
+            "--delete-branch",
+            "--auto",
+        ])
+        .current_dir(&repo_dir)
+        .output()
+        .await
+        .map_err(|e| AppError::Internal(format!("failed to spawn gh: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(AppError::BadGatewayMessage(format!(
+            "gh pr merge failed: {}",
+            stderr.trim()
+        )));
+    }
+
+    Ok(Json(VisualPrApproveResponse {
+        message: format!("PR #{number} approved — squash merge queued (auto-merge)"),
+    }))
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -107,6 +107,9 @@ pub struct AppState {
     pub stt: Option<portal_stt::SttProvider>,
     /// Per-recording cap (MB) for `POST /api/stt/transcribe`.
     pub max_audio_mb: u32,
+    /// Admin visual-PR review runtime (testing feature). Always present;
+    /// disabled internally when `PORTAL_VISUAL_PR_REPO_DIR` is unset.
+    pub visual_prs: handlers::visual_pr::VisualPrState,
 }
 
 impl AppState {
@@ -204,6 +207,7 @@ pub async fn run() -> anyhow::Result<()> {
         session_max_age_days: config.session_max_age_days,
         max_image_mb: config.max_image_mb,
         max_audio_mb: config.max_audio_mb,
+        visual_prs: handlers::visual_pr::VisualPrState::from_env(),
         image_store: handlers::images::ImageStore::new(
             config.image_store_max_bytes,
             config.image_store_ttl,

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -430,6 +430,23 @@ pub fn build_router(app_state: Arc<AppState>) -> Router {
             "/api/admin/forwards",
             get(handlers::admin_subdomains::list_admin_forwards),
         )
+        // Admin visual PR review (testing feature; see handlers::visual_pr)
+        .route(
+            "/api/admin/visual-prs",
+            get(handlers::visual_pr::list_visual_prs),
+        )
+        .route(
+            "/api/admin/visual-prs/{number}/generate",
+            post(handlers::visual_pr::generate_visual_pr),
+        )
+        .route(
+            "/api/admin/visual-prs/{number}/preview.svg",
+            get(handlers::visual_pr::get_visual_pr_svg),
+        )
+        .route(
+            "/api/admin/visual-prs/{number}/approve",
+            post(handlers::visual_pr::approve_visual_pr),
+        )
         // Add single unified state
         .with_state(app_state)
         // Merge rate-limited route groups

--- a/backend/src/test_support.rs
+++ b/backend/src/test_support.rs
@@ -54,6 +54,7 @@ pub fn test_app_state(pool: DbPool) -> AppState {
         oauth: crate::config::OAuthProviders::default(),
         stt: None,
         max_audio_mb: 25,
+        visual_prs: crate::handlers::visual_pr::VisualPrState::from_env(),
         device_flow_store: None,
         public_url: "http://localhost:3000".to_string(),
         cookie_key: Key::generate(),

--- a/frontend/src/pages/admin/mod.rs
+++ b/frontend/src/pages/admin/mod.rs
@@ -10,11 +10,13 @@ mod overview_tab;
 mod sessions_tab;
 mod subdomains_tab;
 mod users_tab;
+mod visual_prs_tab;
 
 use overview_tab::AdminOverviewTab;
 use sessions_tab::AdminSessionsTab;
 use subdomains_tab::AdminSubdomainsTab;
 use users_tab::AdminUsersTab;
+use visual_prs_tab::AdminVisualPrsTab;
 
 use crate::components::ConfirmModal;
 use crate::utils::{self, FetchError, On401};
@@ -41,6 +43,7 @@ enum AdminTab {
     Users,
     Sessions,
     Subdomains,
+    VisualPrs,
 }
 
 // ============================================================================
@@ -427,6 +430,7 @@ pub fn admin_page(props: &AdminPageProps) -> Html {
     let on_users_tab = make_tab_handler(AdminTab::Users);
     let on_sessions_tab = make_tab_handler(AdminTab::Sessions);
     let on_subdomains_tab = make_tab_handler(AdminTab::Subdomains);
+    let on_visual_prs_tab = make_tab_handler(AdminTab::VisualPrs);
 
     // Cancel confirmation
     let on_cancel_confirm = {
@@ -497,6 +501,12 @@ pub fn admin_page(props: &AdminPageProps) -> Html {
                                 >
                                     { "Subdomains" }
                                 </button>
+                                <button
+                                    class={classes!("tab-btn", if *active_tab == AdminTab::VisualPrs { Some("active") } else { None })}
+                                    onclick={on_visual_prs_tab}
+                                >
+                                    { "Visual PRs" }
+                                </button>
                             </nav>
 
                             <div class="admin-content">
@@ -527,6 +537,9 @@ pub fn admin_page(props: &AdminPageProps) -> Html {
                                         }
                                         AdminTab::Subdomains => {
                                             html! { <AdminSubdomainsTab /> }
+                                        }
+                                        AdminTab::VisualPrs => {
+                                            html! { <AdminVisualPrsTab /> }
                                         }
                                     }
                                 }

--- a/frontend/src/pages/admin/visual_prs_tab.rs
+++ b/frontend/src/pages/admin/visual_prs_tab.rs
@@ -1,0 +1,291 @@
+// TODO(#1165): remove this file-local ratchet after replacing production unwrap/expect paths.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! Admin ▸ Visual PRs: list open pull requests, kick off background
+//! generation of a before/after summary SVG (the `.claude/skills/visual-pr`
+//! house style), and click into a ready preview to approve (squash-merge)
+//! the PR. Testing feature — previews live in backend memory only.
+
+use gloo::timers::callback::Interval;
+use gloo_net::http::Request;
+use shared::api::{
+    VisualPrApproveResponse, VisualPrItem, VisualPrListResponse, VisualPrPreviewState,
+};
+use wasm_bindgen_futures::spawn_local;
+use yew::prelude::*;
+
+use crate::utils::{self, On401};
+
+/// Poll cadence while the tab is open: generation runs for minutes, so a
+/// 5-second refresh keeps status chips honest without hammering `gh`.
+const POLL_MS: u32 = 5_000;
+
+#[function_component(AdminVisualPrsTab)]
+pub fn admin_visual_prs_tab() -> Html {
+    let data = use_state(|| None::<VisualPrListResponse>);
+    let expanded = use_state(|| None::<i64>);
+    let confirm_merge = use_state(|| false);
+    let notice = use_state(|| None::<String>);
+
+    let reload = {
+        let data = data.clone();
+        move || {
+            let data = data.clone();
+            spawn_local(async move {
+                if let Ok(d) = utils::fetch_json::<VisualPrListResponse>(
+                    "/api/admin/visual-prs",
+                    On401::Ignore,
+                )
+                .await
+                {
+                    data.set(Some(d));
+                }
+            });
+        }
+    };
+
+    {
+        let reload = reload.clone();
+        use_effect_with((), move |_| {
+            reload();
+            let interval = Interval::new(POLL_MS, reload);
+            move || drop(interval)
+        });
+    }
+
+    let on_generate = {
+        let reload = reload.clone();
+        let notice = notice.clone();
+        Callback::from(move |number: i64| {
+            let reload = reload.clone();
+            let notice = notice.clone();
+            spawn_local(async move {
+                let url = utils::api_url(&format!("/api/admin/visual-prs/{number}/generate"));
+                match Request::post(&url).send().await {
+                    Ok(resp) if resp.ok() => notice.set(None),
+                    Ok(resp) => notice.set(Some(format!(
+                        "Generate for #{number} failed: HTTP {}",
+                        resp.status()
+                    ))),
+                    Err(e) => notice.set(Some(format!("Generate for #{number} failed: {e}"))),
+                }
+                reload();
+            });
+        })
+    };
+
+    let on_approve = {
+        let reload = reload.clone();
+        let notice = notice.clone();
+        let expanded = expanded.clone();
+        let confirm_merge = confirm_merge.clone();
+        Callback::from(move |number: i64| {
+            let reload = reload.clone();
+            let notice = notice.clone();
+            let expanded = expanded.clone();
+            let confirm_merge = confirm_merge.clone();
+            spawn_local(async move {
+                let url = utils::api_url(&format!("/api/admin/visual-prs/{number}/approve"));
+                match Request::post(&url).send().await {
+                    Ok(resp) if resp.ok() => {
+                        let msg = resp
+                            .json::<VisualPrApproveResponse>()
+                            .await
+                            .map(|r| r.message)
+                            .unwrap_or_else(|_| format!("PR #{number} approved"));
+                        notice.set(Some(msg));
+                        expanded.set(None);
+                    }
+                    Ok(resp) => {
+                        let body = resp.text().await.unwrap_or_default();
+                        notice.set(Some(format!("Approve #{number} failed: {body}")));
+                    }
+                    Err(e) => notice.set(Some(format!("Approve #{number} failed: {e}"))),
+                }
+                confirm_merge.set(false);
+                reload();
+            });
+        })
+    };
+
+    let Some(list) = (*data).clone() else {
+        return html! { <p class="empty-state">{ "Loading pull requests…" }</p> };
+    };
+
+    if !list.enabled {
+        return html! {
+            <section class="visual-prs">
+                <h3>{ "Visual PR review" }</h3>
+                <p class="empty-state">
+                    { list.disabled_reason.unwrap_or_else(|| "Feature disabled.".to_string()) }
+                </p>
+            </section>
+        };
+    }
+
+    let expanded_pr: Option<VisualPrItem> =
+        expanded.and_then(|n| list.prs.iter().find(|p| p.number == n).cloned());
+
+    html! {
+        <section class="visual-prs">
+            <h3>{ "Visual PR review" }</h3>
+            <p class="section-note">
+                { "Generate renders a before/after summary of the PR's actual diff in the background \
+                   (a headless claude run — takes a minute or three). Click a ready preview to review \
+                   and approve." }
+            </p>
+            if let Some(msg) = (*notice).clone() {
+                <p class="visual-pr-notice">{ msg }</p>
+            }
+            if list.prs.is_empty() {
+                <p class="empty-state">{ "No open pull requests." }</p>
+            } else {
+                <table class="admin-table">
+                    <thead>
+                        <tr>
+                            <th>{ "PR" }</th>
+                            <th>{ "Title" }</th>
+                            <th>{ "Branch" }</th>
+                            <th>{ "Preview" }</th>
+                            <th class="actions"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        { for list.prs.iter().map(|pr| render_row(pr, &expanded, &on_generate)) }
+                    </tbody>
+                </table>
+            }
+            if let Some(pr) = expanded_pr {
+                { render_preview_modal(&pr, &expanded, &confirm_merge, &on_generate, &on_approve) }
+            }
+        </section>
+    }
+}
+
+fn render_row(
+    pr: &VisualPrItem,
+    expanded: &UseStateHandle<Option<i64>>,
+    on_generate: &Callback<i64>,
+) -> Html {
+    let number = pr.number;
+    let status = match pr.preview {
+        VisualPrPreviewState::None => html! { <span class="visual-pr-chip none">{ "—" }</span> },
+        VisualPrPreviewState::Generating => {
+            html! { <span class="visual-pr-chip generating">{ "Generating…" }</span> }
+        }
+        VisualPrPreviewState::Ready => {
+            html! { <span class="visual-pr-chip ready">{ "Ready" }</span> }
+        }
+        VisualPrPreviewState::Failed => html! {
+            <span class="visual-pr-chip failed" title={pr.preview_error.clone().unwrap_or_default()}>
+                { "Failed" }
+            </span>
+        },
+    };
+
+    let action = match pr.preview {
+        VisualPrPreviewState::Generating => html! {},
+        VisualPrPreviewState::Ready => {
+            let expanded = expanded.clone();
+            html! {
+                <button class="header-button" onclick={Callback::from(move |_| expanded.set(Some(number)))}>
+                    { "View" }
+                </button>
+            }
+        }
+        VisualPrPreviewState::None | VisualPrPreviewState::Failed => {
+            let on_generate = on_generate.clone();
+            let label = if pr.preview == VisualPrPreviewState::Failed {
+                "Retry"
+            } else {
+                "Generate"
+            };
+            html! {
+                <button class="header-button" onclick={Callback::from(move |_| on_generate.emit(number))}>
+                    { label }
+                </button>
+            }
+        }
+    };
+
+    html! {
+        <tr key={pr.number.to_string()}>
+            <td class="numeric">
+                <a href={pr.url.clone()} target="_blank" rel="noopener noreferrer">
+                    { format!("#{}", pr.number) }
+                </a>
+            </td>
+            <td>
+                { &pr.title }
+                if pr.draft {
+                    <span class="visual-pr-chip none">{ "draft" }</span>
+                }
+            </td>
+            <td class="timestamp">{ &pr.head_ref }</td>
+            <td>{ status }</td>
+            <td class="actions">{ action }</td>
+        </tr>
+    }
+}
+
+fn render_preview_modal(
+    pr: &VisualPrItem,
+    expanded: &UseStateHandle<Option<i64>>,
+    confirm_merge: &UseStateHandle<bool>,
+    on_generate: &Callback<i64>,
+    on_approve: &Callback<i64>,
+) -> Html {
+    let number = pr.number;
+    let svg_url = utils::api_url(&format!("/api/admin/visual-prs/{number}/preview.svg"));
+
+    let on_close = {
+        let expanded = expanded.clone();
+        let confirm_merge = confirm_merge.clone();
+        Callback::from(move |_: MouseEvent| {
+            expanded.set(None);
+            confirm_merge.set(false);
+        })
+    };
+    let on_regenerate = {
+        let on_generate = on_generate.clone();
+        let expanded = expanded.clone();
+        Callback::from(move |_: MouseEvent| {
+            on_generate.emit(number);
+            expanded.set(None);
+        })
+    };
+    let approve_button = if **confirm_merge {
+        let on_approve = on_approve.clone();
+        html! {
+            <button class="modal-confirm" onclick={Callback::from(move |_: MouseEvent| on_approve.emit(number))}>
+                { "Confirm squash-merge" }
+            </button>
+        }
+    } else {
+        let confirm_merge = confirm_merge.clone();
+        html! {
+            <button class="modal-confirm" onclick={Callback::from(move |_: MouseEvent| confirm_merge.set(true))}>
+                { "Approve & merge" }
+            </button>
+        }
+    };
+
+    html! {
+        <div class="modal-overlay" onclick={on_close.clone()}>
+            <div
+                class="modal-content visual-pr-modal"
+                onclick={Callback::from(|e: MouseEvent| e.stop_propagation())}
+            >
+                <h3>
+                    { format!("PR #{} · {}", pr.number, pr.title) }
+                </h3>
+                <img class="visual-pr-preview" src={svg_url} alt={format!("Visual summary of PR #{}", pr.number)} />
+                <div class="modal-buttons">
+                    <button class="modal-cancel" onclick={on_close}>{ "Close" }</button>
+                    <button class="modal-cancel" onclick={on_regenerate}>{ "Regenerate" }</button>
+                    { approve_button }
+                </div>
+            </div>
+        </div>
+    }
+}

--- a/frontend/styles/admin.css
+++ b/frontend/styles/admin.css
@@ -457,3 +457,57 @@
 .subdomain-table a:hover {
     text-decoration: underline;
 }
+
+/* ---- Visual PR review tab ---- */
+
+.visual-prs .section-note {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    margin: 0.25rem 0 0.75rem;
+}
+
+.visual-pr-notice {
+    color: var(--text-teal, #7dcfff);
+    font-size: 0.85rem;
+    margin: 0.25rem 0 0.75rem;
+}
+
+.visual-pr-chip {
+    display: inline-block;
+    padding: 0.1rem 0.5rem;
+    border-radius: 0.75rem;
+    font-size: 0.75rem;
+    margin-left: 0.4rem;
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+}
+
+.visual-pr-chip.generating {
+    border-color: var(--warning, #e0af68);
+    color: var(--warning, #e0af68);
+}
+
+.visual-pr-chip.ready {
+    border-color: var(--success, #9ece6a);
+    color: var(--success, #9ece6a);
+}
+
+.visual-pr-chip.failed {
+    border-color: var(--error, #f7768e);
+    color: var(--error, #f7768e);
+}
+
+.visual-pr-modal {
+    max-width: min(1400px, 94vw);
+    width: min(1400px, 94vw);
+}
+
+.visual-pr-preview {
+    display: block;
+    width: 100%;
+    height: auto;
+    margin: 0.75rem 0;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: #16161e;
+}

--- a/shared/src/api/mod.rs
+++ b/shared/src/api/mod.rs
@@ -14,6 +14,7 @@ mod scheduled_tasks;
 mod sessions;
 mod settings;
 mod users;
+mod visual_prs;
 
 pub use auth::*;
 pub use device_flow::*;
@@ -29,6 +30,7 @@ pub use scheduled_tasks::*;
 pub use sessions::*;
 pub use settings::*;
 pub use users::*;
+pub use visual_prs::*;
 
 #[cfg(test)]
 mod tests {

--- a/shared/src/api/visual_prs.rs
+++ b/shared/src/api/visual_prs.rs
@@ -1,0 +1,54 @@
+//! Admin ▸ Visual PRs: list open pull requests and manage generated
+//! before/after summary SVGs (the `.claude/skills/visual-pr` style).
+
+use serde::{Deserialize, Serialize};
+
+/// Lifecycle of a PR's generated preview on the backend.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum VisualPrPreviewState {
+    /// No preview has been generated for this PR (or the backend restarted;
+    /// previews are held in memory only).
+    None,
+    /// A generation task is running.
+    Generating,
+    /// A preview SVG is available at `/api/admin/visual-prs/{number}/preview.svg`.
+    Ready,
+    /// The last generation attempt failed; see `preview_error`.
+    Failed,
+}
+
+/// One open pull request as listed by the visual-PR admin panel.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct VisualPrItem {
+    pub number: i64,
+    pub title: String,
+    pub head_ref: String,
+    pub author: String,
+    /// RFC 3339 timestamp of the PR's last update, verbatim from GitHub.
+    pub updated_at: String,
+    pub draft: bool,
+    /// Web URL of the PR on GitHub.
+    pub url: String,
+    pub preview: VisualPrPreviewState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preview_error: Option<String>,
+}
+
+/// Response for `GET /api/admin/visual-prs`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct VisualPrListResponse {
+    /// False when the backend has no `PORTAL_VISUAL_PR_REPO_DIR` configured;
+    /// `disabled_reason` says what to set.
+    pub enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disabled_reason: Option<String>,
+    pub prs: Vec<VisualPrItem>,
+}
+
+/// Response for `POST /api/admin/visual-prs/{number}/approve`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct VisualPrApproveResponse {
+    /// Human-readable outcome ("merge queued", trailing `gh` output, …).
+    pub message: String,
+}


### PR DESCRIPTION
Adds a **Visual PRs** tab to the admin panel — a testing feature for visual PR review.

**Flow**
1. The tab lists open pull requests (`gh pr list` in a configured checkout), each with a preview status chip, polling every 5 s.
2. **Generate** kicks off a background task: a headless `claude` run in that checkout follows the committed `.claude/skills/visual-pr` skill — it reads the PR's actual diff and renders the before/after summary SVG. The run's final `ResultMessage` is parsed with the `claude-codes` types; the SVG is validated and lifted into memory.
3. A **Ready** preview opens full-width in a modal; **Approve & merge** (two-click confirm) runs `gh pr merge --squash --delete-branch --auto`.

**Config**: off unless `PORTAL_VISUAL_PR_REPO_DIR` points at a git checkout with `gh` auth and the skill; `PORTAL_VISUAL_PR_CLAUDE_BIN` overrides the binary. Previews are in-memory only (a restart clears them — regeneration is one click). Env vars documented in AGENTS.md.

Smoke-tested end-to-end against the live repo: list, generate (PR #1772, ~4 min, on-style code-grounded output), preview serving, and validator all green.