### PR TITLE
Stop rejecting inline math that starts with a digit

### DIFF
--- a/frontend/src/components/markdown/math.rs
+++ b/frontend/src/components/markdown/math.rs
@@ -71,22 +71,40 @@ pub(super) fn extract_math_placeholders(text: &str) -> (String, Vec<String>) {
                 continue;
             }
         }
-        // Inline math: $...$ on a single line. Skip dollar amounts ("$5",
-        // "$100") by requiring the character after `$` not to be a digit or
-        // whitespace.
+        // Inline math: $...$ on a single line.
+        //
+        // Telling math from money is the whole problem with `$` delimiters, and
+        // the guard is on the CLOSING side. A digit after the opening `$` says
+        // nothing — `$9N = 10N - N$` and `$105 \times 9 = 945$` are math, and
+        // rejecting them (as an earlier "no digit after `$`" rule did) silently
+        // drops most arithmetic anyone writes. What money reliably looks like is
+        // a *second* amount: in "spent $0.03 and $0.05" the candidate closer is
+        // followed by a digit, which is the tell. A lone `$20` never pairs.
+        //
+        // The three conditions, matching markdown-it-texmath:
+        //   1. the opening `$` is not followed by whitespace,
+        //   2. the closing `$` is not preceded by whitespace,
+        //   3. the closing `$` is not followed by a digit.
+        //
+        // Known give-up: "$5 per hour, or $x" pairs as math. That shape is far
+        // rarer than numeric math, which is why the tradeoff runs this way.
         if bytes[i] == b'$' {
             let line_end = text[i + 1..]
                 .find('\n')
                 .map(|n| i + 1 + n)
                 .unwrap_or(bytes.len());
             if let Some(rel) = text[i + 1..line_end].find('$') {
-                let after = bytes.get(i + 1).copied();
+                let after_open = bytes.get(i + 1).copied();
                 let before_close_idx = i + 1 + rel;
                 let before_close = bytes.get(before_close_idx.saturating_sub(1)).copied();
-                let looks_like_money =
-                    matches!(after, Some(c) if c.is_ascii_digit() || c == b' ' || c == b'\t');
-                let trailing_money = matches!(before_close, Some(b' ') | Some(b'\t'));
-                if !looks_like_money && !trailing_money {
+                let after_close = bytes.get(before_close_idx + 1).copied();
+
+                let empty = before_close_idx == i + 1;
+                let opens_on_space = matches!(after_open, Some(b' ') | Some(b'\t') | None);
+                let closes_on_space = matches!(before_close, Some(b' ') | Some(b'\t'));
+                let another_amount_follows = matches!(after_close, Some(c) if c.is_ascii_digit());
+
+                if !empty && !opens_on_space && !closes_on_space && !another_amount_follows {
                     let end = before_close_idx + 1;
                     emit_placeholder(&mut output, &mut math_blocks, &text[i..end]);
                     i = end;
@@ -208,4 +226,107 @@ pub(super) fn restore_math(text: &str, math_blocks: &[String]) -> String {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{extract_math_placeholders, MATH_CLOSE, MATH_OPEN};
+
+    /// The math literals `extract_math_placeholders` pulled out of `text`.
+    fn math_in(text: &str) -> Vec<String> {
+        extract_math_placeholders(text).1
+    }
+
+    fn is_math(text: &str) -> bool {
+        !math_in(text).is_empty()
+    }
+
+    #[test]
+    fn numeric_math_is_not_mistaken_for_money() {
+        // Every one of these rendered as raw source before the closing-side
+        // rule, because each opens on a digit. They came from one real
+        // transcript about digit patterns, where that is the norm, not an edge
+        // case.
+        for source in [
+            r"$111111 \times 7 = 777777$",
+            r"$1\underline{99999}8$",
+            r"$777777\cdot9=6\underline{99999}3$",
+            r"$9N = 10N - N$",
+            r"$105 \times 9 = 945$",
+            r"$89\cdot9 = 801$",
+        ] {
+            assert!(is_math(source), "should typeset: {source}");
+        }
+    }
+
+    #[test]
+    fn letter_led_math_still_works() {
+        for source in [r"$a \cdot 9 = 10a - a$", "$N$", "$b > a$", r"$c \le a+1$"] {
+            assert!(is_math(source), "should typeset: {source}");
+        }
+    }
+
+    #[test]
+    fn money_pairs_are_left_alone() {
+        // A second amount is the tell: the candidate closer is followed by a
+        // digit. This is the case the old opening-side digit check was aiming
+        // at, and it is the one that actually shows up in transcripts.
+        for source in [
+            "spent $0.03 and $0.05 on that turn",
+            "between $5 and $10",
+            "prices: $100, $250, $999",
+            "the run cost $1.20 and the retry cost $0.40",
+        ] {
+            assert!(!is_math(source), "should stay literal: {source}");
+        }
+    }
+
+    #[test]
+    fn a_lone_amount_never_pairs() {
+        for source in ["it cost $20", "$0.03", "paid $5 today"] {
+            assert!(!is_math(source), "should stay literal: {source}");
+        }
+    }
+
+    #[test]
+    fn whitespace_hugging_the_delimiters_is_not_math() {
+        // Opening on a space is how prose like "$ 5" reads, and a closer that
+        // trails a space is the other half of the same shape.
+        assert!(!is_math("$ x + 1$"));
+        assert!(!is_math("$x + 1 $"));
+        assert!(!is_math("$$"), "empty span is not math");
+    }
+
+    #[test]
+    fn math_is_ignored_inside_code() {
+        assert!(!is_math("`$9N = 10N$`"), "inline code is verbatim");
+        assert!(!is_math("```\n$9N = 10N$\n```"), "fenced code is verbatim");
+    }
+
+    #[test]
+    fn a_placeholder_replaces_the_span_in_place() {
+        let (text, blocks) = extract_math_placeholders(r"before $9N = 10N - N$ after");
+        assert_eq!(blocks, vec![r"$9N = 10N - N$".to_string()]);
+        assert_eq!(
+            text,
+            format!("before {MATH_OPEN}MATH0{MATH_CLOSE} after"),
+            "the span should be swapped for its placeholder, surroundings intact"
+        );
+    }
+
+    #[test]
+    fn two_spans_in_one_paragraph_both_typeset() {
+        // The reported symptom: within a single paragraph the digit-led span
+        // stayed raw while the letter-led one rendered.
+        let blocks =
+            math_in(r"windows: $111111 \times 7 = 777777$ — because $a \cdot 9 = 10a - a$.");
+        assert_eq!(blocks.len(), 2, "both spans should typeset, got {blocks:?}");
+    }
+
+    #[test]
+    fn display_and_latex_delimiters_are_unchanged() {
+        assert_eq!(math_in("$$9N = 10N$$"), vec!["$$9N = 10N$$".to_string()]);
+        assert_eq!(math_in(r"\(9N\)"), vec![r"\(9N\)".to_string()]);
+        assert_eq!(math_in(r"\[9N\]"), vec![r"\[9N\]".to_string()]);
+    }
 }


### PR DESCRIPTION
Reported symptom: in a document about digit patterns, most formulas rendered as raw LaTeX while others in the *same paragraph* typeset fine.

## Cause

The inline `$...$` scanner refused to open a math span when the character after the opening `$` was a digit, to avoid eating dollar amounts:

```rust
let looks_like_money = matches!(after, Some(c) if c.is_ascii_digit() || c == b' ' || c == b'\t');
```

Most arithmetic starts with a number, so the rule split the page by first character — ten for ten against the real splitter:

| Stayed raw | starts with | Typeset | starts with |
|---|---|---|---|
| `$111111 \times 7 = 777777$` | `1` | `$a \cdot 9 = 10a - a$` | `a` |
| `$1\underline{99999}8$` | `1` | `$N$` | `N` |
| `$9N = 10N - N$` | `9` | `$b > a$` | `b` |
| `$105 \times 9 = 945$` | `1` | `$c \le a+1$` | `c` |

## Fix

Guard on the **closing** side instead, which is where money is actually distinguishable. A lone `$20` never pairs; what a price list has is a *second* amount, so in "spent $0.03 and $0.05" the candidate closer is followed by a digit. Three conditions, matching markdown-it-texmath:

1. the opening `$` is not followed by whitespace
2. the closing `$` is not preceded by whitespace
3. the closing `$` is not followed by a digit

**Tradeoff:** `"$5 per hour, or $x"` now pairs as math. That shape is much rarer in transcripts than numeric math, which is why it runs this way — noted in the code so the next person does not have to rediscover the reasoning.

## Tests

`math.rs` had none. It has nine now: the spans from the report, the money shapes the old rule existed to protect (`spent $0.03 and $0.05`, `between $5 and $10`, lone amounts), whitespace-hugging delimiters, code-span and fence exclusion, placeholder substitution, and the untouched `$$` / `\(` / `\[` paths. Full frontend suite green (675).