### PR TITLE
Surface rejected sign-in codes with recovery guidance; bump SDK crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,9 +1152,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-codes"
-version = "2.1.234"
+version = "2.1.240"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e3b042ba5df1a6448cd5bdd4c0c12f77b10ef08ea3a63cfe4120056a824fc23"
+checksum = "b2f97c4f32c22bfd00c131c1a7733ea38898b972aacb364bfe06c5328c03b1f7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1254,9 +1254,9 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.151.0"
+version = "0.151.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe5ff0fc50186a8e05735c6922793f2e38e62a073dd1857073e225ee45c0495"
+checksum = "c055e7cb9fac8a4a5372ebf0aeb4baf7949ff0cbffd97c1a6cc435c526ce3778"
 dependencies = [
  "log",
  "serde",
@@ -4528,9 +4528,9 @@ dependencies = [
 
 [[package]]
 name = "muse-codes"
-version = "0.2.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb1d1840d0d6722c6211ef97e6d334f66595388654d5925e91420900b20b5a6"
+checksum = "e105eb7cfadf1140264299fb1d1fc78b5e027ef9c49cd016b7055a7757399050"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,11 +76,11 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Claude Code integration
-claude-codes = { version = "2.1.234", default-features = false, features = ["types"] }
+claude-codes = { version = "2.1.240", default-features = false, features = ["types"] }
 
 # Muse CLI integration
-muse-codes = { version = "0.2.1", default-features = false }
-codex-codes = { version = "0.151.0", default-features = false, features = ["types"] }
+muse-codes = { version = "1.0.2", default-features = false }
+codex-codes = { version = "0.151.2", default-features = false, features = ["types"] }
 
 # Web Push (VAPID + RFC8291 encryption). `default-features = false` drops the
 # bundled HTTP clients (isahc/libcurl and hyper) — we build the message here and

--- a/claude-session-lib/src/login.rs
+++ b/claude-session-lib/src/login.rs
@@ -145,8 +145,22 @@ fn run_flow(
                 message: Some(transcript_tail(&out.transcript)),
             },
             // CodeRejected / LoginTimeout / LoginChildExited all Display as
-            // self-describing text — relay it verbatim (login contract).
-            Err(e) => failed(&e.to_string()),
+            // self-describing text — relay it verbatim (login contract). A
+            // rejected code additionally gets recovery guidance: codes are
+            // single-use, expire within minutes, and are PKCE-bound to the
+            // sign-in window that minted their URL, so the fix is always a
+            // fresh sign-in — never re-pasting the old code.
+            Err(e) => {
+                let mut message = e.to_string();
+                if matches!(e, claude_codes::Error::CodeRejected { .. }) {
+                    message.push_str(
+                        " — the code may have expired, been used already, or come \
+                         from an earlier sign-in window. Start a new sign-in and \
+                         paste the fresh code promptly.",
+                    );
+                }
+                failed(&message)
+            }
         },
         // Disconnected = session dropped (cancel); Timeout = user wandered off.
         // Either way `flow` drops on return → PTY child reaped. Nobody is

--- a/claude-session-lib/src/proxy_session/wiggum.rs
+++ b/claude-session-lib/src/proxy_session/wiggum.rs
@@ -522,6 +522,7 @@ mod tests {
             time_to_request_ms: None,
             num_turns: 1,
             result: Some(result.to_string()),
+            subagent_stats: None,
             session_id: "test-session".to_string(),
             total_cost_usd: 0.0,
             usage: None,


### PR DESCRIPTION
Follow-up to the sign-in failure storm hit: claude CLI ≥ 2.1.25x hard-exits(1) after a rejected OAuth token exchange instead of parking on the retry screen, and the portal relayed the SDK's raw channel-forensics blob (`[channels: screen=no-token …] Login failed: Request failed with status code 400`).

- **claude-codes 2.1.223 → 2.1.240**: upstream now classifies that exit shape as a typed `CodeRejected` carrying the CLI's own reason (reproduced live against claude 2.1.259). The portal matches on the variant and appends recovery guidance — codes are single-use, expire within minutes, and are PKCE-bound to the sign-in window that minted their URL, so the answer is always a fresh sign-in, never re-pasting.
- **muse-codes 0.2.1 → 1.0.2**: MuseModel catalog (context/output-limit accessors), `profile_id` now `Option` on `run.model.configured` — absorbed with no code changes.
- **codex-codes 0.151.0 → 0.151.2**: misalignment-block continuation on TurnError, paginated thread-history RPCs.

Only mechanical fallout across the workspace: the new `ResultMessage.subagent_stats` field in one test initializer. Full workspace tests (32 suites), WASM build, clippy, fmt all green.