### PR TITLE
Screen muse's reminder auto-approval bookkeeping from the transcript

### DIFF
--- a/frontend/src/components/muse_renderer.rs
+++ b/frontend/src/components/muse_renderer.rs
@@ -277,22 +277,31 @@ fn is_reminder_task(node: &TaskNode) -> bool {
 /// ("latest running task") lands tool outcomes on a running scaffolding task
 /// in every captured turn, so blindly hiding all reminders would silently drop
 /// the tool results Matt most wants to see. Rendering any reminder node that
-/// holds a tool result, streamed output, or a side-effect keeps that content
-/// visible; the attribution itself is corrected upstream in the reducer.
+/// holds a tool result, streamed output, or a *noteworthy* side-effect keeps
+/// that content visible; a routine grant (the 1.0.x `…auto_approval`
+/// bookkeeping) is not content — a reminder card carrying only that would
+/// render as a bare "reminder.child_run — policy: …" line.
 fn is_hidden_scaffolding(node: &TaskNode) -> bool {
     is_reminder_task(node)
         && node.tool_results.is_empty()
         && node.output.is_empty()
-        && node.side_effect.is_none()
+        && !node
+            .side_effect
+            .as_ref()
+            .is_some_and(|(_, decision)| side_effect_is_noteworthy(decision))
 }
 
 /// Whether a side-effect policy decision deserves a line on the task card.
-/// Muse's routine decisions (`allow:policy`, `not_applicable`) are stamped on
+/// Muse's routine decisions (`allow:policy`, `not_applicable`, and the 1.0.x
+/// grant vocabulary ending `auto_approval` — e.g.
+/// `reminder_child:read_only:subagent_tool_auto_approval`) are stamped on
 /// effectively every task and carry no information; a denial is the anomaly
 /// the audit line exists for. Anything outside the known-boring vocabulary
 /// renders too, so future decision kinds surface instead of vanishing.
 fn side_effect_is_noteworthy(decision: &str) -> bool {
-    !(decision == "not_applicable" || decision.starts_with("allow"))
+    !(decision == "not_applicable"
+        || decision.starts_with("allow")
+        || decision.ends_with("auto_approval"))
 }
 
 fn render_task_node(node: &TaskNode) -> Html {
@@ -532,11 +541,33 @@ mod tests {
 
     #[test]
     fn routine_policy_decisions_are_not_noteworthy() {
-        // The two decisions muse stamps on every routine task (observed in
-        // the captured fixtures) must stay off the card.
+        // The decisions muse stamps on every routine task (observed in the
+        // captured fixtures) must stay off the card.
         assert!(!side_effect_is_noteworthy("allow:policy"));
         assert!(!side_effect_is_noteworthy("allow:user"));
         assert!(!side_effect_is_noteworthy("not_applicable"));
+        // Muse Code 1.0.x grant vocabulary — an approval, same class as allow.
+        assert!(!side_effect_is_noteworthy(
+            "reminder_child:read_only:subagent_tool_auto_approval"
+        ));
+    }
+
+    #[test]
+    fn reminder_with_only_a_routine_grant_stays_hidden() {
+        // Live-captured (2026-09-04): a `reminder.child_run` node carrying only
+        // its auto-approval side-effect rendered as a bare
+        // "reminder.child_run — policy: …" line. A boring grant is not content.
+        let mut n = node(Some("reminder.child_run"));
+        n.side_effect = Some((
+            "reminder.child_run".to_string(),
+            "reminder_child:read_only:subagent_tool_auto_approval".to_string(),
+        ));
+        assert!(is_hidden_scaffolding(&n));
+
+        // A denial on a reminder task is the anomaly — it must render.
+        let mut denied = node(Some("reminder.child_run"));
+        denied.side_effect = Some(("reminder.child_run".to_string(), "deny:policy".to_string()));
+        assert!(!is_hidden_scaffolding(&denied));
     }
 
     #[test]

--- a/muse-session-lib/src/classifier.rs
+++ b/muse-session-lib/src/classifier.rs
@@ -152,6 +152,22 @@ impl MuseClassifier {
             return vec![AgentOutput::Noop];
         }
 
+        // Reminder scaffolding identifies itself by *operation* even when its
+        // task was never registered above (Muse Code 1.0.x emits the
+        // `reminder.child_run` auto-approval under a task id whose `proposed`
+        // this classifier may never see). Same rationale as the tracked case:
+        // policy bookkeeping renders as repeated
+        // "reminder.child_run — policy: …" noise, so screen on the operation
+        // name too, not only on task tracking.
+        if event_kind == Some("side_effect_intent")
+            && event
+                .and_then(|e| e.get("operation"))
+                .and_then(|o| o.as_str())
+                .is_some_and(|op| op.starts_with("reminder."))
+        {
+            return vec![AgentOutput::Noop];
+        }
+
         // Turn boundary: any link whose `proposed` never arrived (crash,
         // drift) flushes fail-open as visible rather than being held
         // forever.
@@ -578,6 +594,35 @@ mod reminder_screen {
             matches!(c.classify(policy)[..], [AgentOutput::Noop]),
             "reminder auto-approval policy is internal bookkeeping"
         );
+    }
+
+    #[test]
+    fn reminder_operation_is_screened_even_without_task_registration() {
+        // Live-captured (Muse Code 1.0.x): the `reminder.child_run`
+        // auto-approval can arrive under a task id whose `proposed` this
+        // classifier never saw — task tracking alone misses it, and the
+        // record rendered as "reminder.child_run — policy: …" noise. The
+        // operation name is screened directly.
+        let mut c = MuseClassifier::default();
+        let policy = lifecycle(
+            "side_effect_intent",
+            "never-registered",
+            json!({
+                "operation": "reminder.child_run",
+                "policy_decision": "reminder_child:read_only:subagent_tool_auto_approval"
+            }),
+        );
+        assert!(
+            matches!(c.classify(policy)[..], [AgentOutput::Noop]),
+            "reminder-operation bookkeeping is screened without registration"
+        );
+        // A non-reminder operation on an unregistered task still passes.
+        let other = lifecycle(
+            "side_effect_intent",
+            "never-registered-2",
+            json!({"operation": "tool.exec", "policy_decision": "deny:policy"}),
+        );
+        assert!(matches!(c.classify(other)[..], [AgentOutput::Visible(_)]));
     }
 
     #[test]


### PR DESCRIPTION
A muse session surfaced this as a whole transcript entry:

> `reminder.child_run — policy: reminder_child:read_only:subagent_tool_auto_approval`

That is muse's internal note that it auto-approved its own reminder subagent — pure policy bookkeeping. Three defense layers each half-missed it:

- **Classifier (proxy side)**: reminder scaffolding is screened by tracked task id, but Muse Code 1.0.x can deliver the `child_run` side-effect under a task id whose `proposed` the classifier never saw. It now also screens any `side_effect_intent` whose *operation* starts with `reminder.` — registration no longer required.
- **Noteworthy-decision vocabulary (renderer)**: `allow:*` / `not_applicable` were known-boring, but 1.0.x's grant vocabulary (`…:subagent_tool_auto_approval`) wasn't, so it "failed visible" as designed. Decisions ending `auto_approval` are approvals — same boring class.
- **Scaffolding hiding (renderer)**: a reminder card counted *any* side-effect as content worth showing. Now only a **noteworthy** side-effect (a denial, unknown vocabulary) keeps a reminder card visible — a card holding only the routine grant is hidden (still counted in the "reminder tasks hidden" footer).

Denials render everywhere as before, unknown future vocabulary still fails visible, and the renderer-side fixes also heal transcripts already stored with the leaked records.
