### PR TITLE
Send composer secrets as private temp files

### DIFF
--- a/backend/src/handlers/websocket/uploads.rs
+++ b/backend/src/handlers/websocket/uploads.rs
@@ -39,6 +39,7 @@ fn send_upload_failure(tx: &super::WebClientSender, upload_id: String, error: &s
             upload_id,
             success: false,
             error: Some(error.to_string()),
+            path: None,
         },
     ));
 }
@@ -55,10 +56,16 @@ pub(super) fn handle_file_upload_start(
     total_chunks: u32,
     total_size: u64,
     max_image_mb: u32,
+    disposition: shared::FileUploadDisposition,
 ) {
     // Server-side hard cap on total decoded bytes, derived from
     // `PORTAL_MAX_IMAGE_MB`. Saturating to avoid overflow on absurd configs.
-    let effective_max_total_bytes = (max_image_mb as u64).saturating_mul(1024 * 1024);
+    let effective_max_total_bytes = match disposition {
+        shared::FileUploadDisposition::Workspace => {
+            (max_image_mb as u64).saturating_mul(1024 * 1024)
+        }
+        shared::FileUploadDisposition::SecretDrop => shared::protocol::MAX_SECRET_DROP_BYTES,
+    };
 
     // Size is checked BEFORE the chunk-count sanity guard, and the order is the
     // whole point. `total_chunks` is derived from the file size by the sender
@@ -76,7 +83,7 @@ pub(super) fn handle_file_upload_start(
         send_upload_failure(
             tx,
             upload_id,
-            &format!("file is too large (limit {max_image_mb} MB)"),
+            &format!("file is too large (limit {effective_max_total_bytes} bytes)"),
         );
         return;
     }
@@ -103,13 +110,18 @@ pub(super) fn handle_file_upload_start(
         send_upload_failure(tx, upload_id, "session not registered");
         return;
     };
-    let msg = ServerToProxy::FileUploadStart(shared::FileUploadStartFields {
+    let fields = shared::FileUploadStartFields {
         upload_id: upload_id.clone(),
         filename: safe_filename,
         content_type,
         total_chunks,
         total_size,
-    });
+        disposition,
+    };
+    let msg = match disposition {
+        shared::FileUploadDisposition::Workspace => ServerToProxy::FileUploadStart(fields),
+        shared::FileUploadDisposition::SecretDrop => ServerToProxy::SecretDropStart(fields),
+    };
     if !session_manager.send_to_connected_session(key, msg) {
         warn!("Session not connected for file upload start");
         send_upload_failure(tx, upload_id, "agent is offline");

--- a/backend/src/handlers/websocket/web_client_socket.rs
+++ b/backend/src/handlers/websocket/web_client_socket.rs
@@ -199,6 +199,7 @@ fn handle_web_client_message(
             content_type,
             total_chunks,
             total_size,
+            disposition,
         }) => {
             // File uploads end up as `ClaudeInput` on the proxy side — they're
             // mutations too, gate them on editor/owner role.
@@ -222,6 +223,7 @@ fn handle_web_client_message(
                 total_chunks,
                 total_size,
                 app_state.max_image_mb,
+                disposition,
             );
             false
         }

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -1169,6 +1169,7 @@ async fn send_upload_result(
     upload_id: String,
     success: bool,
     error: Option<String>,
+    path: Option<String>,
 ) {
     let mut ws = state.ws_write.lock().await;
     if let Err(e) = ws
@@ -1177,6 +1178,7 @@ async fn send_upload_result(
                 upload_id,
                 success,
                 error,
+                path,
             },
         ))
         .await
@@ -1197,7 +1199,7 @@ async fn fail_upload(state: &mut ConnectionState, upload_id: String, reason: Str
         &upload_id[..8.min(upload_id.len())],
         reason
     );
