### PR TITLE
Visual PRs: pick a gh-capable host + model; generate in a throwaway clone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -980,8 +980,6 @@ When making changes, verify:
 | `PORTAL_APNS_TEAM_ID` | Apple Developer Team ID for native iOS push | Required with other `PORTAL_APNS_*` vars |
 | `PORTAL_APNS_BUNDLE_ID` | App bundle id used as the APNs topic | Required with other `PORTAL_APNS_*` vars |
 | `PORTAL_FCM_SERVICE_ACCOUNT_PATH` | Google service-account JSON path for FCM v1 native Android push | Optional (FCM disabled when unset) |
-| `PORTAL_VISUAL_PR_REPO_DIR` | Git checkout that the admin Visual-PRs tab runs `gh`/`claude` in (testing feature; the checkout needs `gh` auth and the `visual-pr` skill) | Optional (tab disabled when unset) |
-| `PORTAL_VISUAL_PR_CLAUDE_BIN` | Binary invoked for visual-PR generation | Optional (default: `claude`) |
 
 Note: Dev mode is enabled via `--dev-mode` CLI flag, not an environment variable. Voice input is browser-native (Web Speech API on Chromium / Safari) unless `PORTAL_STT_BACKEND` is configured — see below.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "clap",
+ "claude-codes",
  "claude-session-lib",
  "codex-session-lib",
  "croner",

--- a/backend/migrations/2026-09-04-183530_add_visual_pr_previews/down.sql
+++ b/backend/migrations/2026-09-04-183530_add_visual_pr_previews/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE visual_pr_previews;

