### PR TITLE
Fix iPad keyboard dead band after rotation; make tab strips scroll, not overflow

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -101,6 +101,34 @@
     <link data-trunk rel="css" href="styles/schedule-dialog.css" />
     <link data-trunk rel="css" href="styles/session-mobile.css" />
     <link data-trunk rel="css" href="styles/keyboard.css" />
+    <script>
+        // Publish the *visual* viewport height as --app-height. Pure-CSS 100dvh
+        // goes stale on iPadOS when the device rotates while the software
+        // keyboard is involved: the layout keeps the previous orientation's
+        // keyboard inset and a dead band opens above the keyboard.
+        // visualViewport is authoritative across rotations and keyboard
+        // open/close; touch layouts consume the variable (session-mobile.css),
+        // desktop keeps pure-CSS dvh. The delayed re-applies cover iPadOS
+        // settling the viewport a beat after the orientationchange event.
+        (function () {
+            var style = document.documentElement.style;
+            function apply() {
+                var vv = window.visualViewport;
+                var h = vv ? vv.height : window.innerHeight;
+                style.setProperty('--app-height', Math.round(h) + 'px');
+            }
+            if (window.visualViewport) {
+                window.visualViewport.addEventListener('resize', apply);
+                window.visualViewport.addEventListener('scroll', apply);
+            }
+            window.addEventListener('resize', apply);
+            window.addEventListener('orientationchange', function () {
+                setTimeout(apply, 100);
+                setTimeout(apply, 500);
+            });
+            apply();
+        })();
+    </script>
     <link data-trunk rel="css" href="styles/settings.css" />
     <link data-trunk rel="css" href="styles/history.css" />
     <link data-trunk rel="css" href="styles/performance.css" />

--- a/frontend/styles/admin.css
+++ b/frontend/styles/admin.css
@@ -46,17 +46,22 @@
 }
 
 /* Admin Tabs — matches settings tab style */
+/* Scrolls horizontally on narrow viewports instead of shedding tabs off the
+   right edge (same treatment as .settings-tabs). */
 .admin-tabs {
     display: flex;
     gap: 0;
     padding: 0 2rem;
     background: var(--bg-darker);
     border-bottom: 1px solid var(--border);
+    overflow-x: auto;
 }
 
 .admin-tabs .tab-btn {
     background: transparent;
     border: none;
+    white-space: nowrap;
+    flex-shrink: 0;
     color: var(--text-secondary);
     padding: 1rem 1.5rem;
     font-size: 1rem;

--- a/frontend/styles/session-mobile.css
+++ b/frontend/styles/session-mobile.css
@@ -20,6 +20,19 @@
     }
 }
 
+/* --- Touch devices of any width (iPads live above the 768px breakpoint) --
+   100dvh goes stale on iPadOS after an orientation change while the software
+   keyboard is involved: the container keeps the previous orientation's
+   keyboard inset and a dead band opens above the keyboard. --app-height is
+   set from visualViewport (index.html), which tracks rotations and keyboard
+   transitions correctly. Phones (max-width block below) override this with
+   position:fixed + inset:0; desktop pointers keep pure-CSS 100dvh. */
+@media (pointer: coarse) {
+    .focus-flow-container {
+        height: var(--app-height, 100dvh);
+    }
+}
+
 /* --- Tablet + phone (max-width: 768px) ---------------------------------- */
 @media (max-width: 768px) {
     /* Ensure dashboard fills exactly the visual viewport on mobile.

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -26,13 +26,17 @@
 
 /* Header buttons - use shared .header-button class from dashboard.css */
 
-/* Settings Tabs */
+/* Settings Tabs. The strip holds many tabs and must never shed them off the
+   right edge on narrow viewports (the iPad hit this: wider than the phone
+   breakpoint, narrower than the tab row) — it scrolls horizontally instead,
+   with the global thin scrollbar as the affordance. */
 .settings-tabs {
     display: flex;
     gap: 0;
     padding: 0 2rem;
     background: var(--bg-darker);
     border-bottom: 1px solid var(--border);
+    overflow-x: auto;
 }
 
 .tab-button {
@@ -47,6 +51,8 @@
     align-items: center;
     gap: 0.5rem;
     transition: color 0.2s;
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .tab-button:hover {


### PR DESCRIPTION
Both reported iPad bugs share one root: an iPad in portrait (834–1024 px) is wider than the 768 px phone breakpoint, so it silently got the desktop code paths.

**Keyboard dead band after rotation.** The dashboard container was sized with pure-CSS `100dvh`, which iPadOS leaves stale after an orientation change while the software keyboard is involved — the layout keeps the previous orientation's keyboard inset, opening a giant empty band between the app footer and the keyboard. An inline script in `index.html` now publishes `visualViewport.height` as `--app-height` (re-applied on viewport resize/scroll, plus 100 ms/500 ms settle re-applies after `orientationchange`, which iPadOS needs), and coarse-pointer layouts size `.focus-flow-container` from `var(--app-height, 100dvh)`. Phones (≤768 px) keep their existing `position: fixed; inset: 0` override via cascade order; desktop pointers keep pure-CSS dvh untouched.

**Settings/admin tabs flying off the right edge.** `.settings-tabs` only became scrollable under 768 px, so on an iPad the tab row overflowed with no way to reach the shed tabs. The settings and admin tab strips now scroll horizontally at every width — `overflow-x: auto`, `white-space: nowrap`, `flex-shrink: 0` on buttons, with the global thin scrollbar as the affordance. Desktop is unaffected (the row fits, nothing scrolls).
