### PR TITLE
Update codex-codes to 0.151.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.151.2"
+version = "0.151.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c055e7cb9fac8a4a5372ebf0aeb4baf7949ff0cbffd97c1a6cc435c526ce3778"
+checksum = "00af26f96039902d67ff2c5a3f9f89fb05b28b3e58889d8acec37d4e5ee20ade"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ claude-codes = { version = "2.1.259", default-features = false, features = ["typ
 
 # Muse CLI integration
 muse-codes = { version = "1.0.2", default-features = false, features = ["types"] }
-codex-codes = { version = "0.151.2", default-features = false, features = ["types"] }
+codex-codes = { version = "0.151.3", default-features = false, features = ["types"] }
 
 # Web Push (VAPID + RFC8291 encryption). `default-features = false` drops the
 # bundled HTTP clients (isahc/libcurl and hyper) — we build the message here and


### PR DESCRIPTION
## Summary

- update codex-codes from 0.151.2 to 0.151.3
- pick up new rate-limit capability parameters, thread originator metadata, and optional status fields
- confirm the release API changes do not affect portal call sites

## Verification

- cargo fmt --check
- cargo check -p codex-session-lib
- full frontend build delegated to CI because the local host filesystem filled while compiling the fresh WASM target