### PR TITLE
Fix admin stylesheet lint regression

### DIFF
--- a/frontend/styles/admin.css
+++ b/frontend/styles/admin.css
@@ -46,6 +46,7 @@
 }
 
 /* Admin Tabs — matches settings tab style */
+
 /* Scrolls horizontally on narrow viewports instead of shedding tabs off the
    right edge (same treatment as .settings-tabs). */
 .admin-tabs {


### PR DESCRIPTION
## Summary
- restore the required blank line between adjacent admin tab comments
- return main and all branches based on it to a green CSS lint baseline

## Verification
- cd frontend/lint && npm run lint:css