-    send_upload_result(state, upload_id, false, Some(reason)).await;
+    send_upload_result(state, upload_id, false, Some(reason), None).await;
 }
 
 async fn handle_file_upload(upload_event: FileUploadEvent, state: &mut ConnectionState) {
@@ -1207,6 +1209,7 @@ async fn handle_file_upload(upload_event: FileUploadEvent, state: &mut Connectio
             filename,
             total_chunks,
             total_size,
+            disposition,
         } => {
             // Sanitize filename
             let safe_name: String = filename
@@ -1237,13 +1240,34 @@ async fn handle_file_upload(upload_event: FileUploadEvent, state: &mut Connectio
 
             // Write to a hidden temp path; renamed to the real name only on
             // completion so the agent can never read a truncated file.
-            let temp_name = format!(
-                ".{}.{}.upload",
-                safe_name,
-                &upload_id[..8.min(upload_id.len())]
-            );
-            let temp_path = std::path::Path::new(&state.working_directory).join(&temp_name);
-            match tokio::fs::File::create(&temp_path).await {
+            let id = uuid::Uuid::new_v4();
+            let (temp_path, final_path) = match disposition {
+                shared::FileUploadDisposition::Workspace => {
+                    let final_path =
+                        std::path::Path::new(&state.working_directory).join(&safe_name);
+                    let temp_name = format!(".{safe_name}.{id}.upload");
+                    (
+                        std::path::Path::new(&state.working_directory).join(temp_name),
+                        final_path,
+                    )
+                }
+                shared::FileUploadDisposition::SecretDrop => {
+                    let root = std::env::var_os("XDG_RUNTIME_DIR")
+                        .map(std::path::PathBuf::from)
+                        .unwrap_or_else(std::env::temp_dir);
+                    (
+                        root.join(format!(".portal-drop-{id}.upload")),
+                        root.join(format!("portal-drop-{id}")),
+                    )
+                }
+            };
+            let mut options = tokio::fs::OpenOptions::new();
+            options.write(true).create_new(true);
+            #[cfg(unix)]
+            {
+                options.mode(0o600);
+            }
+            match options.open(&temp_path).await {
                 Ok(fh) => {
                     state.active_uploads.insert(
                         upload_id,
@@ -1257,6 +1281,8 @@ async fn handle_file_upload(upload_event: FileUploadEvent, state: &mut Connectio
                             start_time: Instant::now(),
                             last_log_percent: 0,
                             temp_path,
+                            final_path,
+                            disposition,
                         },
                     );
                 }
@@ -1347,7 +1373,7 @@ async fn handle_file_upload(upload_event: FileUploadEvent, state: &mut Connectio
 
                 let filename = recv_state.filename.clone();
                 let received_bytes = recv_state.received_bytes;
-                let final_path = std::path::Path::new(&state.working_directory).join(&filename);
+                let final_path = recv_state.final_path.clone();
                 let temp_path = recv_state.temp_path.clone();
                 if let Err(e) = tokio::fs::rename(&temp_path, &final_path).await {
                     let reason = format!("rename to {} failed: {e}", final_path.display());
@@ -1359,8 +1385,17 @@ async fn handle_file_upload(upload_event: FileUploadEvent, state: &mut Connectio
                     "[upload {}] Complete: {} ({} bytes in {:.1}s, avg {:.1} KB/s)",
                     upload_id_short, filename, received_bytes, elapsed, rate_kb
                 );
+                let is_secret_drop =
+                    recv_state.disposition == shared::FileUploadDisposition::SecretDrop;
+                let secret_path = is_secret_drop.then(|| final_path.display().to_string());
                 state.active_uploads.remove(&upload_id);
-                send_upload_result(state, upload_id, true, None).await;
+                send_upload_result(state, upload_id, true, None, secret_path).await;
+                if is_secret_drop {
+                    tokio::spawn(async move {
+                        tokio::time::sleep(std::time::Duration::from_secs(15 * 60)).await;
+                        let _ = tokio::fs::remove_file(final_path).await;
+                    });
+                }
             }
         }
     }

--- a/claude-session-lib/src/proxy_session/ws_reader.rs
+++ b/claude-session-lib/src/proxy_session/ws_reader.rs
@@ -14,6 +14,7 @@ pub enum FileUploadEvent {
         filename: String,
         total_chunks: u32,
         total_size: u64,
+        disposition: shared::FileUploadDisposition,
     },
     /// A chunk of file data (base64-encoded)
     Chunk { upload_id: String, data: String },
@@ -36,6 +37,8 @@ pub(crate) struct FileReceiveState {
     /// Bytes are written here and renamed to `filename` only on completion,
     /// so a consumer (the agent) can never read a truncated file (#939).
     pub(crate) temp_path: std::path::PathBuf,
+    pub(crate) final_path: std::path::PathBuf,
+    pub(crate) disposition: shared::FileUploadDisposition,
 }
 
 /// A portal input classified by send mode: a plain user input or a
@@ -313,6 +316,7 @@ async fn handle_ws_message(
             content_type: _,
             total_chunks,
             total_size,
+            disposition,
         }) => {
             info!(
                 "[upload {}] Starting: {} ({} bytes, {} chunks)",
@@ -327,10 +331,39 @@ async fn handle_ws_message(
                     filename,
                     total_chunks,
                     total_size,
+                    disposition,
                 })
                 .is_err()
             {
                 error!("Failed to send file upload start to main loop");
+                return WsMessageResult::Disconnect;
+            }
+        }
+        ServerToProxy::SecretDropStart(shared::FileUploadStartFields {
+            upload_id,
+            filename,
+            content_type: _,
+            total_chunks,
+            total_size,
+            disposition: _,
+        }) => {
+            info!(
+                "[upload {}] Starting private drop ({} bytes, {} chunks)",
+                &upload_id[..8.min(upload_id.len())],
+                total_size,
+                total_chunks
+            );
+            if file_upload_tx
+                .send(FileUploadEvent::Start {
+                    upload_id,
+                    filename,
+                    total_chunks,
+                    total_size,
+                    disposition: shared::FileUploadDisposition::SecretDrop,
+                })
+                .is_err()
+            {
+                error!("Failed to send secret drop start to main loop");
                 return WsMessageResult::Disconnect;
             }
         }

--- a/frontend/src/components/message_renderer/renderers/portal.rs
+++ b/frontend/src/components/message_renderer/renderers/portal.rs
@@ -178,6 +178,18 @@ fn render_portal_content(
         shared::PortalContent::AgentMessage { text, .. } => {
             render_markdown_for_session(text, session_id)
         }
+        shared::PortalContent::SecretDrop { path, file_size } => {
+            let name = path.rsplit('/').next().unwrap_or("secret file");
+            html! {
+                <div class="portal-secret-drop">
+                    <span aria-hidden="true">{ "🔒" }</span>
+                    <span>{ name }</span>
+                    <span class="portal-secret-drop-size">
+                        { format!("{} bytes · contents not stored in chat", file_size) }
+                    </span>
+                </div>
+            }
+        }
     }
 }
 

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -151,6 +151,10 @@ pub enum SessionViewMsg {
         content: String,
         upload_ids: Vec<String>,
     },
+    SecretDrop {
+        upload_id: String,
+        file_size: u64,
+    },
     /// The upload-commit wait expired (old proxy or very slow link):
     /// dispatch the held prompt anyway — pre-transactional behavior.
     UploadCommitTimeout,
@@ -192,6 +196,12 @@ struct PendingUploadPrompt {
     _timeout: Timeout,
 }
 
+struct PendingSecretDrop {
+    upload_id: String,
+    file_size: u64,
+    _timeout: Timeout,
+}
+
 pub struct SessionView {
     messages: Vec<RenderedMessage>,
     ws_connected: bool,
@@ -201,10 +211,11 @@ pub struct SessionView {
     outbox: Outbox,
     /// See [`PendingUploadPrompt`].
     pending_upload_prompt: Option<PendingUploadPrompt>,
+    pending_secret_drop: Option<PendingSecretDrop>,
     /// Upload outcomes that arrived before the prompt handoff (a small
     /// file can commit while later files are still streaming). Bounded;
     /// consumed by `handle_upload_prompt`.
-    early_upload_results: std::collections::HashMap<String, Result<(), String>>,
+    early_upload_results: std::collections::HashMap<String, shared::FileUploadResultFields>,
     messages_ref: NodeRef,
     should_autoscroll: bool,
     #[allow(dead_code)]
@@ -328,6 +339,7 @@ impl Component for SessionView {
             ws_sender: None,
             outbox: Outbox::default(),
             pending_upload_prompt: None,
+            pending_secret_drop: None,
             early_upload_results: HashMap::new(),
             messages_ref: NodeRef::default(),
             should_autoscroll: true,
@@ -515,7 +527,15 @@ impl Component for SessionView {
                 content,
                 upload_ids,
             } => self.handle_upload_prompt(ctx, content, upload_ids),
+            SessionViewMsg::SecretDrop {
+                upload_id,
+                file_size,
+            } => self.handle_secret_drop(ctx, upload_id, file_size),
             SessionViewMsg::UploadCommitTimeout => {
+                if self.pending_secret_drop.take().is_some() {
+                    self.push_upload_error("secret upload commit timed out");
+                    return true;
+                }
                 if let Some(pending) = self.pending_upload_prompt.take() {
                     // Old proxy (no upload acks) or a very slow link: fall
                     // back to pre-transactional behavior instead of eating
@@ -927,9 +947,9 @@ impl SessionView {
         let mut remaining: std::collections::HashSet<String> = upload_ids.into_iter().collect();
         let mut early_failure: Option<String> = None;
         remaining.retain(|id| match self.early_upload_results.remove(id) {
-            Some(Ok(())) => false,
-            Some(Err(e)) => {
-                early_failure = Some(e);
+            Some(fields) if fields.success => false,
+            Some(fields) => {
+                early_failure = Some(fields.error.unwrap_or_else(|| "upload failed".to_string()));
                 true
             }
             None => true,
@@ -961,6 +981,35 @@ impl SessionView {
     /// the backend). Resolve the held prompt, or stash the result if the
     /// prompt handoff hasn't happened yet.
     fn handle_upload_result(&mut self, fields: shared::FileUploadResultFields) -> bool {
+        if self
+            .pending_secret_drop
+            .as_ref()
+            .is_some_and(|pending| pending.upload_id == fields.upload_id)
+        {
+            let Some(pending) = self.pending_secret_drop.take() else {
+                return false;
+            };
+            if fields.success {
+                if let Some(path) = fields.path {
+                    let message = shared::PortalMessage::with_content(vec![
+                        shared::PortalContent::SecretDrop {
+                            path,
+                            file_size: pending.file_size,
+                        },
+                    ]);
+                    self.dispatch_agent_input(message.to_json(), None);
+                } else {
+                    self.push_upload_error("secret-drop result did not include a path");
+                }
+            } else {
+                self.push_upload_error(
+                    &fields
+                        .error
+                        .unwrap_or_else(|| "secret upload failed".to_string()),
+                );
+            }
+            return true;
+        }
         if let Some(ref mut pending) = self.pending_upload_prompt {
             if pending.remaining.contains(&fields.upload_id) {
                 if fields.success {
@@ -983,12 +1032,29 @@ impl SessionView {
         }
         // Pre-handoff (or unrelated) result: stash for handle_upload_prompt.
         if self.early_upload_results.len() < 64 {
-            let outcome = if fields.success {
-                Ok(())
-            } else {
-                Err(fields.error.unwrap_or_else(|| "upload failed".to_string()))
-            };
-            self.early_upload_results.insert(fields.upload_id, outcome);
+            self.early_upload_results
+                .insert(fields.upload_id.clone(), fields);
+        }
+        false
+    }
+
+    fn handle_secret_drop(
+        &mut self,
+        ctx: &Context<Self>,
+        upload_id: String,
+        file_size: u64,
+    ) -> bool {
+        let link = ctx.link().clone();
+        let timeout = Timeout::new(45_000, move || {
+            link.send_message(SessionViewMsg::UploadCommitTimeout);
+        });
+        self.pending_secret_drop = Some(PendingSecretDrop {
+            upload_id: upload_id.clone(),
+            file_size,
+            _timeout: timeout,
+        });
+        if let Some(fields) = self.early_upload_results.remove(&upload_id) {
+            return self.handle_upload_result(fields);
         }
         false
     }
@@ -1291,6 +1357,13 @@ impl SessionView {
                 upload_ids,
             }
         });
+        let on_secret_drop =
+            link.callback(
+                |(upload_id, file_size): (String, u64)| SessionViewMsg::SecretDrop {
+                    upload_id,
+                    file_size,
+                },
+            );
         let on_message_sent = link.callback(|_| SessionViewMsg::MessageSent);
         html! {
             <InputBar
@@ -1302,6 +1375,7 @@ impl SessionView {
                 {on_send_text}
                 {on_send_frame}
                 {on_upload_prompt}
+                {on_secret_drop}
                 {on_message_sent}
             />
         }

--- a/frontend/src/pages/dashboard/session_view/input_bar.rs
+++ b/frontend/src/pages/dashboard/session_view/input_bar.rs
@@ -62,6 +62,9 @@ pub struct InputBarProps {
     /// phase 4) — the agent must never be told about a file that isn't
     /// fully on disk.
     pub on_upload_prompt: Callback<(String, Vec<String>)>,
+    /// Composer contents streamed as an opaque secret drop. The callback only
+    /// carries the upload id and byte count; secret bytes stay on upload frames.
+    pub on_secret_drop: Callback<(String, u64)>,
     /// Fires once per submit (text or upload) so the parent can bump its
     /// per-session "I sent something" bookkeeping.
     pub on_message_sent: Callback<()>,
@@ -115,6 +118,7 @@ pub enum InputBarMsg {
     SendInput,
     /// User picked "Wiggum" from the send-mode dropdown.
     SendWiggum,
+    SendSecretDrop,
     HistoryUp,
     HistoryDown,
     ToggleSendModeDropdown,
@@ -337,6 +341,10 @@ impl Component for InputBar {
                 self.send_mode_dropdown_open = false;
                 self.dispatch_text_send(ctx, SendMode::Wiggum)
             }
+            InputBarMsg::SendSecretDrop => {
+                self.start_secret_drop(ctx);
+                true
+            }
             InputBarMsg::HistoryUp => {
                 let current = self.get_input_text();
                 if let Some(cmd) = self.command_history.navigate_up(&current) {
@@ -502,6 +510,11 @@ impl Component for InputBar {
             if e.ctrl_key() && e.key().to_lowercase() == "m" {
                 e.prevent_default();
                 return InputBarMsg::ToggleVoice;
+            }
+
+            if (e.ctrl_key() || e.meta_key()) && e.shift_key() && e.key() == "Enter" {
+                e.prevent_default();
+                return InputBarMsg::SendSecretDrop;
             }
 
             // Modal editing (opt-in). When vim consumes the key we're done;
@@ -742,6 +755,66 @@ impl InputBar {
     /// that emits `FileUploadStart` / `FileUploadChunk` frames per file
     /// via `on_send_frame` and a final `ClaudeInput` carrying the combined
     /// message text.
+    fn start_secret_drop(&mut self, ctx: &Context<Self>) {
+        self.send_mode_dropdown_open = false;
+        let content = self.get_input_text();
+        if content.is_empty() {
+            return;
+        }
+        let bytes = content.into_bytes();
+        if bytes.len() as u64 > shared::protocol::MAX_SECRET_DROP_BYTES {
+            ctx.link()
+                .send_message(InputBarMsg::FileUploadError(format!(
+                    "Secret file is too large (limit {} KiB)",
+                    shared::protocol::MAX_SECRET_DROP_BYTES / 1024
+                )));
+            return;
+        }
+
+        self.set_input_text("");
+        self.input_text.clear();
+        self.pending_suggestion = None;
+        self.upload_progress = Some(0.0);
+        self.upload_files = vec![("secret file".to_string(), bytes.len() as u64)];
+        ctx.props().on_message_sent.emit(());
+
+        let upload_id = Uuid::new_v4().to_string();
+        let total_size = bytes.len() as u64;
+        let total_chunks = bytes.len().div_ceil(UPLOAD_CHUNK_SIZE).max(1) as u32;
+        ctx.props()
+            .on_send_frame
+            .emit(ClientToServer::FileUploadStart(
+                shared::FileUploadStartFields {
+                    upload_id: upload_id.clone(),
+                    filename: "portal-secret".to_string(),
+                    content_type: "application/octet-stream".to_string(),
+                    total_chunks,
+                    total_size,
+                    disposition: shared::FileUploadDisposition::SecretDrop,
+                },
+            ));
+        for i in 0..total_chunks {
+            let start = i as usize * UPLOAD_CHUNK_SIZE;
+            let end = ((i as usize + 1) * UPLOAD_CHUNK_SIZE).min(bytes.len());
+            let encoded = base64::Engine::encode(
+                &base64::engine::general_purpose::STANDARD,
+                &bytes[start..end],
+            );
+            ctx.props()
+                .on_send_frame
+                .emit(ClientToServer::FileUploadChunk(
+                    shared::FileUploadChunkFields {
+                        upload_id: upload_id.clone(),
+                        chunk_index: i,
+                        data: encoded,
+                    },
+                ));
+        }
+        ctx.props().on_secret_drop.emit((upload_id, total_size));
+        ctx.link()
+            .send_message(InputBarMsg::FileUploaded("secret file".to_string()));
+    }
+
     fn start_upload(&mut self, ctx: &Context<Self>, files: Vec<web_sys::File>) {
         self.send_mode_dropdown_open = false;
         self.drag_hover = false;
@@ -801,6 +874,7 @@ impl InputBar {
                         content_type: ct,
                         total_chunks,
                         total_size: file_size,
+                        disposition: shared::FileUploadDisposition::Workspace,
                     },
                 ));
 
@@ -945,6 +1019,7 @@ impl InputBar {
             InputBarMsg::ToggleSendModeDropdown
         });
         let on_wiggum = link.callback(|_| InputBarMsg::SendWiggum);
+        let on_secret_drop = link.callback(|_| InputBarMsg::SendSecretDrop);
 
         let file_input_ref = self.file_input_ref.clone();
         let on_attach_dropdown = Callback::from(move |_: MouseEvent| {
@@ -1032,6 +1107,14 @@ impl InputBar {
                     >
                         { "Send with attachment(s)" }
                         <span class="option-hint">{ "Upload files + message" }</span>
+                    </button>
+                    <button
+                        type="button"
+                        class="dropdown-option secret-drop"
+                        onclick={on_secret_drop}
+                    >
+                        { "Send as secret file" }
+                        <span class="option-hint">{ "Ctrl+Shift+Enter · not stored in chat" }</span>
                     </button>
                 </div>
             </div>

--- a/shared/src/endpoints/session.rs
+++ b/shared/src/endpoints/session.rs
@@ -289,6 +289,11 @@ pub enum ServerToProxy {
     /// Start a chunked file upload to the proxy's working directory
     FileUploadStart(FileUploadStartFields),
 
+    /// Start a credential-sized upload into a private runtime temp file. A
+    /// distinct wire variant makes pre-feature proxies fail closed instead of
+    /// ignoring a disposition field and writing the secret into the workspace.
+    SecretDropStart(FileUploadStartFields),
+
     /// A single chunk of a file upload (base64-encoded, ~1KB decoded)
     FileUploadChunk(FileUploadChunkFields),
 

--- a/shared/src/endpoints/types.rs
+++ b/shared/src/endpoints/types.rs
@@ -201,6 +201,16 @@ pub struct FileUploadStartFields {
     pub total_chunks: u32,
     #[serde(default)]
     pub total_size: u64,
+    #[serde(default)]
+    pub disposition: FileUploadDisposition,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FileUploadDisposition {
+    #[default]
+    Workspace,
+    SecretDrop,
 }
 
 /// Fields for a single file upload chunk.
@@ -224,6 +234,10 @@ pub struct FileUploadResultFields {
     pub success: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Committed host path. Present only for secret drops; ordinary uploads
+    /// continue to construct their workspace-relative prompt client-side.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
 }
 
 // ---- Port forwarding (docs/PORT_FORWARDING.md) ------------------------------

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -821,21 +821,26 @@ impl PortalMessage {
     /// Text form to send to the agent for portal event envelopes that have an
     /// agent-facing representation.
     pub fn agent_facing_text(&self) -> Option<String> {
-        let [PortalContent::AgentMessage {
-            from_agent_type,
-            from_session_id,
-            text,
-        }] = self.content.as_slice()
-        else {
-            return None;
-        };
-        let reminder = agent_message_reply_reminder(from_session_id);
-        Some(format!(
-            "[message from {from_agent_type} {from_session_id}]\n{text}\n\n\
+        match self.content.as_slice() {
+            [PortalContent::AgentMessage {
+                from_agent_type,
+                from_session_id,
+                text,
+            }] => {
+                let reminder = agent_message_reply_reminder(from_session_id);
+                Some(format!(
+                    "[message from {from_agent_type} {from_session_id}]\n{text}\n\n\
 <system-reminder>\n\
 {reminder}\n\
 </system-reminder>"
-        ))
+                ))
+            }
+            [PortalContent::SecretDrop { path, file_size }] => Some(format!(
+                "[secret file from user: {path}, {file_size} bytes]\n\
+The file contains sensitive material. Use it directly without printing, echoing, or quoting its contents."
+            )),
+            _ => None,
+        }
     }
 
     pub fn to_json(&self) -> serde_json::Value {
@@ -978,6 +983,14 @@ pub enum PortalContent {
         from_session_id: String,
         text: String,
     },
+    /// Content-free transcript record for a composer buffer delivered through
+    /// the secret-drop upload path. Only the committed path and byte count are
+    /// persisted; the file bytes never enter an AgentInput frame.
+    #[serde(rename = "secret_drop")]
+    SecretDrop {
+        path: String,
+        file_size: u64,
+    },
 }
 
 /// A bounded, declarative slider exposed by a portable figure. The host owns
@@ -1075,6 +1088,11 @@ impl std::fmt::Debug for PortalContent {
                 .field("from_agent_type", from_agent_type)
                 .field("from_session_id", from_session_id)
                 .field("text", text)
+                .finish(),
+            Self::SecretDrop { path, file_size } => f
+                .debug_struct("SecretDrop")
+                .field("path", path)
+                .field("file_size", file_size)
                 .finish(),
         }
     }
@@ -1500,6 +1518,21 @@ mod tests {
             "[message from codex 12345678-0000-0000-0000-000000000000]\nhello from another agent"
         ));
         assert!(text.contains("agent-portal message send 12345678 \"your reply\""));
+    }
+
+    #[test]
+    fn secret_drop_agent_text_contains_only_metadata() {
+        let secret = "super-secret-token";
+        let msg = PortalMessage::with_content(vec![PortalContent::SecretDrop {
+            path: "/tmp/portal-drop-123".to_string(),
+            file_size: secret.len() as u64,
+        }]);
+        let serialized = serde_json::to_string(&msg).unwrap();
+        let agent_text = msg.agent_facing_text().unwrap();
+        assert!(!serialized.contains(secret));
+        assert!(!agent_text.contains(secret));
+        assert!(agent_text.contains("/tmp/portal-drop-123"));
+        assert!(agent_text.contains("without printing"));
     }
 
     #[test]

--- a/shared/src/protocol.rs
+++ b/shared/src/protocol.rs
@@ -45,6 +45,10 @@ pub const MAX_UPLOAD_CHUNK_BYTES: usize = 64 * 1024; // 64 KiB
 /// stops obviously-pathological `total_chunks` values from being accepted.
 pub const MAX_UPLOAD_TOTAL_CHUNKS: u32 = 65_536;
 
+/// Secret composer drops are intentionally small: they are for credentials
+/// and environment snippets, not general file transfer.
+pub const MAX_SECRET_DROP_BYTES: u64 = 64 * 1024;
+
 /// Interval (in seconds) between launcher heartbeats on the launcher
 /// WebSocket. The backend has no explicit heartbeat timeout — launcher
 /// liveness is the WebSocket connection itself — but it treats each


### PR DESCRIPTION
Closes #1636.

Adds a **Send as secret file** composer action (`Ctrl+Shift+Enter`) that streams the current buffer through the chunked upload transport without putting its bytes in `AgentInput`, message persistence, replay, broadcast, or archive paths. The proxy writes an atomic, randomly named `0600` runtime-temp file, returns only its path, and deletes it after 15 minutes. The persisted typed transcript event contains only the path and byte count; the agent-facing notice explicitly says not to print or quote the contents.

Security details:
- hard 64 KiB decoded cap in browser and backend
- distinct backend→proxy wire variant so older proxies fail closed
- create-new hidden temp + atomic rename
- secret bytes never formatted into logs or normal input frames
- missing commit/path and timeouts fail without notifying the agent

Verification:
- `cargo check --workspace --all-targets`
- `cargo clippy -p shared -p frontend -p backend -p claude-session-lib --all-targets -- -D warnings`
- `cargo test -p frontend --lib` (666 passed)
- focused shared/backend/session-lib tests
- `cargo fmt --all --check`