### PR TITLE
Give the sign-in modal and admin stat cards a real background

### DIFF
--- a/frontend/styles/admin.css
+++ b/frontend/styles/admin.css
@@ -103,7 +103,9 @@
 }
 
 .admin-stat-card {
-    background: var(--bg-secondary);
+    /* --bg-secondary does not exist (see base.css tokens); the undefined
+       var() rendered the stat cards transparent. */
+    background: var(--bg-darker);
     border: 1px solid var(--border);
     border-radius: 8px;
     padding: 1.25rem;

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -1255,7 +1255,9 @@
     overflow-y: auto;
     border: 1px solid var(--border);
     border-radius: 8px;
-    background: var(--bg-secondary);
+    /* --bg-secondary does not exist in this design system (base.css defines
+       --bg-dark/--bg-darker); an undefined var() left the modal transparent. */
+    background: var(--bg-dark);
     box-shadow: 0 12px 40px rgb(0 0 0 / 50%);
 }
 


### PR DESCRIPTION
The agent sign-in modal rendered see-through: `.agent-login-modal` (and `.admin-stat-card`) set `background: var(--bg-secondary)`, but `--bg-secondary` is not a token this design system defines — base.css has `--bg-dark`/`--bg-darker`. An undefined `var()` makes the declaration invalid, so the elements had no background at all.

The modal now uses `--bg-dark` (solid over the dimmed overlay) and the stat cards `--bg-darker` (subtle contrast against the `--bg-dark` page).