### PR TITLE
Update agent protocol SDKs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.151.2"
+version = "0.151.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c055e7cb9fac8a4a5372ebf0aeb4baf7949ff0cbffd97c1a6cc435c526ce3778"
+checksum = "0908ef91bd4086cc66a0fbef4835f3ad6ed81ca9c1d443959d8890fcfd364c71"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ claude-codes = { version = "2.1.259", default-features = false, features = ["typ
 
 # Muse CLI integration
 muse-codes = { version = "1.0.2", default-features = false, features = ["types"] }
-codex-codes = { version = "0.151.2", default-features = false, features = ["types"] }
+codex-codes = { version = "0.151.4", default-features = false, features = ["types"] }
 
 # Web Push (VAPID + RFC8291 encryption). `default-features = false` drops the
 # bundled HTTP clients (isahc/libcurl and hyper) — we build the message here and


### PR DESCRIPTION
## Summary
- update codex-codes from 0.151.2 to 0.151.4
- confirm claude-codes 2.1.259 and muse-codes 1.0.2 are already the newest published versions
- pick up typed rate-limit/thread metadata and the latest Codex model catalog

## Compatibility
Portal does not call the account_rate_limits_read method whose signature changed in 0.151.3. The other changed path type remains wire-compatible as a transparent string.

## Verification
- cargo fmt --all --check
- cargo test -p codex-session-lib -p shared -p frontend
- cargo clippy -p codex-session-lib -p shared -p frontend --all-targets -- -D warnings