### PR TITLE
Focus the most recent session after seppuku

### DIFF
--- a/frontend/src/pages/dashboard/page_focus.rs
+++ b/frontend/src/pages/dashboard/page_focus.rs
@@ -16,6 +16,14 @@ pub(super) struct DashboardFocus {
     pub jump_to_latest_signal: u32,
 }
 
+fn focused_session_terminated(
+    prior: Option<(Uuid, bool)>,
+    focused_id: Uuid,
+    is_live: bool,
+) -> bool {
+    prior == Some((focused_id, true)) && !is_live
+}
+
 #[hook]
 pub(super) fn use_dashboard_focus(
     active_sessions: Vec<SessionInfo>,
@@ -41,6 +49,64 @@ pub(super) fn use_dashboard_focus(
         *last_focused_index.borrow(),
     );
     *last_focused_index.borrow_mut() = focused_index;
+
+    // When the focused session actually terminates, move to the remaining
+    // session the user messaged most recently. Treat either the persisted
+    // Active status or a live websocket as evidence that the session still
+    // exists: this preserves the #1368 stale-poll protection for a newly
+    // launched session whose row briefly disappears while its socket remains
+    // connected.
+    //
+    // Track liveness per focused id so deliberately selecting an already
+    // disconnected session remains possible. We only move focus on a live ->
+    // not-live transition, which is the lifecycle produced by `seppuku`.
+    {
+        let prior_focus_liveness = use_mut_ref(|| None::<(Uuid, bool)>);
+        let focused_id = session_state.focused_id;
+        let connected_sessions = session_state.connected_sessions.clone();
+        let sessions = active_sessions.clone();
+        let hidden_sessions = effective_hidden_sessions.clone();
+        let session_state = session_state.clone();
+
+        use_effect_with(
+            (
+                focused_id,
+                active_session_ids(&sessions),
+                sessions
+                    .iter()
+                    .map(|session| (session.id, session.status.clone()))
+                    .collect::<Vec<_>>(),
+                connected_sessions.clone(),
+                hidden_sessions.clone(),
+            ),
+            move |_| {
+                if let Some(focused_id) = focused_id {
+                    let is_live = connected_sessions.contains(&focused_id)
+                        || sessions.iter().any(|session| {
+                            session.id == focused_id
+                                && session.status == shared::SessionStatus::Active
+                        });
+
+                    let prior = *prior_focus_liveness.borrow();
+                    *prior_focus_liveness.borrow_mut() = Some((focused_id, is_live));
+                    if focused_session_terminated(prior, focused_id, is_live) {
+                        if let Some(next_id) = session_order::termination_focus_fallback(
+                            &sessions,
+                            focused_id,
+                            &hidden_sessions,
+                            &connected_sessions,
+                        ) {
+                            session_state
+                                .dispatch(DashboardSessionAction::FocusAndActivate(next_id));
+                        }
+                    }
+                } else {
+                    *prior_focus_liveness.borrow_mut() = None;
+                }
+                || ()
+            },
+        );
+    }
 
     // On initial load, focus first non-hidden session and activate all non-hidden sessions.
     {
@@ -184,5 +250,34 @@ pub(super) fn use_dashboard_focus(
         interrupt_signal: *interrupt_signal,
         on_jump_to_latest,
         jump_to_latest_signal: *jump_to_latest_signal,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::focused_session_terminated;
+    use uuid::Uuid;
+
+    #[test]
+    fn switches_only_when_the_same_focused_session_transitions_out_of_live() {
+        let focused = Uuid::from_u128(1);
+        let other = Uuid::from_u128(2);
+
+        assert!(focused_session_terminated(
+            Some((focused, true)),
+            focused,
+            false
+        ));
+        assert!(!focused_session_terminated(
+            Some((focused, true)),
+            focused,
+            true
+        ));
+        assert!(!focused_session_terminated(
+            Some((other, false)),
+            focused,
+            false
+        ));
+        assert!(!focused_session_terminated(None, focused, false));
     }
 }

--- a/frontend/src/pages/dashboard/session_order.rs
+++ b/frontend/src/pages/dashboard/session_order.rs
@@ -46,6 +46,41 @@ pub(super) fn history_hydration_cmp(a: &SessionInfo, b: &SessionInfo) -> Orderin
         .then_with(|| a.id.cmp(&b.id))
 }
 
+/// Pick the most recently messaged session to receive focus after the current
+/// session terminates.
+///
+/// Prefer a visible, live session, then any visible session, and finally any
+/// remaining session. This is deliberately independent of rail order (and of
+/// host grouping): "most recently edited" is [`SessionInfo::last_messaged_at`],
+/// not whichever pill happens to render first.
+pub(super) fn termination_focus_fallback(
+    sessions: &[SessionInfo],
+    terminated_id: Uuid,
+    hidden: &HashSet<Uuid>,
+    connected: &HashSet<Uuid>,
+) -> Option<Uuid> {
+    let remaining = || {
+        sessions
+            .iter()
+            .filter(|session| session.id != terminated_id)
+    };
+    let newest = |iter: Box<dyn Iterator<Item = &SessionInfo> + '_>| {
+        iter.min_by(|a, b| history_hydration_cmp(a, b))
+            .map(|session| session.id)
+    };
+
+    newest(Box::new(remaining().filter(|session| {
+        !hidden.contains(&session.id)
+            && (session.status == shared::SessionStatus::Active || connected.contains(&session.id))
+    })))
+    .or_else(|| {
+        newest(Box::new(
+            remaining().filter(|session| !hidden.contains(&session.id)),
+        ))
+    })
+    .or_else(|| newest(Box::new(remaining())))
+}
+
 /// Label shown for the "no hostname" bucket in the grouped rail.
 pub(super) const UNKNOWN_HOST_LABEL: &str = "unknown host";
 
