### PR TITLE
Update codex-codes to 0.151.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,9 +1254,9 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.150.1"
+version = "0.151.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "766bb584b37591c58a19332932f99ac2526680dc62dad40899b272fa26d9cb24"
+checksum = "7fe5ff0fc50186a8e05735c6922793f2e38e62a073dd1857073e225ee45c0495"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ claude-codes = { version = "2.1.234", default-features = false, features = ["typ
 
 # Muse CLI integration
 muse-codes = { version = "0.2.1", default-features = false }
-codex-codes = { version = "0.150.1", default-features = false, features = ["types"] }
+codex-codes = { version = "0.151.0", default-features = false, features = ["types"] }
 
 # Web Push (VAPID + RFC8291 encryption). `default-features = false` drops the
 # bundled HTTP clients (isahc/libcurl and hyper) — we build the message here and


### PR DESCRIPTION
Updates the types-only codex-codes dependency from 0.150.1 to 0.151.0. This incorporates the 0.150.2 wire-surface additions/fixes and the 0.151.0 Codex CLI compatibility rebaseline.\n\nVerified locally:\n- cargo check -p shared -p codex-session-lib -p frontend -p backend\n- cargo test -p shared -p codex-session-lib --lib\n- cargo fmt --all --check