### PR TITLE
Update claude-codes to 2.1.259

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1154,9 +1154,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-codes"
-version = "2.1.240"
+version = "2.1.259"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f97c4f32c22bfd00c131c1a7733ea38898b972aacb364bfe06c5328c03b1f7"
+checksum = "0d41ba6c9ba2428767a4a4bb775dd19db7a3a85040ed9a8f201f46a9e658daf3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Claude Code integration
-claude-codes = { version = "2.1.240", default-features = false, features = ["types"] }
+claude-codes = { version = "2.1.259", default-features = false, features = ["types"] }
 
 # Muse CLI integration
 muse-codes = { version = "1.0.2", default-features = false, features = ["types"] }

--- a/claude-session-lib/src/proxy_session/wiggum.rs
+++ b/claude-session-lib/src/proxy_session/wiggum.rs
@@ -544,6 +544,8 @@ mod tests {
             // 2.1.163/2.1.164 additions — also absent here.
             request_sent_wall_ms: None,
             user_message_uuid: None,
+            user_message_uuids: Vec::new(),
+            queued_turn_count: None,
             fast_mode_disabled_reason: None,
         }
     }


### PR DESCRIPTION
## Summary
- update `claude-codes` from 2.1.240 to 2.1.259
- extend the Wiggum result fixture for additive `user_message_uuids` and `queued_turn_count` fields
- retain existing transitive lockfile selections

Upstream changelog review: 2.1.259 models additive Claude CLI 2.1.239–2.1.259 wire drift, including reply UUIDs, queued turn counts, ambient task metadata, resource links, unified rate-limit windows, init metadata, and `AccountOnHold`. No production portal match sites require changes because these fields deserialize compatibly and existing enums are not exhaustively matched.

## Verification
- `cargo check -p claude-session-lib -p session-lib -p frontend -p shared -p claude-portal -p agent-portal`
- `CARGO_PROFILE_TEST_DEBUG=0 cargo test -p claude-session-lib` (96 passed)
- `cargo fmt --check`
- `git diff --check`