### PR TITLE
Privatize SessionManager registries

### DIFF
--- a/backend/src/background.rs
+++ b/backend/src/background.rs
@@ -759,7 +759,7 @@ pub async fn broadcast_user_spend_updates(app_state: Arc<AppState>) {
     use diesel::prelude::*;
     use shared::{ServerToClient, SessionCost};
 
-    if app_state.session_manager.user_clients.is_empty() {
+    if !app_state.session_manager.has_any_user_clients() {
         return;
     }
 

--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -164,13 +164,8 @@ pub async fn get_stats(
     .map_err(|e| admin_db_query("Failed to query turn-metrics token stats", e))?;
 
     // Get connected client counts from session manager (no DB query needed)
-    let connected_proxy_clients = app_state.session_manager.sessions.len();
-    let connected_web_clients: usize = app_state
-        .session_manager
-        .user_clients
-        .iter()
-        .map(|r| r.value().len())
-        .sum();
+    let connected_proxy_clients = app_state.session_manager.connected_proxy_count();
+    let connected_web_clients = app_state.session_manager.connected_web_client_count();
 
     Ok(Json(AdminStats {
         total_users: user_stats.total,
@@ -377,8 +372,7 @@ pub async fn list_sessions(
         .map(|(session, user_email)| {
             let is_connected = app_state
                 .session_manager
-                .sessions
-                .contains_key(session.id.to_string().as_str());
+                .is_proxy_connected(session.id.to_string().as_str());
 
             AdminSessionInfo {
                 id: session.id,

--- a/backend/src/handlers/agent_comms.rs
+++ b/backend/src/handlers/agent_comms.rs
@@ -114,8 +114,7 @@ pub async fn list_agent_sessions(
         .map(|s| {
             let connected = app_state
                 .session_manager
-                .sessions
-                .contains_key(s.id.to_string().as_str());
+                .is_proxy_connected(s.id.to_string().as_str());
             let busy = connected
                 && latest_signals
                     .get(&s.id)

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -46,14 +46,10 @@ pub async fn launch_session(
     Json(req): Json<LaunchRequest>,
 ) -> Result<Json<LaunchResponse>, AppError> {
     let launcher_id = resolve_launch_target(&app_state.session_manager, req.launcher_id, user_id)?;
-    let (hostname, version) = {
-        let launcher = app_state
-            .session_manager
-            .launchers
-            .get(&launcher_id)
-            .ok_or(AppError::NotFound("Launcher not found"))?;
-        (launcher.hostname.clone(), launcher.version.clone())
-    };
+    let (hostname, version) = app_state
+        .session_manager
+        .launcher_host_version(launcher_id)
+        .ok_or(AppError::NotFound("Launcher not found"))?;
     if req.create_worktree
         && !app_state
             .session_manager
@@ -317,14 +313,10 @@ pub async fn fork_session(
         claude_args = apply_model_override(claude_args, agent_type, model);
     }
 
-    let (hostname, version) = {
-        let launcher = app_state
-            .session_manager
-            .launchers
-            .get(&launcher_id)
-            .ok_or(AppError::BadRequest("Source launcher is offline"))?;
-        (launcher.hostname.clone(), launcher.version.clone())
-    };
+    let (hostname, version) = app_state
+        .session_manager
+        .launcher_host_version(launcher_id)
+        .ok_or(AppError::BadRequest("Source launcher is offline"))?;
     // Mint before persisting the desired row so an auth failure cannot leave
     // behind an orphaned, never-launchable fork.
     let auth_token = mint_launch_token(&app_state, user_id)?;
@@ -436,14 +428,13 @@ fn resolve_launch_target(
     user_id: Uuid,
 ) -> Result<Uuid, AppError> {
     if let Some(launcher_id) = requested_launcher_id {
-        let launcher = session_manager
-            .launchers
-            .get(&launcher_id)
+        let owner = session_manager
+            .launcher_owner(launcher_id)
             .ok_or(AppError::NotFound("Launcher not found"))?;
-        if launcher.user_id != user_id {
+        if owner != user_id {
             warn!(
                 "User {} attempted to launch on launcher {} owned by {}",
-                user_id, launcher_id, launcher.user_id
+                user_id, launcher_id, owner
             );
             return Err(AppError::Forbidden);
         }
@@ -470,15 +461,13 @@ pub async fn list_directories(
     Query(query): Query<DirectoryQuery>,
 ) -> Result<Json<DirectoryListingResponse>, AppError> {
     // Verify the launcher belongs to this user
-    let launcher = app_state
+    let owner = app_state
         .session_manager
-        .launchers
-        .get(&launcher_id)
+        .launcher_owner(launcher_id)
         .ok_or(AppError::NotFound("Launcher not found"))?;
-    if launcher.user_id != user_id {
+    if owner != user_id {
         return Err(AppError::Forbidden);
     }
-    drop(launcher);
 
     let request_id = Uuid::new_v4();
     let rx = app_state.session_manager.register_dir_request(request_id);
@@ -558,12 +547,11 @@ pub async fn update_launcher(
     Path(launcher_id): Path<Uuid>,
 ) -> Result<EmptyResponse, AppError> {
     {
-        let launcher = app_state
+        let owner = app_state
             .session_manager
-            .launchers
-            .get(&launcher_id)
+            .launcher_owner(launcher_id)
             .ok_or(AppError::NotFound("Launcher not found"))?;
-        if launcher.user_id != user_id {
+        if owner != user_id {
             return Err(AppError::Forbidden);
         }
     }
@@ -593,12 +581,11 @@ pub async fn restart_launcher(
     Path(launcher_id): Path<Uuid>,
 ) -> Result<EmptyResponse, AppError> {
     {
-        let launcher = app_state
+        let owner = app_state
             .session_manager
-            .launchers
-            .get(&launcher_id)
+            .launcher_owner(launcher_id)
             .ok_or(AppError::NotFound("Launcher not found"))?;
-        if launcher.user_id != user_id {
+        if owner != user_id {
             return Err(AppError::Forbidden);
         }
     }
@@ -638,12 +625,11 @@ pub async fn probe_agents(
     Path(launcher_id): Path<Uuid>,
 ) -> Result<Json<ProbeAgentsResponse>, AppError> {
     {
-        let launcher = app_state
+        let owner = app_state
             .session_manager
-            .launchers
-            .get(&launcher_id)
+            .launcher_owner(launcher_id)
             .ok_or(AppError::NotFound("Launcher not found"))?;
-        if launcher.user_id != user_id {
+        if owner != user_id {
             return Err(AppError::Forbidden);
         }
     }
@@ -688,12 +674,11 @@ fn require_launcher_owner(
     launcher_id: Uuid,
     user_id: Uuid,
 ) -> Result<(), AppError> {
-    let launcher = app_state
+    let owner = app_state
         .session_manager
-        .launchers
-        .get(&launcher_id)
+        .launcher_owner(launcher_id)
         .ok_or(AppError::NotFound("Launcher not found"))?;
-    if launcher.user_id != user_id {
+    if owner != user_id {
         return Err(AppError::Forbidden);
     }
     Ok(())

--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -382,9 +382,8 @@ fn resolve_resume_launcher(app_state: &AppState, session: &Session) -> Option<Uu
     if let Some(launcher_id) = session.launcher_id {
         if app_state
             .session_manager
-            .launchers
-            .get(&launcher_id)
-            .is_some_and(|l| l.user_id == session.user_id)
+            .launcher_owner(launcher_id)
+            .is_some_and(|owner| owner == session.user_id)
         {
             return Some(launcher_id);
         }
@@ -392,12 +391,7 @@ fn resolve_resume_launcher(app_state: &AppState, session: &Session) -> Option<Uu
 
     app_state
         .session_manager
-        .launchers
-        .iter()
-        .find(|entry| {
-            entry.value().user_id == session.user_id && entry.value().hostname == session.hostname
-        })
-        .map(|entry| *entry.key())
+        .find_launcher_for_user_host(session.user_id, &session.hostname)
 }
 
 // ============================================================================

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -291,12 +291,7 @@ pub async fn handle_launcher_socket(socket: WebSocket, app_state: Arc<AppState>)
 
     // Reject if user already has too many launchers
     const MAX_LAUNCHERS_PER_USER: usize = 10;
-    let user_launcher_count = app_state
-        .session_manager
-        .launchers
-        .iter()
-        .filter(|entry| entry.value().user_id == user_id)
-        .count();
+    let user_launcher_count = app_state.session_manager.launcher_count_for_user(user_id);
 
     if user_launcher_count >= MAX_LAUNCHERS_PER_USER {
         error!(
@@ -627,9 +622,9 @@ fn handle_launcher_message(
         LauncherToServer::LauncherHeartbeat {
             running_sessions, ..
         } => {
-            if let Some(mut launcher) = app_state.session_manager.launchers.get_mut(&launcher_id) {
-                launcher.running_sessions = running_sessions;
-            }
+            app_state
+                .session_manager
+                .update_launcher_running_sessions(launcher_id, running_sessions);
             // Echo the heartbeat so a launcher that supports it can detect a
             // half-open control socket and reconnect (#1366). Gated on the
             // capability so older launchers never receive an undecodable frame.
@@ -1010,10 +1005,7 @@ fn reconcile_desired_sessions(app_state: &AppState, launcher_id: Uuid, user_id: 
 
     let running_sessions = app_state
         .session_manager
-        .launchers
-        .get(&launcher_id)
-        .map(|launcher| launcher.running_sessions.clone())
-        .unwrap_or_default();
+        .launcher_running_sessions(launcher_id);
 
     let Ok(mut conn) = app_state.db_pool.get() else {
         warn!("Failed to get DB connection for desired-session reconciliation");

--- a/backend/src/handlers/websocket/session_manager/client_fanout.rs
+++ b/backend/src/handlers/websocket/session_manager/client_fanout.rs
@@ -29,6 +29,25 @@ fn fanout_to_clients(clients: &mut Vec<WebClientSender>, msg: ServerToClient) {
 }
 
 impl SessionManager {
+    /// Number of live proxy connections. Registry representation stays private
+    /// so callers cannot bypass generation-guarded lifecycle operations.
+    pub fn connected_proxy_count(&self) -> usize {
+        self.sessions.len()
+    }
+
+    /// Total number of live user-level web client connections.
+    pub fn connected_web_client_count(&self) -> usize {
+        self.user_clients
+            .iter()
+            .map(|entry| entry.value().len())
+            .sum()
+    }
+
+    /// Whether any user currently has a live web client connection.
+    pub fn has_any_user_clients(&self) -> bool {
+        !self.user_clients.is_empty()
+    }
+
     pub fn add_web_client(&self, session_key: SessionId, sender: WebClientSender) {
         info!("Adding web client for session: {}", session_key);
         self.web_clients

--- a/backend/src/handlers/websocket/session_manager/launcher_registry.rs
+++ b/backend/src/handlers/websocket/session_manager/launcher_registry.rs
@@ -33,6 +33,55 @@ pub struct LauncherConnection {
 }
 
 impl SessionManager {
+    /// Owner of a connected launcher, if it is still registered.
+    pub fn launcher_owner(&self, launcher_id: Uuid) -> Option<Uuid> {
+        self.launchers
+            .get(&launcher_id)
+            .map(|launcher| launcher.user_id)
+    }
+
+    /// Host identity used when persisting a desired session launch.
+    pub fn launcher_host_version(&self, launcher_id: Uuid) -> Option<(String, String)> {
+        self.launchers
+            .get(&launcher_id)
+            .map(|launcher| (launcher.hostname.clone(), launcher.version.clone()))
+    }
+
+    pub fn launcher_count_for_user(&self, user_id: Uuid) -> usize {
+        self.launchers
+            .iter()
+            .filter(|entry| entry.value().user_id == user_id)
+            .count()
+    }
+
+    pub fn launcher_running_sessions(&self, launcher_id: Uuid) -> Vec<Uuid> {
+        self.launchers
+            .get(&launcher_id)
+            .map(|launcher| launcher.running_sessions.clone())
+            .unwrap_or_default()
+    }
+
+    pub fn find_launcher_for_user_host(&self, user_id: Uuid, hostname: &str) -> Option<Uuid> {
+        self.launchers
+            .iter()
+            .find(|entry| entry.value().user_id == user_id && entry.value().hostname == hostname)
+            .map(|entry| *entry.key())
+    }
+
+    /// Replace the launcher's heartbeat-owned running-session snapshot.
+    /// Returns `false` when the launcher disconnected before the update.
+    pub fn update_launcher_running_sessions(
+        &self,
+        launcher_id: Uuid,
+        running_sessions: Vec<Uuid>,
+    ) -> bool {
+        let Some(mut launcher) = self.launchers.get_mut(&launcher_id) else {
+            return false;
+        };
+        launcher.running_sessions = running_sessions;
+        true
+    }
+
     /// Atomically register a launcher, rejecting a duplicate `(user_id, hostname)`
     /// pair in the same operation.
     ///

--- a/backend/src/handlers/websocket/session_manager/mod.rs
+++ b/backend/src/handlers/websocket/session_manager/mod.rs
@@ -196,13 +196,13 @@ pub struct ForwardHealth {
 
 #[derive(Clone)]
 pub struct SessionManager {
-    pub sessions: Arc<DashMap<SessionId, ProxyConnection>>,
-    pub web_clients: Arc<DashMap<SessionId, Vec<WebClientSender>>>,
-    pub user_clients: Arc<DashMap<Uuid, Vec<WebClientSender>>>,
+    sessions: Arc<DashMap<SessionId, ProxyConnection>>,
+    web_clients: Arc<DashMap<SessionId, Vec<WebClientSender>>>,
+    user_clients: Arc<DashMap<Uuid, Vec<WebClientSender>>>,
     last_ack_seq: Arc<DashMap<Uuid, u64>>,
     pending_messages: Arc<DashMap<SessionId, VecDeque<PendingMessage>>>,
     pending_truncations: Arc<DashSet<Uuid>>,
-    pub launchers: Arc<DashMap<Uuid, LauncherConnection>>,
+    launchers: Arc<DashMap<Uuid, LauncherConnection>>,
     /// Dedup index: `(user_id, hostname)` → `launcher_id`. Used to atomically
     /// reject a second launcher connection from the same host for the same
     /// user. Entries here are kept in lockstep with `launchers`: inserted by

--- a/backend/src/handlers/websocket/session_manager/proxy_lifecycle.rs
+++ b/backend/src/handlers/websocket/session_manager/proxy_lifecycle.rs
@@ -11,6 +11,11 @@ use uuid::Uuid;
 use super::{ProxyConnection, ProxySender, SessionId, SessionManager};
 
 impl SessionManager {
+    /// Whether a proxy is currently registered for `session_key`.
+    pub fn is_proxy_connected(&self, session_key: &str) -> bool {
+        self.sessions.contains_key(session_key)
+    }
+
     /// Register a proxy connection for a session. Returns a generation number
     /// that must be passed to `unregister_session` to prevent stale cleanup
     /// from removing a newer connection. `cancel` is the socket task's


### PR DESCRIPTION
## Summary
- make proxy, web-client, user-client, and launcher registries private
- replace external map access with narrow lifecycle/query methods
- keep launcher heartbeat mutation behind the registry boundary

## Context
Continues #1165 item 4. Earlier slices encapsulated correlations and per-session tracking, but four core registries remained publicly mutable.

## Verification
- cargo check -p backend
- cargo test -p backend session_manager --lib (53 passed)
- cargo fmt --all --check
- git diff --check