### PR TITLE
Keep Computers rows a stable height while probe results percolate in

### DIFF
--- a/frontend/src/pages/settings/agents_panel.rs
+++ b/frontend/src/pages/settings/agents_panel.rs
@@ -108,7 +108,11 @@ fn render_install_cell(
     html! {
         <td class="agents-cell installed">
             <span class="agents-badge installed">{ "installed" }</span>
-            <span class={classes!("agents-login", login_class)}>{ login_text }</span>
+            // The CSS ellipsizes long login labels; the tooltip carries the
+            // full text.
+            <span class={classes!("agents-login", login_class)} title={login_text.clone()}>
+                { login_text }
+            </span>
             { for sign_in_button(&install.login, agent, agent_name, launcher.launcher_id, on_sign_in) }
         </td>
     }

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -1153,6 +1153,16 @@
     font-size: 0.8rem;
 }
 
+/* Reserve the height of the tallest loaded state (badge + login line +
+   sign-in button, plus cell padding under border-box sizing) in EVERY probe
+   state. Probe results percolate in per machine, and without this each
+   arriving result grew its row from a one-line "…" to a three-line stack,
+   reflowing the whole table. td height acts as a minimum, so unexpected
+   content can still grow a cell rather than clip. */
+.agents-cell {
+    height: 5.5rem;
+}
+
 /* Stack the badge/label/button without `display: flex` — flex on a <td>
    takes it out of table layout, so the per-agent cells stop forming columns
    and pile into the first one. */
@@ -1191,8 +1201,16 @@
     background: color-mix(in srgb, var(--error, #f7768e) 18%, transparent);
 }
 
+/* One line, ellipsized (full text in the title tooltip): a long login label
+   ("signed in — user@host (plan) [via]") must not wrap, both because wrapping
+   breaks the reserved-height row stability above and because it widens the
+   auto-layout column when the probe result lands. */
 .agents-login {
     font-size: 0.8rem;
+    max-width: 14rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .agents-login.unknown {


### PR DESCRIPTION
Follow-up to the percolating probes: results now arrive per machine at different times, and each arrival grew its cell from a one-line "…" placeholder to a badge + login + sign-in-button stack — so the table visibly reflowed on every landing.

- `.agents-cell` now reserves the height of the tallest loaded state (5.5 rem under the global border-box sizing), so every probe state — loading, offline, loaded, unknown — occupies the same vertical space and results swap in place. td height acts as a minimum, so oversized content still grows rather than clips.
- Long login labels ("signed in — user@host (plan) [via]") are ellipsized to one line with the full text in a tooltip; previously they could wrap (breaking any fixed row height) and also widened their auto-layout column when the result landed, shifting things horizontally.