--- a/backend/migrations/2026-09-04-183530_add_visual_pr_previews/up.sql
+++ b/backend/migrations/2026-09-04-183530_add_visual_pr_previews/up.sql
@@ -1,0 +1,13 @@
+-- Durable storage for admin visual-PR preview SVGs (generated on a launcher
+-- host from a throwaway shallow clone; the portal is the long-term home).
+CREATE TABLE visual_pr_previews (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    repo VARCHAR(255) NOT NULL,
+    pr_number BIGINT NOT NULL,
+    svg TEXT NOT NULL,
+    model VARCHAR(100),
+    generated_on VARCHAR(255),
+    created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    UNIQUE (repo, pr_number)
+);

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -649,8 +649,8 @@ pub async fn probe_agents(
     }
 
     match tokio::time::timeout(std::time::Duration::from_secs(5), rx).await {
-        Ok(Ok(LauncherToServer::ProbeAgentsResult { agents, .. })) => {
-            Ok(Json(ProbeAgentsResponse { agents }))
+        Ok(Ok(LauncherToServer::ProbeAgentsResult { agents, gh, .. })) => {
+            Ok(Json(ProbeAgentsResponse { agents, gh }))
         }
         Ok(Ok(_)) => Err(AppError::Internal(
             "Unexpected launcher probe response".to_string(),
@@ -669,7 +669,7 @@ pub async fn probe_agents(
 /// Confirm the caller owns `launcher_id` (agent logins run credentials on that
 /// host, so only its owner may drive them). 404 on unknown so we don't leak
 /// launcher existence to non-owners.
-fn require_launcher_owner(
+pub(crate) fn require_launcher_owner(
     app_state: &AppState,
     launcher_id: Uuid,
     user_id: Uuid,
@@ -685,7 +685,7 @@ fn require_launcher_owner(
 }
 
 /// Relay one request/response RPC to a launcher, reusing the probe correlation.
-async fn launcher_rpc(
+pub(crate) async fn launcher_rpc(
     app_state: &AppState,
     launcher_id: Uuid,
     request_id: Uuid,

--- a/backend/src/handlers/visual_pr.rs
+++ b/backend/src/handlers/visual_pr.rs
@@ -1,180 +1,215 @@
-//! Admin ▸ Visual PRs: list open pull requests and generate before/after
-//! summary SVGs in the `.claude/skills/visual-pr` house style.
+//! Admin ▸ Visual PRs: list a repo's open pull requests and manage generated
+//! before/after summary SVGs (the `.claude/skills/visual-pr` style).
 //!
-//! Generation shells out to a headless `claude` run (driven through the
-//! `claude-codes` protocol types) inside a configured git checkout
-//! (`PORTAL_VISUAL_PR_REPO_DIR`); PR listing and approval shell out to `gh`
-//! in the same checkout, reusing its ambient auth. This is an admin-only
-//! testing feature: previews are held in memory and do not survive a backend
-//! restart — regeneration is one click.
+//! All `gh` and `claude` work runs on a **launcher host the admin picks in the
+//! tab** — one that advertises [`shared::LAUNCHER_CAPABILITY_VISUAL_PR`] and
+//! probes with an authenticated `gh`. Generation on that host is
+//! self-contained (shallow clone into a tempdir, render, clean up); the
+//! returned SVG is stored durably in `visual_pr_previews`, upserted per
+//! `(repo, pr_number)`. Nothing is configured on the backend.
 
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::{header, HeaderMap, StatusCode},
     response::IntoResponse,
     Json,
 };
-use claude_codes::ClaudeOutput;
+use diesel::prelude::*;
 use serde::Deserialize;
 use shared::api::{
-    VisualPrApproveResponse, VisualPrItem, VisualPrListResponse, VisualPrPreviewState,
+    VisualPrApproveRequest, VisualPrApproveResponse, VisualPrGenerateRequest, VisualPrItem,
+    VisualPrListResponse, VisualPrPreviewState,
 };
+use shared::{LauncherToServer, ServerToLauncher, LAUNCHER_CAPABILITY_VISUAL_PR};
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use tower_cookies::Cookies;
 use tracing::{error, info};
+use uuid::Uuid;
 
-use crate::{errors::AppError, handlers::admin::require_admin, AppState};
+use crate::handlers::launchers::{launcher_rpc, require_launcher_owner};
+use crate::{errors::AppError, handlers::admin::require_admin, schema, AppState};
 
-/// Ceiling on one headless generation run. A typical run is 1–3 minutes;
-/// past ten something is wedged and the slot should free up.
-const GENERATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
+/// Ceiling on one launcher-side generation (shallow clone + headless claude).
+/// Slightly above the launcher's own 600s so its verdict arrives first.
+const GENERATE_TIMEOUT_SECS: u64 = 620;
+const LIST_TIMEOUT_SECS: u64 = 30;
+const APPROVE_TIMEOUT_SECS: u64 = 60;
 
 // ============================================================================
-// State
+// State: in-flight/failed markers only — finished SVGs live in the DB
 // ============================================================================
 
-/// One PR's preview lifecycle. SVGs are small (≈10 KB) so they live inline.
 #[derive(Debug, Clone)]
-enum PreviewEntry {
+enum Transient {
     Generating,
-    Ready { svg: String },
     Failed { error: String },
 }
 
-/// In-memory visual-PR runtime hung off [`AppState`]. Cloning shares the
-/// entry map (AppState itself derives `Clone`).
-#[derive(Clone)]
+/// In-memory generation markers hung off [`AppState`] (cloning shares the
+/// map). Ready previews are durable rows in `visual_pr_previews`.
+#[derive(Clone, Default)]
 pub struct VisualPrState {
-    /// Git checkout that `gh` and `claude` run in. `None` = feature disabled
-    /// (the list endpoint reports why; everything else 503s).
-    pub repo_dir: Option<PathBuf>,
-    /// Binary to invoke for generation (default `claude`).
-    pub claude_bin: String,
-    entries: Arc<Mutex<HashMap<i64, PreviewEntry>>>,
+    transient: Arc<Mutex<HashMap<(String, i64), Transient>>>,
 }
 
 impl VisualPrState {
-    pub fn from_env() -> Self {
-        let repo_dir = std::env::var("PORTAL_VISUAL_PR_REPO_DIR")
-            .ok()
-            .filter(|v| !v.trim().is_empty())
-            .map(PathBuf::from);
-        let claude_bin = std::env::var("PORTAL_VISUAL_PR_CLAUDE_BIN")
-            .ok()
-            .filter(|v| !v.trim().is_empty())
-            .unwrap_or_else(|| "claude".to_string());
-        match &repo_dir {
-            Some(dir) => info!("Visual PRs: enabled, repo dir {}", dir.display()),
-            None => info!("Visual PRs: disabled (PORTAL_VISUAL_PR_REPO_DIR unset)"),
-        }
-        Self {
-            repo_dir,
-            claude_bin,
-            entries: Arc::new(Mutex::new(HashMap::new())),
-        }
+    fn get(&self, repo: &str, n: i64) -> Option<Transient> {
+        self.transient
+            .lock()
+            .expect("poisoned")
+            .get(&(repo.to_string(), n))
+            .cloned()
     }
 
-    fn repo_dir(&self) -> Result<&PathBuf, AppError> {
-        self.repo_dir.as_ref().ok_or(AppError::ServiceUnavailable(
-            "visual PRs disabled: set PORTAL_VISUAL_PR_REPO_DIR",
-        ))
+    fn set(&self, repo: &str, n: i64, t: Transient) {
+        self.transient
+            .lock()
+            .expect("poisoned")
+            .insert((repo.to_string(), n), t);
     }
 
-    fn entry(&self, number: i64) -> Option<PreviewEntry> {
-        self.entries.lock().expect("poisoned").get(&number).cloned()
-    }
-
-    fn set_entry(&self, number: i64, entry: PreviewEntry) {
-        self.entries.lock().expect("poisoned").insert(number, entry);
+    fn clear(&self, repo: &str, n: i64) {
+        self.transient
+            .lock()
+            .expect("poisoned")
+            .remove(&(repo.to_string(), n));
     }
 }
 
 // ============================================================================
-// GET /api/admin/visual-prs — open PRs merged with preview state
+// Shared checks
 // ============================================================================
 
-/// Shape of one element of `gh pr list --json ...`.
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct GhPr {
-    number: i64,
-    title: String,
-    head_ref_name: String,
-    updated_at: String,
-    is_draft: bool,
-    url: String,
-    author: GhAuthor,
+/// `owner/name` with a bounded charset — the only repo shape relayed to a
+/// launcher (which validates again before touching `gh`).
+fn validate_repo(repo: &str) -> Result<(), AppError> {
+    let mut parts = repo.split('/');
+    let ok = |s: &str| {
+        !s.is_empty()
+            && s.len() <= 100
+            && !s.starts_with('-')
+            && s.chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+    };
+    match (parts.next(), parts.next(), parts.next()) {
+        (Some(owner), Some(name), None) if ok(owner) && ok(name) => Ok(()),
+        _ => Err(AppError::BadRequest("repo must be owner/name")),
+    }
 }
 
+/// Model overrides pass straight to `claude --model`; bound the charset.
+fn validate_model(model: &Option<String>) -> Result<(), AppError> {
+    if let Some(m) = model {
+        let ok = !m.is_empty()
+            && m.len() <= 64
+            && !m.starts_with('-')
+            && m.chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | ':'));
+        if !ok {
+            return Err(AppError::BadRequest("invalid model name"));
+        }
+    }
+    Ok(())
+}
+
+/// The chosen launcher must be the caller's, connected, and advertise the
+/// visual-PR capability (older launchers can't decode the frames — #1366).
+/// Returns the launcher's hostname for provenance stamping.
+fn require_visual_pr_launcher(
+    app_state: &AppState,
+    launcher_id: Uuid,
+    user_id: Uuid,
+) -> Result<String, AppError> {
+    require_launcher_owner(app_state, launcher_id, user_id)?;
+    let launcher = app_state
+        .session_manager
+        .get_launchers_for_user(&user_id)
+        .into_iter()
+        .find(|l| l.launcher_id == launcher_id)
+        .ok_or(AppError::NotFound("Launcher not found"))?;
+    if !launcher
+        .capabilities
+        .iter()
+        .any(|c| c == LAUNCHER_CAPABILITY_VISUAL_PR)
+    {
+        return Err(AppError::Conflict(
+            "this launcher is too old for visual PRs — update it first",
+        ));
+    }
+    Ok(launcher.hostname)
+}
+
+// ============================================================================
+// GET /api/admin/visual-prs?launcher_id=…&repo=… — open PRs + preview state
+// ============================================================================
+
 #[derive(Deserialize)]
-struct GhAuthor {
-    login: String,
+pub struct VisualPrListQuery {
+    pub launcher_id: Uuid,
+    pub repo: String,
 }
 
 pub async fn list_visual_prs(
     State(app_state): State<Arc<AppState>>,
     headers: HeaderMap,
     cookies: Cookies,
+    Query(q): Query<VisualPrListQuery>,
 ) -> Result<Json<VisualPrListResponse>, AppError> {
-    require_admin(&app_state, &headers, &cookies)?;
+    let admin = require_admin(&app_state, &headers, &cookies)?;
+    validate_repo(&q.repo)?;
+    require_visual_pr_launcher(&app_state, q.launcher_id, admin.id)?;
 
-    let Some(repo_dir) = app_state.visual_prs.repo_dir.clone() else {
-        return Ok(Json(VisualPrListResponse {
-            enabled: false,
-            disabled_reason: Some(
-                "Set PORTAL_VISUAL_PR_REPO_DIR to a git checkout with gh auth to enable."
-                    .to_string(),
-            ),
-            prs: vec![],
-        }));
+    let request_id = Uuid::new_v4();
+    let reply = launcher_rpc(
+        &app_state,
+        q.launcher_id,
+        request_id,
+        ServerToLauncher::VisualPrListPrs {
+            request_id,
+            repo: q.repo.clone(),
+        },
+        LIST_TIMEOUT_SECS,
+    )
+    .await?;
+    let rows = match reply {
+        LauncherToServer::VisualPrListResult { error: Some(e), .. } => {
+            return Err(AppError::BadGatewayMessage(format!("gh pr list: {e}")))
+        }
+        LauncherToServer::VisualPrListResult { prs, .. } => prs,
+        _ => {
+            return Err(AppError::Internal(
+                "unexpected launcher reply to VisualPrListPrs".into(),
+            ))
+        }
     };
 
-    let output = tokio::process::Command::new("gh")
-        .args([
-            "pr",
-            "list",
-            "--state",
-            "open",
-            "--limit",
-            "50",
-            "--json",
-            "number,title,headRefName,updatedAt,isDraft,url,author",
-        ])
-        .current_dir(&repo_dir)
-        .output()
-        .await
-        .map_err(|e| AppError::Internal(format!("failed to spawn gh: {e}")))?;
+    // Stored previews for this repo (Ready), merged under any transient state.
+    let stored: Vec<i64> = {
+        let mut conn = app_state.conn()?;
+        schema::visual_pr_previews::table
+            .filter(schema::visual_pr_previews::repo.eq(&q.repo))
+            .select(schema::visual_pr_previews::pr_number)
+            .load(&mut conn)?
+    };
+    let stored: std::collections::HashSet<i64> = stored.into_iter().collect();
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        error!("gh pr list failed: {}", stderr.trim());
-        return Err(AppError::BadGatewayMessage(format!(
-            "gh pr list failed: {}",
-            stderr.trim()
-        )));
-    }
-
-    let gh_prs: Vec<GhPr> = serde_json::from_slice(&output.stdout)
-        .map_err(|e| AppError::Internal(format!("unparseable gh pr list output: {e}")))?;
-
-    let prs = gh_prs
+    let prs = rows
         .into_iter()
         .map(|pr| {
-            let (preview, preview_error) = match app_state.visual_prs.entry(pr.number) {
+            let (preview, preview_error) = match app_state.visual_prs.get(&q.repo, pr.number) {
+                Some(Transient::Generating) => (VisualPrPreviewState::Generating, None),
+                Some(Transient::Failed { error }) => (VisualPrPreviewState::Failed, Some(error)),
+                None if stored.contains(&pr.number) => (VisualPrPreviewState::Ready, None),
                 None => (VisualPrPreviewState::None, None),
-                Some(PreviewEntry::Generating) => (VisualPrPreviewState::Generating, None),
-                Some(PreviewEntry::Ready { .. }) => (VisualPrPreviewState::Ready, None),
-                Some(PreviewEntry::Failed { error }) => (VisualPrPreviewState::Failed, Some(error)),
             };
             VisualPrItem {
                 number: pr.number,
                 title: pr.title,
-                head_ref: pr.head_ref_name,
-                author: pr.author.login,
+                head_ref: pr.head_ref,
+                author: pr.author,
                 updated_at: pr.updated_at,
-                draft: pr.is_draft,
+                draft: pr.draft,
                 url: pr.url,
                 preview,
                 preview_error,
@@ -182,15 +217,11 @@ pub async fn list_visual_prs(
         })
         .collect();
 
-    Ok(Json(VisualPrListResponse {
-        enabled: true,
-        disabled_reason: None,
-        prs,
-    }))
+    Ok(Json(VisualPrListResponse { prs }))
 }
 
 // ============================================================================
-// POST /api/admin/visual-prs/{number}/generate — kick off a background run
+// POST /api/admin/visual-prs/{number}/generate — render on the chosen host
 // ============================================================================
 
 pub async fn generate_visual_pr(
@@ -198,157 +229,168 @@ pub async fn generate_visual_pr(
     Path(number): Path<i64>,
     headers: HeaderMap,
     cookies: Cookies,
+    Json(req): Json<VisualPrGenerateRequest>,
 ) -> Result<StatusCode, AppError> {
     let admin = require_admin(&app_state, &headers, &cookies)?;
-    app_state.visual_prs.repo_dir()?;
+    validate_repo(&req.repo)?;
+    validate_model(&req.model)?;
+    let hostname = require_visual_pr_launcher(&app_state, req.launcher_id, admin.id)?;
 
     if matches!(
-        app_state.visual_prs.entry(number),
-        Some(PreviewEntry::Generating)
+        app_state.visual_prs.get(&req.repo, number),
+        Some(Transient::Generating)
     ) {
         return Err(AppError::Conflict("a generation is already running"));
     }
 
-    info!("Visual PR #{number}: generation started by {}", admin.email);
+    info!(
+        "Visual PR {}#{number}: generation on {hostname} (model {:?}) by {}",
+        req.repo, req.model, admin.email
+    );
     app_state
         .visual_prs
-        .set_entry(number, PreviewEntry::Generating);
-    tokio::spawn(run_generation(app_state.clone(), number));
+        .set(&req.repo, number, Transient::Generating);
+    tokio::spawn(run_generation(
+        app_state.clone(),
+        req,
+        number,
+        hostname,
+        admin.id,
+    ));
     Ok(StatusCode::ACCEPTED)
 }
 
-/// The background generation task: headless `claude` follows the committed
-/// `visual-pr` skill and writes the SVG to a temp path; we parse its final
-/// `ResultMessage` (via `claude-codes`) for success, then lift the file into
-/// memory.
-async fn run_generation(app_state: Arc<AppState>, number: i64) {
-    let result = generate_svg(&app_state, number).await;
-    match result {
+/// Background half of generate: RPC to the launcher (which clones, renders,
+/// and cleans up), then persist the SVG for long-term serving.
+async fn run_generation(
+    app_state: Arc<AppState>,
+    req: VisualPrGenerateRequest,
+    number: i64,
+    hostname: String,
+    admin_id: Uuid,
+) {
+    let request_id = Uuid::new_v4();
+    let reply = launcher_rpc(
+        &app_state,
+        req.launcher_id,
+        request_id,
+        ServerToLauncher::VisualPrGenerate {
+            request_id,
+            repo: req.repo.clone(),
+            pr_number: number,
+            model: req.model.clone(),
+        },
+        GENERATE_TIMEOUT_SECS,
+    )
+    .await;
+
+    let outcome: Result<String, String> = match reply {
+        Ok(LauncherToServer::VisualPrGenerateResult { svg: Some(svg), .. }) => Ok(svg),
+        Ok(LauncherToServer::VisualPrGenerateResult { error, .. }) => {
+            Err(error.unwrap_or_else(|| "launcher returned no SVG".into()))
+        }
+        Ok(_) => Err("unexpected launcher reply to VisualPrGenerate".into()),
+        // launcher_rpc's failures carry static reasons; keep them readable.
+        Err(AppError::GatewayTimeout(m)) | Err(AppError::BadGateway(m)) => Err(m.to_string()),
+        Err(e) => Err(format!("{e:?}")),
+    };
+
+    match outcome {
         Ok(svg) => {
-            info!("Visual PR #{number}: preview ready ({} bytes)", svg.len());
-            app_state
-                .visual_prs
-                .set_entry(number, PreviewEntry::Ready { svg });
-        }
-        Err(e) => {
-            error!("Visual PR #{number}: generation failed: {e}");
-            app_state
-                .visual_prs
-                .set_entry(number, PreviewEntry::Failed { error: e });
-        }
-    }
-}
-
-async fn generate_svg(app_state: &Arc<AppState>, number: i64) -> Result<String, String> {
-    let repo_dir = app_state
-        .visual_prs
-        .repo_dir
-        .clone()
-        .ok_or("visual PRs disabled")?;
-    let out_path = std::env::temp_dir().join(format!("visual-pr-{number}.svg"));
-    // A stale file from an earlier run must not be mistaken for this run's output.
-    let _ = tokio::fs::remove_file(&out_path).await;
-
-    let prompt = format!(
-        "Generate the visual PR summary for PR #{number} of this repository by following \
-         .claude/skills/visual-pr/SKILL.md exactly. Read the real diff first \
-         (`gh pr view {number}`, `gh pr diff {number}`) and ground every identifier in the \
-         code — do not invent names. Write the final SVG to {out} and validate it with \
-         `python3 .claude/skills/visual-pr/check_svg.py {out}`. Do NOT run `agent-portal show`, \
-         do NOT check out branches, do NOT commit, push, or modify the repository.",
-        out = out_path.display(),
-    );
-
-    let child = tokio::process::Command::new(&app_state.visual_prs.claude_bin)
-        .args([
-            "-p",
-            &prompt,
-            "--output-format",
-            "json",
-            "--dangerously-skip-permissions",
-        ])
-        .current_dir(&repo_dir)
-        .stdin(std::process::Stdio::null())
-        .output();
-
-    let output = tokio::time::timeout(GENERATION_TIMEOUT, child)
-        .await
-        .map_err(|_| format!("timed out after {}s", GENERATION_TIMEOUT.as_secs()))?
-        .map_err(|e| format!("failed to spawn claude: {e}"))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let tail: String = stderr
-            .chars()
-            .rev()
-            .take(400)
-            .collect::<Vec<_>>()
-            .iter()
-            .rev()
-            .collect();
-        return Err(format!(
-            "claude exited with {}: {}",
-            output.status,
-            tail.trim()
-        ));
-    }
-
-    // `--output-format json` prints a single ResultMessage object.
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    match serde_json::from_str::<ClaudeOutput>(stdout.trim()) {
-        Ok(ClaudeOutput::Result(result)) if result.is_error => {
-            return Err(format!(
-                "claude reported an error: {}",
-                result.result.unwrap_or_else(|| "(no detail)".to_string())
-            ));
-        }
-        Ok(_) => {}
-        Err(e) => {
-            // The run may still have produced the file; note the parse failure
-            // only if it didn't.
-            if !out_path.exists() {
-                return Err(format!("unparseable claude output ({e})"));
+            let row = crate::models::NewVisualPrPreview {
+                repo: req.repo.clone(),
+                pr_number: number,
+                svg,
+                model: req.model.clone(),
+                generated_on: Some(hostname),
+                created_by: Some(admin_id),
+            };
+            let stored = app_state
+                .conn()
+                .map_err(|e| format!("{e:?}"))
+                .and_then(|mut conn| {
+                    diesel::insert_into(schema::visual_pr_previews::table)
+                        .values(&row)
+                        .on_conflict((
+                            schema::visual_pr_previews::repo,
+                            schema::visual_pr_previews::pr_number,
+                        ))
+                        .do_update()
+                        .set((
+                            schema::visual_pr_previews::svg.eq(&row.svg),
+                            schema::visual_pr_previews::model.eq(&row.model),
+                            schema::visual_pr_previews::generated_on.eq(&row.generated_on),
+                            schema::visual_pr_previews::created_by.eq(row.created_by),
+                            schema::visual_pr_previews::created_at.eq(diesel::dsl::now),
+                        ))
+                        .execute(&mut conn)
+                        .map_err(|e| e.to_string())
+                });
+            match stored {
+                Ok(_) => {
+                    info!("Visual PR {}#{number}: preview stored", req.repo);
+                    app_state.visual_prs.clear(&req.repo, number);
+                }
+                Err(e) => {
+                    error!("Visual PR {}#{number}: store failed: {e}", req.repo);
+                    app_state.visual_prs.set(
+                        &req.repo,
+                        number,
+                        Transient::Failed {
+                            error: format!("generated, but storing failed: {e}"),
+                        },
+                    );
+                }
             }
         }
+        Err(e) => {
+            error!("Visual PR {}#{number}: generation failed: {e}", req.repo);
+            app_state
+                .visual_prs
+                .set(&req.repo, number, Transient::Failed { error: e });
+        }
     }
-
-    let svg = tokio::fs::read_to_string(&out_path).await.map_err(|e| {
-        format!(
-            "claude finished but wrote no SVG at {}: {e}",
-            out_path.display()
-        )
-    })?;
-    if !svg.trim_start().starts_with("<svg") {
-        return Err("output file does not start with <svg".to_string());
-    }
-    Ok(svg)
 }
 
 // ============================================================================
-// GET /api/admin/visual-prs/{number}/preview.svg — serve a ready preview
+// GET /api/admin/visual-prs/{number}/preview.svg?repo=… — serve a stored SVG
 // ============================================================================
+
+#[derive(Deserialize)]
+pub struct PreviewQuery {
+    pub repo: String,
+}
 
 pub async fn get_visual_pr_svg(
     State(app_state): State<Arc<AppState>>,
     Path(number): Path<i64>,
     headers: HeaderMap,
     cookies: Cookies,
+    Query(q): Query<PreviewQuery>,
 ) -> Result<impl IntoResponse, AppError> {
     require_admin(&app_state, &headers, &cookies)?;
-    match app_state.visual_prs.entry(number) {
-        Some(PreviewEntry::Ready { svg }) => Ok((
+    validate_repo(&q.repo)?;
+    let mut conn = app_state.conn()?;
+    let svg: Option<String> = schema::visual_pr_previews::table
+        .filter(schema::visual_pr_previews::repo.eq(&q.repo))
+        .filter(schema::visual_pr_previews::pr_number.eq(number))
+        .select(schema::visual_pr_previews::svg)
+        .first(&mut conn)
+        .optional()?;
+    match svg {
+        Some(svg) => Ok((
             [
                 (header::CONTENT_TYPE, "image/svg+xml"),
                 (header::CACHE_CONTROL, "no-store"),
             ],
             svg,
         )),
-        _ => Err(AppError::NotFound("no preview for this PR")),
+        None => Err(AppError::NotFound("no preview for this PR")),
     }
 }
 
 // ============================================================================
-// POST /api/admin/visual-prs/{number}/approve — squash-merge via gh
+// POST /api/admin/visual-prs/{number}/approve — squash-merge via the host's gh
 // ============================================================================
 
 pub async fn approve_visual_pr(
@@ -356,36 +398,71 @@ pub async fn approve_visual_pr(
     Path(number): Path<i64>,
     headers: HeaderMap,
     cookies: Cookies,
+    Json(req): Json<VisualPrApproveRequest>,
 ) -> Result<Json<VisualPrApproveResponse>, AppError> {
     let admin = require_admin(&app_state, &headers, &cookies)?;
-    let repo_dir = app_state.visual_prs.repo_dir()?.clone();
+    validate_repo(&req.repo)?;
+    require_visual_pr_launcher(&app_state, req.launcher_id, admin.id)?;
 
-    info!("Visual PR #{number}: approve requested by {}", admin.email);
-    // `--auto` merges immediately when requirements are already met and
-    // otherwise arms auto-merge for when CI goes green — either way one call.
-    let output = tokio::process::Command::new("gh")
-        .args([
-            "pr",
-            "merge",
-            &number.to_string(),
-            "--squash",
-            "--delete-branch",
-            "--auto",
-        ])
-        .current_dir(&repo_dir)
-        .output()
-        .await
-        .map_err(|e| AppError::Internal(format!("failed to spawn gh: {e}")))?;
+    info!(
+        "Visual PR {}#{number}: approve requested by {}",
+        req.repo, admin.email
+    );
+    let request_id = Uuid::new_v4();
+    let reply = launcher_rpc(
+        &app_state,
+        req.launcher_id,
+        request_id,
+        ServerToLauncher::VisualPrApprove {
+            request_id,
+            repo: req.repo.clone(),
+            pr_number: number,
+        },
+        APPROVE_TIMEOUT_SECS,
+    )
+    .await?;
+    match reply {
+        LauncherToServer::VisualPrApproveResult {
+            success: true,
+            message,
+            ..
+        } => Ok(Json(VisualPrApproveResponse {
+            message: message.unwrap_or_else(|| format!("PR #{number} approved")),
+        })),
+        LauncherToServer::VisualPrApproveResult { message, .. } => {
+            Err(AppError::BadGatewayMessage(format!(
+                "gh pr merge failed: {}",
+                message.unwrap_or_else(|| "(no detail)".into())
+            )))
+        }
+        _ => Err(AppError::Internal(
+            "unexpected launcher reply to VisualPrApprove".into(),
+        )),
+    }
+}
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(AppError::BadGatewayMessage(format!(
-            "gh pr merge failed: {}",
-            stderr.trim()
-        )));
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repo_validation_is_strict() {
+        assert!(validate_repo("meawoppl/agent-portal").is_ok());
+        assert!(validate_repo("a-b/c_d.e").is_ok());
+        assert!(validate_repo("meawoppl").is_err());
+        assert!(validate_repo("a/b/c").is_err());
+        assert!(validate_repo("a b/c").is_err());
+        assert!(validate_repo("-owner/name").is_err());
+        assert!(validate_repo("owner/").is_err());
     }
 
-    Ok(Json(VisualPrApproveResponse {
-        message: format!("PR #{number} approved — squash merge queued (auto-merge)"),
-    }))
+    #[test]
+    fn model_validation_is_strict() {
+        assert!(validate_model(&None).is_ok());
+        assert!(validate_model(&Some("sonnet".into())).is_ok());
+        assert!(validate_model(&Some("claude-fable-5".into())).is_ok());
+        assert!(validate_model(&Some("-p".into())).is_err());
+        assert!(validate_model(&Some("a model".into())).is_err());
+        assert!(validate_model(&Some(String::new())).is_err());
+    }
 }

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -688,7 +688,10 @@ fn handle_launcher_message(
         }
         LauncherToServer::AgentLoginStartResult { request_id, .. }
         | LauncherToServer::AgentLoginOutcomeResult { request_id, .. }
-        | LauncherToServer::InstallAgentResult { request_id, .. } => {
+        | LauncherToServer::InstallAgentResult { request_id, .. }
+        | LauncherToServer::VisualPrListResult { request_id, .. }
+        | LauncherToServer::VisualPrGenerateResult { request_id, .. }
+        | LauncherToServer::VisualPrApproveResult { request_id, .. } => {
             // Same request/response correlation as the probe path.
             app_state
                 .session_manager

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -107,8 +107,7 @@ pub struct AppState {
     pub stt: Option<portal_stt::SttProvider>,
     /// Per-recording cap (MB) for `POST /api/stt/transcribe`.
     pub max_audio_mb: u32,
-    /// Admin visual-PR review runtime (testing feature). Always present;
-    /// disabled internally when `PORTAL_VISUAL_PR_REPO_DIR` is unset.
+    /// Admin visual-PR in-flight markers (finished SVGs live in the DB).
     pub visual_prs: handlers::visual_pr::VisualPrState,
 }
 
@@ -207,7 +206,7 @@ pub async fn run() -> anyhow::Result<()> {
         session_max_age_days: config.session_max_age_days,
         max_image_mb: config.max_image_mb,
         max_audio_mb: config.max_audio_mb,
-        visual_prs: handlers::visual_pr::VisualPrState::from_env(),
+        visual_prs: handlers::visual_pr::VisualPrState::default(),
         image_store: handlers::images::ImageStore::new(
             config.image_store_max_bytes,
             config.image_store_ttl,

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -701,6 +701,20 @@ pub struct NewTurnMetric {
     pub context_snapshot_tokens: Option<i64>,
 }
 
+/// One stored visual-PR preview SVG (admin feature), upserted per
+/// `(repo, pr_number)` — regenerating replaces the previous render.
+#[derive(Debug, Insertable)]
+#[diesel(table_name = crate::schema::visual_pr_previews)]
+pub struct NewVisualPrPreview {
+    pub repo: String,
+    pub pr_number: i64,
+    pub svg: String,
+    pub model: Option<String>,
+    /// Hostname of the launcher that rendered it.
+    pub generated_on: Option<String>,
+    pub created_by: Option<Uuid>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -301,6 +301,22 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    visual_pr_previews (id) {
+        id -> Uuid,
+        #[max_length = 255]
+        repo -> Varchar,
+        pr_number -> Int8,
+        svg -> Text,
+        #[max_length = 100]
+        model -> Nullable<Varchar>,
+        #[max_length = 255]
+        generated_on -> Nullable<Varchar>,
+        created_by -> Nullable<Uuid>,
+        created_at -> Timestamp,
+    }
+}
+
 diesel::joinable!(custom_subdomains -> sessions (session_id));
 diesel::joinable!(custom_subdomains -> users (created_by));
 diesel::joinable!(deleted_session_costs -> users (user_id));
@@ -323,6 +339,7 @@ diesel::joinable!(turn_metrics -> messages (user_message_id));
 diesel::joinable!(turn_metrics -> sessions (session_id));
 diesel::joinable!(turn_metrics -> users (user_id));
 diesel::joinable!(user_identities -> users (user_id));
+diesel::joinable!(visual_pr_previews -> users (created_by));
 
 diesel::allow_tables_to_appear_in_same_query!(
     custom_subdomains,
@@ -341,4 +358,5 @@ diesel::allow_tables_to_appear_in_same_query!(
     turn_metrics,
     user_identities,
     users,
+    visual_pr_previews,
 );

--- a/backend/src/test_support.rs
+++ b/backend/src/test_support.rs
@@ -54,7 +54,7 @@ pub fn test_app_state(pool: DbPool) -> AppState {
         oauth: crate::config::OAuthProviders::default(),
         stt: None,
         max_audio_mb: 25,
-        visual_prs: crate::handlers::visual_pr::VisualPrState::from_env(),
+        visual_prs: crate::handlers::visual_pr::VisualPrState::default(),
         device_flow_store: None,
         public_url: "http://localhost:3000".to_string(),
         cookie_key: Key::generate(),

--- a/frontend/src/components/muse_renderer.rs
+++ b/frontend/src/components/muse_renderer.rs
@@ -277,22 +277,31 @@ fn is_reminder_task(node: &TaskNode) -> bool {
 /// ("latest running task") lands tool outcomes on a running scaffolding task
 /// in every captured turn, so blindly hiding all reminders would silently drop
 /// the tool results Matt most wants to see. Rendering any reminder node that
-/// holds a tool result, streamed output, or a side-effect keeps that content
-/// visible; the attribution itself is corrected upstream in the reducer.
+/// holds a tool result, streamed output, or a *noteworthy* side-effect keeps
+/// that content visible; a routine grant (the 1.0.x `…auto_approval`
+/// bookkeeping) is not content — a reminder card carrying only that would
+/// render as a bare "reminder.child_run — policy: …" line.
 fn is_hidden_scaffolding(node: &TaskNode) -> bool {
     is_reminder_task(node)
         && node.tool_results.is_empty()
         && node.output.is_empty()
-        && node.side_effect.is_none()
+        && !node
+            .side_effect
+            .as_ref()
+            .is_some_and(|(_, decision)| side_effect_is_noteworthy(decision))
 }
 
 /// Whether a side-effect policy decision deserves a line on the task card.
-/// Muse's routine decisions (`allow:policy`, `not_applicable`) are stamped on
+/// Muse's routine decisions (`allow:policy`, `not_applicable`, and the 1.0.x
+/// grant vocabulary ending `auto_approval` — e.g.
+/// `reminder_child:read_only:subagent_tool_auto_approval`) are stamped on
 /// effectively every task and carry no information; a denial is the anomaly
 /// the audit line exists for. Anything outside the known-boring vocabulary
 /// renders too, so future decision kinds surface instead of vanishing.
 fn side_effect_is_noteworthy(decision: &str) -> bool {
-    !(decision == "not_applicable" || decision.starts_with("allow"))
+    !(decision == "not_applicable"
+        || decision.starts_with("allow")
+        || decision.ends_with("auto_approval"))
 }
 
 fn render_task_node(node: &TaskNode) -> Html {
@@ -532,11 +541,33 @@ mod tests {
 
     #[test]
     fn routine_policy_decisions_are_not_noteworthy() {
-        // The two decisions muse stamps on every routine task (observed in
-        // the captured fixtures) must stay off the card.
+        // The decisions muse stamps on every routine task (observed in the
+        // captured fixtures) must stay off the card.
         assert!(!side_effect_is_noteworthy("allow:policy"));
         assert!(!side_effect_is_noteworthy("allow:user"));
         assert!(!side_effect_is_noteworthy("not_applicable"));
+        // Muse Code 1.0.x grant vocabulary — an approval, same class as allow.
+        assert!(!side_effect_is_noteworthy(
+            "reminder_child:read_only:subagent_tool_auto_approval"
+        ));
+    }
+
+    #[test]
+    fn reminder_with_only_a_routine_grant_stays_hidden() {
+        // Live-captured (2026-09-04): a `reminder.child_run` node carrying only
+        // its auto-approval side-effect rendered as a bare
+        // "reminder.child_run — policy: …" line. A boring grant is not content.
+        let mut n = node(Some("reminder.child_run"));
+        n.side_effect = Some((
+            "reminder.child_run".to_string(),
+            "reminder_child:read_only:subagent_tool_auto_approval".to_string(),
+        ));
+        assert!(is_hidden_scaffolding(&n));
+
+        // A denial on a reminder task is the anomaly — it must render.
+        let mut denied = node(Some("reminder.child_run"));
+        denied.side_effect = Some(("reminder.child_run".to_string(), "deny:policy".to_string()));
+        assert!(!is_hidden_scaffolding(&denied));
     }
 
     #[test]

--- a/frontend/src/pages/admin/visual_prs_tab.rs
+++ b/frontend/src/pages/admin/visual_prs_tab.rs
@@ -1,17 +1,24 @@
 // TODO(#1165): remove this file-local ratchet after replacing production unwrap/expect paths.
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-//! Admin ▸ Visual PRs: list open pull requests, kick off background
-//! generation of a before/after summary SVG (the `.claude/skills/visual-pr`
-//! house style), and click into a ready preview to approve (squash-merge)
-//! the PR. Testing feature — previews live in backend memory only.
+//! Admin ▸ Visual PRs: pick a launcher host (one with an authenticated `gh`),
+//! a model, and a repo; list the repo's open PRs; kick off background
+//! generation of a before/after summary SVG on that host (shallow clone →
+//! headless claude → cleanup); click a ready preview to review and approve
+//! (squash-merge) the PR. Finished SVGs are stored durably in the portal DB.
 
+use gloo::storage::{LocalStorage, Storage};
 use gloo::timers::callback::Interval;
 use gloo_net::http::Request;
 use shared::api::{
-    VisualPrApproveResponse, VisualPrItem, VisualPrListResponse, VisualPrPreviewState,
+    ProbeAgentsResponse, VisualPrApproveRequest, VisualPrApproveResponse, VisualPrGenerateRequest,
+    VisualPrItem, VisualPrListResponse, VisualPrPreviewState,
 };
+use shared::{GhStatus, LauncherInfo, LAUNCHER_CAPABILITY_VISUAL_PR};
+use std::collections::HashMap;
+use uuid::Uuid;
 use wasm_bindgen_futures::spawn_local;
+use web_sys::{HtmlInputElement, HtmlSelectElement};
 use yew::prelude::*;
 
 use crate::utils::{self, On401};
@@ -20,53 +27,159 @@ use crate::utils::{self, On401};
 /// 5-second refresh keeps status chips honest without hammering `gh`.
 const POLL_MS: u32 = 5_000;
 
+/// localStorage keys for the picker state, so the tab reopens configured.
+const LS_HOST: &str = "visual-pr-host";
+const LS_MODEL: &str = "visual-pr-model";
+const LS_REPO: &str = "visual-pr-repo";
+
+/// Model choices passed to the headless claude run's `--model`. CLI aliases,
+/// not API ids — empty string means the CLI default.
+const MODELS: &[(&str, &str)] = &[
+    ("", "Default model"),
+    ("sonnet", "Sonnet"),
+    ("opus", "Opus"),
+    ("haiku", "Haiku"),
+];
+
 #[function_component(AdminVisualPrsTab)]
 pub fn admin_visual_prs_tab() -> Html {
-    let data = use_state(|| None::<VisualPrListResponse>);
+    let launchers = use_state(Vec::<LauncherInfo>::new);
+    let gh_probes = use_state(HashMap::<Uuid, GhStatus>::new);
+    let host = use_state(|| LocalStorage::get::<String>(LS_HOST).unwrap_or_default());
+    let model = use_state(|| LocalStorage::get::<String>(LS_MODEL).unwrap_or_default());
+    let repo = use_state(|| LocalStorage::get::<String>(LS_REPO).unwrap_or_default());
+    let list = use_state(|| None::<VisualPrListResponse>);
+    let list_error = use_state(|| None::<String>);
     let expanded = use_state(|| None::<i64>);
     let confirm_merge = use_state(|| false);
     let notice = use_state(|| None::<String>);
 
-    let reload = {
-        let data = data.clone();
-        move || {
-            let data = data.clone();
+    // Launchers + a gh probe per connected one, once on mount. The picker
+    // marks hosts whose gh is missing/unauthenticated (or whose launcher
+    // predates the visual-PR capability) as unusable.
+    {
+        let launchers = launchers.clone();
+        let gh_probes = gh_probes.clone();
+        use_effect_with((), move |_| {
             spawn_local(async move {
-                if let Ok(d) = utils::fetch_json::<VisualPrListResponse>(
-                    "/api/admin/visual-prs",
-                    On401::Ignore,
-                )
-                .await
-                {
-                    data.set(Some(d));
+                let Ok(list) =
+                    utils::fetch_json::<Vec<LauncherInfo>>("/api/launchers", On401::Ignore).await
+                else {
+                    return;
+                };
+                for l in list.iter().filter(|l| l.connected) {
+                    let gh_probes = gh_probes.clone();
+                    let id = l.launcher_id;
+                    spawn_local(async move {
+                        let path = format!("/api/launchers/{id}/probe-agents");
+                        if let Ok(resp) =
+                            utils::fetch_json::<ProbeAgentsResponse>(&path, On401::Ignore).await
+                        {
+                            if let Some(gh) = resp.gh {
+                                let mut next = (*gh_probes).clone();
+                                next.insert(id, gh);
+                                gh_probes.set(next);
+                            }
+                        }
+                    });
+                }
+                launchers.set(list);
+            });
+            || ()
+        });
+    }
+
+    let reload = {
+        let list = list.clone();
+        let list_error = list_error.clone();
+        let host = host.clone();
+        let repo = repo.clone();
+        move || {
+            let (Ok(launcher_id), repo) = (host.parse::<Uuid>(), (*repo).clone()) else {
+                return;
+            };
+            if !repo.contains('/') {
+                return;
+            }
+            let list = list.clone();
+            let list_error = list_error.clone();
+            spawn_local(async move {
+                let path = format!("/api/admin/visual-prs?launcher_id={launcher_id}&repo={repo}");
+                match utils::fetch_json::<VisualPrListResponse>(&path, On401::Ignore).await {
+                    Ok(d) => {
+                        list.set(Some(d));
+                        list_error.set(None);
+                    }
+                    Err(e) => list_error.set(Some(e.to_string())),
                 }
             });
         }
     };
 
+    // Refetch when the host/repo selection changes, then keep polling.
     {
         let reload = reload.clone();
-        use_effect_with((), move |_| {
+        use_effect_with(((*host).clone(), (*repo).clone()), move |_| {
             reload();
             let interval = Interval::new(POLL_MS, reload);
             move || drop(interval)
         });
     }
 
+    let on_host = {
+        let host = host.clone();
+        Callback::from(move |e: Event| {
+            let v = e.target_unchecked_into::<HtmlSelectElement>().value();
+            let _ = LocalStorage::set(LS_HOST, &v);
+            host.set(v);
+        })
+    };
+    let on_model = {
+        let model = model.clone();
+        Callback::from(move |e: Event| {
+            let v = e.target_unchecked_into::<HtmlSelectElement>().value();
+            let _ = LocalStorage::set(LS_MODEL, &v);
+            model.set(v);
+        })
+    };
+    let on_repo = {
+        let repo = repo.clone();
+        Callback::from(move |e: Event| {
+            let v = e
+                .target_unchecked_into::<HtmlInputElement>()
+                .value()
+                .trim()
+                .to_string();
+            let _ = LocalStorage::set(LS_REPO, &v);
+            repo.set(v);
+        })
+    };
+
     let on_generate = {
         let reload = reload.clone();
         let notice = notice.clone();
+        let host = host.clone();
+        let repo = repo.clone();
+        let model = model.clone();
         Callback::from(move |number: i64| {
+            let Ok(launcher_id) = host.parse::<Uuid>() else {
+                return;
+            };
+            let body = VisualPrGenerateRequest {
+                launcher_id,
+                repo: (*repo).clone(),
+                model: Some((*model).clone()).filter(|m| !m.is_empty()),
+            };
             let reload = reload.clone();
             let notice = notice.clone();
             spawn_local(async move {
                 let url = utils::api_url(&format!("/api/admin/visual-prs/{number}/generate"));
-                match Request::post(&url).send().await {
+                match Request::post(&url).json(&body).unwrap().send().await {
                     Ok(resp) if resp.ok() => notice.set(None),
-                    Ok(resp) => notice.set(Some(format!(
-                        "Generate for #{number} failed: HTTP {}",
-                        resp.status()
-                    ))),
+                    Ok(resp) => {
+                        let text = resp.text().await.unwrap_or_default();
+                        notice.set(Some(format!("Generate for #{number} failed: {text}")));
+                    }
                     Err(e) => notice.set(Some(format!("Generate for #{number} failed: {e}"))),
                 }
                 reload();
@@ -79,14 +192,23 @@ pub fn admin_visual_prs_tab() -> Html {
         let notice = notice.clone();
         let expanded = expanded.clone();
         let confirm_merge = confirm_merge.clone();
+        let host = host.clone();
+        let repo = repo.clone();
         Callback::from(move |number: i64| {
+            let Ok(launcher_id) = host.parse::<Uuid>() else {
+                return;
+            };
+            let body = VisualPrApproveRequest {
+                launcher_id,
+                repo: (*repo).clone(),
+            };
             let reload = reload.clone();
             let notice = notice.clone();
             let expanded = expanded.clone();
             let confirm_merge = confirm_merge.clone();
             spawn_local(async move {
                 let url = utils::api_url(&format!("/api/admin/visual-prs/{number}/approve"));
-                match Request::post(&url).send().await {
+                match Request::post(&url).json(&body).unwrap().send().await {
                     Ok(resp) if resp.ok() => {
                         let msg = resp
                             .json::<VisualPrApproveResponse>()
@@ -108,57 +230,124 @@ pub fn admin_visual_prs_tab() -> Html {
         })
     };
 
-    let Some(list) = (*data).clone() else {
-        return html! { <p class="empty-state">{ "Loading pull requests…" }</p> };
-    };
+    let expanded_pr: Option<VisualPrItem> = expanded.and_then(|n| {
+        list.as_ref()
+            .and_then(|l| l.prs.iter().find(|p| p.number == n).cloned())
+    });
 
-    if !list.enabled {
-        return html! {
-            <section class="visual-prs">
-                <h3>{ "Visual PR review" }</h3>
-                <p class="empty-state">
-                    { list.disabled_reason.unwrap_or_else(|| "Feature disabled.".to_string()) }
-                </p>
-            </section>
-        };
-    }
-
-    let expanded_pr: Option<VisualPrItem> =
-        expanded.and_then(|n| list.prs.iter().find(|p| p.number == n).cloned());
+    let configured = host.parse::<Uuid>().is_ok() && repo.contains('/');
 
     html! {
         <section class="visual-prs">
             <h3>{ "Visual PR review" }</h3>
             <p class="section-note">
-                { "Generate renders a before/after summary of the PR's actual diff in the background \
-                   (a headless claude run — takes a minute or three). Click a ready preview to review \
-                   and approve." }
+                { "Pick a computer with an authenticated GitHub CLI — generation shallow-clones \
+                   the repo into a temp dir on that machine, renders a before/after summary of \
+                   the PR's actual diff, stores the image here, and cleans the clone up." }
             </p>
+            { picker_row(&launchers, &gh_probes, &host, &model, &repo, &on_host, &on_model, &on_repo) }
             if let Some(msg) = (*notice).clone() {
                 <p class="visual-pr-notice">{ msg }</p>
             }
-            if list.prs.is_empty() {
-                <p class="empty-state">{ "No open pull requests." }</p>
+            if let Some(err) = (*list_error).clone() {
+                <p class="visual-pr-notice">{ err }</p>
+            }
+            if !configured {
+                <p class="empty-state">{ "Choose a host and enter a repo (owner/name) to list its open PRs." }</p>
+            } else if let Some(list) = &*list {
+                if list.prs.is_empty() {
+                    <p class="empty-state">{ "No open pull requests." }</p>
+                } else {
+                    <table class="admin-table">
+                        <thead>
+                            <tr>
+                                <th>{ "PR" }</th>
+                                <th>{ "Title" }</th>
+                                <th>{ "Branch" }</th>
+                                <th>{ "Preview" }</th>
+                                <th class="actions"></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            { for list.prs.iter().map(|pr| render_row(pr, &expanded, &on_generate)) }
+                        </tbody>
+                    </table>
+                }
             } else {
-                <table class="admin-table">
-                    <thead>
-                        <tr>
-                            <th>{ "PR" }</th>
-                            <th>{ "Title" }</th>
-                            <th>{ "Branch" }</th>
-                            <th>{ "Preview" }</th>
-                            <th class="actions"></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        { for list.prs.iter().map(|pr| render_row(pr, &expanded, &on_generate)) }
-                    </tbody>
-                </table>
+                <p class="empty-state">{ "Loading pull requests…" }</p>
             }
             if let Some(pr) = expanded_pr {
-                { render_preview_modal(&pr, &expanded, &confirm_merge, &on_generate, &on_approve) }
+                { render_preview_modal(&pr, &repo, &expanded, &confirm_merge, &on_generate, &on_approve) }
             }
         </section>
+    }
+}
+
+/// Host / model / repo pickers. A host is offered only when its launcher
+/// advertises the visual-PR capability; gh state annotates the label so an
+/// unauthenticated machine explains itself.
+#[allow(clippy::too_many_arguments)]
+fn picker_row(
+    launchers: &[LauncherInfo],
+    gh_probes: &HashMap<Uuid, GhStatus>,
+    host: &str,
+    model: &str,
+    repo: &str,
+    on_host: &Callback<Event>,
+    on_model: &Callback<Event>,
+    on_repo: &Callback<Event>,
+) -> Html {
+    let host_options = launchers
+        .iter()
+        .filter(|l| l.connected)
+        .map(|l| {
+            let capable = l
+                .capabilities
+                .iter()
+                .any(|c| c == LAUNCHER_CAPABILITY_VISUAL_PR);
+            let (usable, gh_label) = match gh_probes.get(&l.launcher_id) {
+                _ if !capable => (false, " (launcher too old)"),
+                Some(gh) if gh.authenticated => (true, " (gh ✓)"),
+                Some(gh) if gh.installed => (false, " (gh not signed in)"),
+                Some(_) => (false, " (gh not installed)"),
+                None => (false, " (probing gh…)"),
+            };
+            let id = l.launcher_id.to_string();
+            html! {
+                <option value={id.clone()} disabled={!usable} selected={id == host}>
+                    { format!("{}{}", l.hostname, gh_label) }
+                </option>
+            }
+        })
+        .collect::<Html>();
+
+    html! {
+        <div class="visual-pr-pickers">
+            <label>
+                { "Host" }
+                <select onchange={on_host}>
+                    <option value="" selected={host.is_empty()}>{ "Choose a computer" }</option>
+                    { host_options }
+                </select>
+            </label>
+            <label>
+                { "Model" }
+                <select onchange={on_model}>
+                    { for MODELS.iter().map(|(value, label)| html! {
+                        <option value={*value} selected={*value == model}>{ *label }</option>
+                    }) }
+                </select>
+            </label>
+            <label>
+                { "Repo" }
+                <input
+                    type="text"
+                    placeholder="owner/name"
+                    value={repo.to_string()}
+                    onchange={on_repo}
+                />
+            </label>
+        </div>
     }
 }
 
@@ -210,7 +399,7 @@ fn render_row(
 
     html! {
         <tr key={pr.number.to_string()}>
-            <td class="numeric">
+            <td class="num">
                 <a href={pr.url.clone()} target="_blank" rel="noopener noreferrer">
                     { format!("#{}", pr.number) }
                 </a>
@@ -230,13 +419,16 @@ fn render_row(
 
 fn render_preview_modal(
     pr: &VisualPrItem,
+    repo: &str,
     expanded: &UseStateHandle<Option<i64>>,
     confirm_merge: &UseStateHandle<bool>,
     on_generate: &Callback<i64>,
     on_approve: &Callback<i64>,
 ) -> Html {
     let number = pr.number;
-    let svg_url = utils::api_url(&format!("/api/admin/visual-prs/{number}/preview.svg"));
+    let svg_url = utils::api_url(&format!(
+        "/api/admin/visual-prs/{number}/preview.svg?repo={repo}"
+    ));
 
     let on_close = {
         let expanded = expanded.clone();

--- a/frontend/styles/admin.css
+++ b/frontend/styles/admin.css
@@ -518,3 +518,28 @@
     border-radius: 4px;
     background: #16161e;
 }
+
+.visual-pr-pickers {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin: 0.5rem 0 1rem;
+}
+
+.visual-pr-pickers label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.visual-pr-pickers select,
+.visual-pr-pickers input {
+    background: var(--bg-darker);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 0.4rem 0.6rem;
+    min-width: 14rem;
+}

--- a/launcher/Cargo.toml
+++ b/launcher/Cargo.toml
@@ -9,6 +9,8 @@ name = "agent-portal"
 path = "src/main.rs"
 
 [dependencies]
+tempfile = "3.27.0"
+claude-codes = { workspace = true }
 # Shared types
 shared = { path = "../shared" }
 

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -85,6 +85,10 @@ pub async fn run_launcher_loop(
     let mut last_parked_reason: Option<LauncherRejectReason> = None;
     let mut scheduler = Scheduler::new();
     let mut login_registry = crate::login_registry::LoginRegistry::new();
+    // Replies from detached work (visual-PR generation runs minutes): tasks
+    // send finished frames here and the select loop forwards them, so long
+    // work never blocks the message loop or the heartbeat.
+    let (bg_tx, mut bg_rx) = mpsc::unbounded_channel::<LauncherToServer>();
 
     loop {
         // Re-resolve the token every attempt (CLI flag still wins): a parked
@@ -118,6 +122,7 @@ pub async fn run_launcher_loop(
                         shared::LAUNCHER_CAPABILITY_FORK_SESSION.to_string(),
                         shared::LAUNCHER_CAPABILITY_RESTART.to_string(),
                         shared::LAUNCHER_CAPABILITY_HEARTBEAT_ACK.to_string(),
+                        shared::LAUNCHER_CAPABILITY_VISUAL_PR.to_string(),
                     ],
                 };
                 if ws_sender.send(register).await.is_err() {
@@ -243,6 +248,7 @@ pub async fn run_launcher_loop(
                                             &mut process_manager,
                                             &mut scheduler,
                                             &mut login_registry,
+                                            &bg_tx,
                                         ).await;
                                     }
                                 }
@@ -284,6 +290,13 @@ pub async fn run_launcher_loop(
                             // Enforce max runtime on scheduled sessions
                             for session_id in scheduler.timed_out_sessions() {
                                 process_manager.stop(&session_id).await;
+                            }
+                        }
+
+                        Some(reply) = bg_rx.recv() => {
+                            if ws_sender.send(reply).await.is_err() {
+                                warn!("Failed to send background task reply");
+                                break;
                             }
                         }
 
@@ -621,6 +634,7 @@ async fn handle_message(
     process_manager: &mut ProcessManager,
     scheduler: &mut Scheduler,
     login_registry: &mut crate::login_registry::LoginRegistry,
+    bg_tx: &mpsc::UnboundedSender<LauncherToServer>,
 ) {
     match msg {
         ServerToLauncher::LaunchSession {
@@ -812,10 +826,17 @@ async fn handle_message(
         ServerToLauncher::ProbeAgents { request_id } => {
             // Synchronous probe in a blocking task so two `--version` spawns
             // don't hold up the message loop.
-            let agents = tokio::task::spawn_blocking(probe_agents_for_response)
-                .await
-                .unwrap_or_default();
-            let response = shared::LauncherToServer::ProbeAgentsResult { request_id, agents };
+            let (agents, gh) = tokio::task::spawn_blocking(|| {
+                (probe_agents_for_response(), session_lib::probe::probe_gh())
+            })
+            .await
+            .map(|(agents, gh)| (agents, Some(gh)))
+            .unwrap_or((Vec::new(), None));
+            let response = shared::LauncherToServer::ProbeAgentsResult {
+                request_id,
+                agents,
+                gh,
+            };
             if ws_sender.send(response).await.is_err() {
                 warn!("Failed to send probe agents result");
             }
@@ -843,6 +864,61 @@ async fn handle_message(
             if ws_sender.send(response).await.is_err() {
                 warn!("Failed to send install agent result");
             }
+        }
+        ServerToLauncher::VisualPrListPrs { request_id, repo } => {
+            let bg_tx = bg_tx.clone();
+            tokio::spawn(async move {
+                let (prs, error) = match crate::visual_pr::list_prs(&repo).await {
+                    Ok(prs) => (prs, None),
+                    Err(e) => (Vec::new(), Some(e)),
+                };
+                let _ = bg_tx.send(LauncherToServer::VisualPrListResult {
+                    request_id,
+                    prs,
+                    error,
+                });
+            });
+        }
+        ServerToLauncher::VisualPrGenerate {
+            request_id,
+            repo,
+            pr_number,
+            model,
+        } => {
+            info!("Visual PR generate requested: {repo}#{pr_number}");
+            // Minutes of clone + headless claude — always detached; the reply
+            // rides the background channel.
+            let bg_tx = bg_tx.clone();
+            tokio::spawn(async move {
+                let (svg, error) =
+                    match crate::visual_pr::generate(&repo, pr_number, model.as_deref()).await {
+                        Ok(svg) => (Some(svg), None),
+                        Err(e) => (None, Some(e)),
+                    };
+                let _ = bg_tx.send(LauncherToServer::VisualPrGenerateResult {
+                    request_id,
+                    svg,
+                    error,
+                });
+            });
+        }
+        ServerToLauncher::VisualPrApprove {
+            request_id,
+            repo,
+            pr_number,
+        } => {
+            let bg_tx = bg_tx.clone();
+            tokio::spawn(async move {
+                let (success, message) = match crate::visual_pr::approve(&repo, pr_number).await {
+                    Ok(m) => (true, Some(m)),
+                    Err(e) => (false, Some(e)),
+                };
+                let _ = bg_tx.send(LauncherToServer::VisualPrApproveResult {
+                    request_id,
+                    success,
+                    message,
+                });
+            });
         }
         ServerToLauncher::ScheduleSync { tasks } => {
             info!("Received ScheduleSync with {} task(s)", tasks.len());

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -14,6 +14,7 @@ mod process_manager;
 mod scheduler;
 mod seppuku;
 mod service;
+mod visual_pr;
 mod worktree;
 
 use clap::{Parser, Subcommand};

--- a/launcher/src/visual_pr.rs
+++ b/launcher/src/visual_pr.rs
@@ -1,0 +1,252 @@
+//! Visual-PR work delegated to this launcher host by the backend: list a
+//! repo's open PRs, render a before/after summary SVG for one, or approve it —
+//! all through this host's authenticated `gh`.
+//!
+//! Generation is self-contained and leaves nothing behind: shallow-clone the
+//! repo into a `tempfile` dir, run a headless `claude` against the PR's real
+//! diff there, read the SVG out, and let the `TempDir` drop reclaim the disk.
+//! The backend stores the returned SVG durably; this host keeps nothing.
+
+use shared::api::VisualPrRow;
+use std::path::Path;
+use std::time::Duration;
+use tracing::{info, warn};
+
+/// Ceiling on one headless generation run (clone + claude). A typical run is
+/// 1–3 minutes; past ten something is wedged.
+const GENERATION_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Ceiling on plain `gh` calls (list, merge, clone).
+const GH_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// `owner/name`, nothing else — the only shape ever passed to `gh --repo` or
+/// the clone. Defense in depth (the backend validates too): these strings
+/// reach `Command` args directly, never a shell, but a bounded charset keeps
+/// them from meaning anything surprising to `gh` itself.
+pub fn repo_is_valid(repo: &str) -> bool {
+    let mut parts = repo.split('/');
+    let (Some(owner), Some(name), None) = (parts.next(), parts.next(), parts.next()) else {
+        return false;
+    };
+    let ok = |s: &str| {
+        !s.is_empty()
+            && s.len() <= 100
+            // A leading '-' would read as a flag to gh/git.
+            && !s.starts_with('-')
+            && s.chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+    };
+    ok(owner) && ok(name)
+}
+
+/// `gh pr list` for `repo`, parsed into wire rows.
+pub async fn list_prs(repo: &str) -> Result<Vec<VisualPrRow>, String> {
+    if !repo_is_valid(repo) {
+        return Err(format!("invalid repo `{repo}` (expected owner/name)"));
+    }
+    let output = run_with_timeout(
+        tokio::process::Command::new("gh").args([
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            "50",
+            "--json",
+            "number,title,headRefName,updatedAt,isDraft,url,author",
+        ]),
+        GH_TIMEOUT,
+    )
+    .await?;
+
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct GhPr {
+        number: i64,
+        title: String,
+        head_ref_name: String,
+        updated_at: String,
+        is_draft: bool,
+        url: String,
+        author: GhAuthor,
+    }
+    #[derive(serde::Deserialize)]
+    struct GhAuthor {
+        login: String,
+    }
+
+    let rows: Vec<GhPr> = serde_json::from_slice(&output)
+        .map_err(|e| format!("unparseable gh pr list output: {e}"))?;
+    Ok(rows
+        .into_iter()
+        .map(|pr| VisualPrRow {
+            number: pr.number,
+            title: pr.title,
+            head_ref: pr.head_ref_name,
+            author: pr.author.login,
+            updated_at: pr.updated_at,
+            draft: pr.is_draft,
+            url: pr.url,
+        })
+        .collect())
+}
+
+/// Render the visual summary SVG for `repo`#`pr_number` in a throwaway
+/// shallow clone. The `TempDir` guard reclaims the clone on every exit path.
+pub async fn generate(repo: &str, pr_number: i64, model: Option<&str>) -> Result<String, String> {
+    if !repo_is_valid(repo) {
+        return Err(format!("invalid repo `{repo}` (expected owner/name)"));
+    }
+    let dir = tempfile::Builder::new()
+        .prefix("visual-pr-")
+        .tempdir()
+        .map_err(|e| format!("could not create temp dir: {e}"))?;
+    let checkout = dir.path().join("repo");
+
+    info!("visual-pr: shallow-cloning {repo} for PR #{pr_number}");
+    run_with_timeout(
+        tokio::process::Command::new("gh").args([
+            "repo",
+            "clone",
+            repo,
+            &checkout.to_string_lossy(),
+            "--",
+            "--depth",
+            "1",
+        ]),
+        GH_TIMEOUT,
+    )
+    .await
+    .map_err(|e| format!("shallow clone failed: {e}"))?;
+
+    let out_path = dir.path().join(format!("visual-pr-{pr_number}.svg"));
+    let svg = run_claude(repo, pr_number, model, &checkout, &out_path).await;
+    // TempDir drop cleans the clone up on success and failure alike; make the
+    // intent explicit rather than relying on scope.
+    drop(dir);
+    svg
+}
+
+async fn run_claude(
+    repo: &str,
+    pr_number: i64,
+    model: Option<&str>,
+    checkout: &Path,
+    out_path: &Path,
+) -> Result<String, String> {
+    let prompt = format!(
+        "Render a visual before/after summary SVG for PR #{pr_number} of {repo}. \
+         If this repository contains .claude/skills/visual-pr/SKILL.md, follow it exactly \
+         (including its validator). Otherwise follow this compact spec: one SVG, \
+         viewBox 0 0 2000 1200, full-bleed background #16161e, sans-serif; header \
+         'PR #{pr_number} · <title>' in #565f89 at 24px; a 1-2 line thesis in #e6e9f5 at 34px \
+         stating the claim of the change; a BEFORE panel (label #f7768e) on the left and an \
+         AFTER panel (label #9ece6a) on the right split by a dashed divider at x=1000; \
+         thin-bordered boxes (#3d4666 borders, #1e202e fill, #a9b1d6 body text, #7aa2f7 for \
+         code identifiers) with arrows; red #f7768e only for defects, green #9ece6a only for \
+         fixes, orange #e0af68 for caveats; one muted footer line naming a real limitation. \
+         Ground every identifier in the actual diff: read it with `gh pr view {pr_number}` and \
+         `gh pr diff {pr_number}` before drawing anything, and never invent names. \
+         Write the final SVG to {out} and nothing else there. Do NOT run agent-portal show, \
+         do NOT check out branches, commit, push, or modify the repository.",
+        out = out_path.display(),
+    );
+
+    let mut cmd = tokio::process::Command::new("claude");
+    cmd.args([
+        "-p",
+        &prompt,
+        "--output-format",
+        "json",
+        "--dangerously-skip-permissions",
+    ]);
+    if let Some(model) = model {
+        cmd.args(["--model", model]);
+    }
+    cmd.current_dir(checkout).stdin(std::process::Stdio::null());
+
+    let stdout = run_with_timeout(&mut cmd, GENERATION_TIMEOUT).await?;
+    // `--output-format json` ends with a ResultMessage; is_error carries the
+    // run's own verdict when the process still exited 0.
+    if let Ok(claude_codes::ClaudeOutput::Result(result)) =
+        serde_json::from_slice::<claude_codes::ClaudeOutput>(stdout.trim_ascii())
+    {
+        if result.is_error {
+            return Err(format!(
+                "claude reported an error: {}",
+                result.result.unwrap_or_else(|| "(no detail)".to_string())
+            ));
+        }
+    }
+
+    let svg = tokio::fs::read_to_string(out_path)
+        .await
+        .map_err(|e| format!("claude finished but wrote no SVG: {e}"))?;
+    if !svg.trim_start().starts_with("<svg") {
+        return Err("output file does not start with <svg".to_string());
+    }
+    Ok(svg)
+}
+
+/// `gh pr merge --squash --auto` for `repo`#`pr_number`.
+pub async fn approve(repo: &str, pr_number: i64) -> Result<String, String> {
+    if !repo_is_valid(repo) {
+        return Err(format!("invalid repo `{repo}` (expected owner/name)"));
+    }
+    run_with_timeout(
+        tokio::process::Command::new("gh").args([
+            "pr",
+            "merge",
+            &pr_number.to_string(),
+            "--repo",
+            repo,
+            "--squash",
+            "--delete-branch",
+            "--auto",
+        ]),
+        GH_TIMEOUT,
+    )
+    .await?;
+    Ok(format!(
+        "PR #{pr_number} approved — squash merge queued (auto-merge)"
+    ))
+}
+
+/// Run a command with a deadline; success returns stdout, failure returns the
+/// stderr tail (or the timeout/spawn reason).
+async fn run_with_timeout(
+    cmd: &mut tokio::process::Command,
+    timeout: Duration,
+) -> Result<Vec<u8>, String> {
+    let output = tokio::time::timeout(timeout, cmd.output())
+        .await
+        .map_err(|_| format!("timed out after {}s", timeout.as_secs()))?
+        .map_err(|e| format!("failed to spawn: {e}"))?;
+    if output.status.success() {
+        Ok(output.stdout)
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let tail: String = stderr.trim().chars().take(400).collect();
+        warn!("visual-pr command failed ({}): {tail}", output.status);
+        Err(format!("exited with {}: {tail}", output.status))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repo_validation_is_strict() {
+        assert!(repo_is_valid("meawoppl/agent-portal"));
+        assert!(repo_is_valid("a-b/c_d.e"));
+        assert!(!repo_is_valid("meawoppl"));
+        assert!(!repo_is_valid("a/b/c"));
+        assert!(!repo_is_valid("a b/c"));
+        assert!(!repo_is_valid("-owner/--flag; rm"));
+        assert!(!repo_is_valid(""));
+        assert!(!repo_is_valid("owner/"));
+    }
+}

--- a/muse-session-lib/src/classifier.rs
+++ b/muse-session-lib/src/classifier.rs
@@ -152,6 +152,22 @@ impl MuseClassifier {
             return vec![AgentOutput::Noop];
         }
 
+        // Reminder scaffolding identifies itself by *operation* even when its
+        // task was never registered above (Muse Code 1.0.x emits the
+        // `reminder.child_run` auto-approval under a task id whose `proposed`
+        // this classifier may never see). Same rationale as the tracked case:
+        // policy bookkeeping renders as repeated
+        // "reminder.child_run — policy: …" noise, so screen on the operation
+        // name too, not only on task tracking.
+        if event_kind == Some("side_effect_intent")
+            && event
+                .and_then(|e| e.get("operation"))
+                .and_then(|o| o.as_str())
+                .is_some_and(|op| op.starts_with("reminder."))
+        {
+            return vec![AgentOutput::Noop];
+        }
+
         // Turn boundary: any link whose `proposed` never arrived (crash,
         // drift) flushes fail-open as visible rather than being held
         // forever.
@@ -578,6 +594,35 @@ mod reminder_screen {
             matches!(c.classify(policy)[..], [AgentOutput::Noop]),
             "reminder auto-approval policy is internal bookkeeping"
         );
+    }
+
+    #[test]
+    fn reminder_operation_is_screened_even_without_task_registration() {
+        // Live-captured (Muse Code 1.0.x): the `reminder.child_run`
+        // auto-approval can arrive under a task id whose `proposed` this
+        // classifier never saw — task tracking alone misses it, and the
+        // record rendered as "reminder.child_run — policy: …" noise. The
+        // operation name is screened directly.
+        let mut c = MuseClassifier::default();
+        let policy = lifecycle(
+            "side_effect_intent",
+            "never-registered",
+            json!({
+                "operation": "reminder.child_run",
+                "policy_decision": "reminder_child:read_only:subagent_tool_auto_approval"
+            }),
+        );
+        assert!(
+            matches!(c.classify(policy)[..], [AgentOutput::Noop]),
+            "reminder-operation bookkeeping is screened without registration"
+        );
+        // A non-reminder operation on an unregistered task still passes.
+        let other = lifecycle(
+            "side_effect_intent",
+            "never-registered-2",
+            json!({"operation": "tool.exec", "policy_decision": "deny:policy"}),
+        );
+        assert!(matches!(c.classify(other)[..], [AgentOutput::Visible(_)]));
     }
 
     #[test]

--- a/session-lib/src/probe.rs
+++ b/session-lib/src/probe.rs
@@ -121,6 +121,33 @@ pub fn probe_muse_sandbox() -> Option<bool> {
     }
 }
 
+/// Probe the `gh` CLI: presence via `gh --version`, sign-in via
+/// `gh auth status` (exit 0 iff some host is authenticated). Drives the
+/// visual-PR host picker — generation and PR listing run through the host's
+/// own `gh`, so an unauthenticated host is not a candidate.
+pub fn probe_gh() -> shared::GhStatus {
+    let version = match Command::new("gh").arg("--version").output() {
+        Ok(output) if output.status.success() => String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .next()
+            .map(|l| l.trim().to_string())
+            .filter(|l| !l.is_empty()),
+        Ok(_) | Err(_) => None,
+    };
+    let installed = version.is_some();
+    let authenticated = installed
+        && Command::new("gh")
+            .args(["auth", "status"])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+    shared::GhStatus {
+        installed,
+        authenticated,
+        version,
+    }
+}
+
 /// Presence-only login probe for Muse: the CLI persists no account
 /// identity (no `whoami` at 0.1.0), so a logged-in cell carries a provider
 /// label instead of a name, annotated when the credential comes from the

--- a/shared/src/api/launch.rs
+++ b/shared/src/api/launch.rs
@@ -75,6 +75,10 @@ pub struct DirectoryListingResponse {
 pub struct ProbeAgentsResponse {
     #[serde(default)]
     pub agents: Vec<crate::AgentInstall>,
+    /// `gh` CLI availability on the host (visual-PR host picker). `None` when
+    /// the launcher predates the probe.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gh: Option<crate::GhStatus>,
 }
 
 /// Body of POST /api/launchers/:id/agent-login/start — which agent to sign in.

--- a/shared/src/api/visual_prs.rs
+++ b/shared/src/api/visual_prs.rs
@@ -1,26 +1,15 @@
-//! Admin ▸ Visual PRs: list open pull requests and manage generated
-//! before/after summary SVGs (the `.claude/skills/visual-pr` style).
+//! Admin ▸ Visual PRs: list a repo's open pull requests through a chosen
+//! launcher host's authenticated `gh`, generate before/after summary SVGs on
+//! that host (shallow clone → headless claude → cleanup), and store the
+//! results durably in the portal DB.
 
 use serde::{Deserialize, Serialize};
 
-/// Lifecycle of a PR's generated preview on the backend.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum VisualPrPreviewState {
-    /// No preview has been generated for this PR (or the backend restarted;
-    /// previews are held in memory only).
-    None,
-    /// A generation task is running.
-    Generating,
-    /// A preview SVG is available at `/api/admin/visual-prs/{number}/preview.svg`.
-    Ready,
-    /// The last generation attempt failed; see `preview_error`.
-    Failed,
-}
-
-/// One open pull request as listed by the visual-PR admin panel.
+/// One open PR as the launcher's `gh pr list` reports it — the wire row of
+/// `LauncherToServer::VisualPrListResult`, before the backend merges preview
+/// state in.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct VisualPrItem {
+pub struct VisualPrRow {
     pub number: i64,
     pub title: String,
     pub head_ref: String,
@@ -30,20 +19,64 @@ pub struct VisualPrItem {
     pub draft: bool,
     /// Web URL of the PR on GitHub.
     pub url: String,
+}
+
+/// Lifecycle of a PR's generated preview on the backend.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum VisualPrPreviewState {
+    /// No stored preview for this repo+PR.
+    None,
+    /// A generation task is running on a launcher host.
+    Generating,
+    /// A preview SVG is stored; fetch it at
+    /// `/api/admin/visual-prs/{number}/preview.svg?repo=…`.
+    Ready,
+    /// The last generation attempt failed; see `preview_error`.
+    Failed,
+}
+
+/// One open pull request as listed by the visual-PR admin panel: the `gh` row
+/// merged with the portal's stored preview state.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct VisualPrItem {
+    pub number: i64,
+    pub title: String,
+    pub head_ref: String,
+    pub author: String,
+    pub updated_at: String,
+    pub draft: bool,
+    pub url: String,
     pub preview: VisualPrPreviewState,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub preview_error: Option<String>,
 }
 
-/// Response for `GET /api/admin/visual-prs`.
+/// Response for `GET /api/admin/visual-prs?launcher_id=…&repo=…`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct VisualPrListResponse {
-    /// False when the backend has no `PORTAL_VISUAL_PR_REPO_DIR` configured;
-    /// `disabled_reason` says what to set.
-    pub enabled: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub disabled_reason: Option<String>,
     pub prs: Vec<VisualPrItem>,
+}
+
+/// Body for `POST /api/admin/visual-prs/{number}/generate`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct VisualPrGenerateRequest {
+    /// Launcher to run the generation on (must advertise the visual-PR
+    /// capability and have an authenticated `gh`).
+    pub launcher_id: uuid::Uuid,
+    /// `owner/name`.
+    pub repo: String,
+    /// Model override passed to the headless claude run (`--model`); `None`
+    /// uses the CLI default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+}
+
+/// Body for `POST /api/admin/visual-prs/{number}/approve`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct VisualPrApproveRequest {
+    pub launcher_id: uuid::Uuid,
+    pub repo: String,
 }
 
 /// Response for `POST /api/admin/visual-prs/{number}/approve`.

--- a/shared/src/endpoints/launcher.rs
+++ b/shared/src/endpoints/launcher.rs
@@ -134,6 +134,36 @@ pub enum LauncherToServer {
         request_id: Uuid,
         #[serde(default)]
         agents: Vec<AgentInstall>,
+        /// `gh` CLI availability on this host (additive; older launchers omit
+        /// it → `None` = unknown). Drives the visual-PR host picker.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        gh: Option<crate::GhStatus>,
+    },
+
+    /// Reply to `VisualPrListPrs`: the repo's open PRs, or `gh`'s own error.
+    VisualPrListResult {
+        request_id: Uuid,
+        #[serde(default)]
+        prs: Vec<crate::api::VisualPrRow>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+
+    /// Reply to `VisualPrGenerate`: the rendered SVG, or why generation failed.
+    VisualPrGenerateResult {
+        request_id: Uuid,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        svg: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+
+    /// Reply to `VisualPrApprove`.
+    VisualPrApproveResult {
+        request_id: Uuid,
+        success: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
     },
 
     /// Reply to `InstallAgent`: whether the install command exited cleanly, plus
@@ -314,6 +344,33 @@ pub enum ServerToLauncher {
     InstallAgent {
         request_id: Uuid,
         agent_type: AgentType,
+    },
+
+    /// List a repo's open PRs via this host's authenticated `gh`
+    /// (`gh pr list --repo …`). Replies `VisualPrListResult`. Sent only to
+    /// launchers advertising [`crate::LAUNCHER_CAPABILITY_VISUAL_PR`].
+    VisualPrListPrs { request_id: Uuid, repo: String },
+
+    /// Render the visual-PR summary SVG for `repo`#`pr_number` on this host:
+    /// shallow-clone into a tempdir, run a headless `claude` (optionally with
+    /// `model`) against the PR's diff, return the SVG, clean the tempdir up.
+    /// Replies `VisualPrGenerateResult` (generation runs minutes — the
+    /// launcher must not block its message loop on it). Capability-gated like
+    /// `VisualPrListPrs`.
+    VisualPrGenerate {
+        request_id: Uuid,
+        repo: String,
+        pr_number: i64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        model: Option<String>,
+    },
+
+    /// Squash-merge (auto) `repo`#`pr_number` via this host's `gh`. Replies
+    /// `VisualPrApproveResult`. Capability-gated like `VisualPrListPrs`.
+    VisualPrApprove {
+        request_id: Uuid,
+        repo: String,
+        pr_number: i64,
     },
 
     /// Begin an interactive login for `agent_type` on this host. The launcher

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -39,6 +39,12 @@ pub const LAUNCHER_CAPABILITY_RESTART: &str = "launcher.restart";
 /// undecodable frame (#1366).
 pub const LAUNCHER_CAPABILITY_HEARTBEAT_ACK: &str = "launcher.heartbeat_ack";
 
+/// Launcher capability advertised by versions that handle the visual-PR RPCs
+/// (`ServerToLauncher::VisualPrListPrs` / `VisualPrGenerate` /
+/// `VisualPrApprove`). The backend only sends those frames to launchers that
+/// advertise this, so older launchers never see an undecodable frame (#1366).
+pub const LAUNCHER_CAPABILITY_VISUAL_PR: &str = "launcher.visual_pr";
+
 /// Tokyo-Night data-visualization palette shared by charts, sparklines, and
 /// terminal colors. CSS theme tokens remain in the stylesheets where the
 /// browser can resolve them directly.
@@ -536,6 +542,19 @@ pub struct AgentLoginOutcome {
     /// have it. Shown verbatim so a failure is diagnosable, not mysterious.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+}
+
+/// `gh` CLI availability on a launcher host, probed alongside the agent CLIs.
+/// Drives the visual-PR host picker: generation and PR listing run through
+/// the host's own authenticated `gh`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GhStatus {
+    /// True iff `gh --version` exited successfully.
+    pub installed: bool,
+    /// True iff `gh auth status` exited successfully (a logged-in `gh`).
+    pub authenticated: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
 }
 
 /// Result of probing one agent CLI on a launcher host. Built at launcher


### PR DESCRIPTION
Reworks the admin Visual PRs feature per feedback: no more `PORTAL_VISUAL_PR_REPO_DIR` (a pre-configured backend checkout with gh auth). The backend now needs **zero configuration**.

**Host + model pickers.** The tab lists the admin's connected launchers and probes each for the GitHub CLI (`gh --version` + `gh auth status`, carried additively on `ProbeAgentsResult`). Hosts with an authenticated `gh` are selectable; others explain themselves ("gh not signed in", "launcher too old"). A model picker (CLI aliases: default/sonnet/opus/haiku) and a repo field (`owner/name`, persisted in localStorage) complete the setup.

**Generation in a throwaway clone.** Three new capability-gated launcher RPCs (`launcher.visual_pr` — older launchers never receive undecodable frames): list PRs, generate, approve. Generation on the chosen host is fully self-contained: shallow-clone the repo into a `tempfile` dir, run headless `claude` there against the PR's real diff (`gh pr diff`; uses the repo's `visual-pr` skill when present, an embedded compact style spec otherwise), read the SVG out, and let the `TempDir` drop reclaim the disk. Long-running generation replies ride a new background channel in the launcher so the message loop and heartbeat never block behind a multi-minute render.

**Durable storage.** The SVG is sent back to the portal and upserted into a new `visual_pr_previews` table keyed `(repo, pr_number)` — long-term hosting lives here, the generating host keeps nothing, and previews survive backend restarts (they were in-memory before).

Safety: `repo` and `model` strings are charset-validated on both the backend and the launcher, passed only as `Command` args (never a shell), with leading-dash rejection so nothing reads as a flag.

Note for rollout: launchers must self-update before they advertise the capability; until then the host picker marks them "launcher too old".