@@ -194,6 +229,52 @@ mod tests {
         assert_eq!(pills[0].id, baseline_id);
         assert_eq!(pills[1].working_directory, "/work/alpha");
         assert_eq!(pills[2].working_directory, "/work/zeta");
+    }
+
+    #[test]
+    fn termination_fallback_uses_message_recency_not_rail_order() {
+        let terminated = session(Uuid::from_u128(1), "/work/a", "host", None);
+        let mut older = session(Uuid::from_u128(2), "/work/z", "host", None);
+        older.last_messaged_at = "2026-08-29T10:00:00Z".to_string();
+        let mut newer = session(Uuid::from_u128(3), "/work/m", "host", None);
+        newer.last_messaged_at = "2026-08-29T11:00:00Z".to_string();
+
+        assert_eq!(
+            termination_focus_fallback(
+                &[terminated.clone(), older, newer.clone()],
+                terminated.id,
+                &HashSet::new(),
+                &HashSet::from([newer.id]),
+            ),
+            Some(newer.id)
+        );
+    }
+
+    #[test]
+    fn termination_fallback_prefers_visible_live_session() {
+        let terminated = session(Uuid::from_u128(1), "/work/a", "host", None);
+        let mut hidden_newest = session(Uuid::from_u128(2), "/work/b", "host", None);
+        hidden_newest.last_messaged_at = "2026-08-29T12:00:00Z".to_string();
+        let mut disconnected = session(Uuid::from_u128(3), "/work/c", "host", None);
+        disconnected.last_messaged_at = "2026-08-29T11:00:00Z".to_string();
+        disconnected.status = SessionStatus::Disconnected;
+        let mut visible_live = session(Uuid::from_u128(4), "/work/d", "host", None);
+        visible_live.last_messaged_at = "2026-08-29T10:00:00Z".to_string();
+
+        assert_eq!(
+            termination_focus_fallback(
+                &[
+                    terminated.clone(),
+                    hidden_newest.clone(),
+                    disconnected,
+                    visible_live.clone(),
+                ],
+                terminated.id,
+                &HashSet::from([hidden_newest.id]),
+                &HashSet::from([visible_live.id]),
+            ),
+            Some(visible_live.id)
+        );
     }
 
     /// The unique-id tie-breaker makes ordering independent of input order:


### PR DESCRIPTION
## Summary
- detect when the focused session transitions from live to terminated
- focus and activate the most recently messaged remaining visible/live session
- preserve the stale-poll protection for newly launched sessions by treating a live socket as authoritative
- keep deliberately selected disconnected transcripts stable

## Verification
- cargo test -p frontend session_order --lib
- cargo test -p frontend page_focus --lib
- cargo test -p frontend page_state --lib
- cargo clippy -p frontend --all-targets -- -D warnings
- cargo fmt --all --check