### PR TITLE
Require a committed visual summary on every PR

### DIFF
--- a/.claude/skills/visual-pr/SKILL.md
+++ b/.claude/skills/visual-pr/SKILL.md
@@ -130,9 +130,15 @@ arrows. When in doubt, rasterize and look:
    table; footer caveat last.
 5. **Validate**: `python3 .claude/skills/visual-pr/check_svg.py <file.svg>` —
    fixes anything it flags (parse errors and off-palette colors are hard errors,
-   overflow estimates are warnings to eyeball).
-6. **Show it**: save as `/tmp/visual-pr-<N>.svg` (keep the repo clean — do not
-   commit generated SVGs) and run `agent-portal show /tmp/visual-pr-<N>.svg`.
+   overflow estimates are warnings to eyeball). CI runs the same validator.
+6. **Commit it to the PR**: save as `000-pr-visualization/<N>.svg` on the PR
+   branch, commit ("Add visual summary for PR #<N>"), and push. The `000-`
+   prefix sorts the SVG first in GitHub's review file list, and the
+   `Visual PR attached` check requires the file to exist and validate — a PR
+   without it does not merge (label `no-visual` for changes where a diagram is
+   genuinely noise).
+7. **Show it**: run `agent-portal show 000-pr-visualization/<N>.svg` so it also
+   renders inline in the session.
 
 ## Quality bar
 

--- a/.github/visual-pr/style.json
+++ b/.github/visual-pr/style.json
@@ -1,0 +1,23 @@
+{
+  "canvas": [2000, 1200],
+  "margin": 40,
+  "char_factor": 0.5,
+  "divider_x": 1000,
+  "divider_band": [190, 1140],
+  "palette": [
+    "#16161e",
+    "#1e202e",
+    "#3d4666",
+    "#565f89",
+    "#a9b1d6",
+    "#c0caf5",
+    "#e6e9f5",
+    "#7aa2f7",
+    "#9ece6a",
+    "#f7768e",
+    "#e0af68",
+    "#bb9af7",
+    "#7dcfff",
+    "none"
+  ]
+}

--- a/.github/workflows/visual-pr.yml
+++ b/.github/workflows/visual-pr.yml
@@ -1,16 +1,15 @@
 name: Visual PR
 
 # Every PR ships its own visual summary, committed at
-# 000-pr-visualization/<pr-number>.svg (the 000- prefix sorts it first in
-# GitHub's review file list, so the picture is the first thing a reviewer
-# sees). This check makes that a requirement.
+# 000-pr-visualization/<pr-number>.svg. Enforcement, validation, and the
+# agent-facing fix instructions live in the reusable action
+# (github.com/meawoppl/visual-pr); this workflow just wires it up.
 #
 # pull_request_target runs THIS file from the BASE branch, so the check exists
 # for every open PR the moment it lands on main — old branches don't need a
 # rebase to start reporting. The PR head is checked out as DATA only (an SVG
 # to look at); nothing from the head is ever executed, which is what makes
-# _target safe here. Keep it that way: never run scripts, build files, or
-# hooks from the head checkout in this workflow.
+# _target safe here. Keep it that way.
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
@@ -21,16 +20,12 @@ permissions:
 jobs:
   visual-pr:
     name: Visual PR attached
-    # Escape hatch for changes where a diagram is genuinely noise (bot bumps,
-    # typo fixes): label the PR `no-visual`. A skipped required job satisfies
-    # the ruleset, so the label is a real opt-out, not a dodge around a red X.
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-visual') }}
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the validator (base branch — trusted code)
+      - name: Check out this repo's visual-pr config (base branch — trusted)
         uses: actions/checkout@v4
         with:
-          sparse-checkout: .claude/skills/visual-pr
+          sparse-checkout: .github/visual-pr
 
       - name: Check out the PR's visualization (head — data only)
         uses: actions/checkout@v4
@@ -40,13 +35,14 @@ jobs:
           path: pr-head
           sparse-checkout: 000-pr-visualization
 
-      - name: Require and validate the PR's SVG
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          FILE="pr-head/000-pr-visualization/${PR_NUMBER}.svg"
-          if [ ! -f "$FILE" ]; then
-            echo "::error::Missing 000-pr-visualization/${PR_NUMBER}.svg — every PR ships its visual summary (generate it with the visual-pr skill: .claude/skills/visual-pr/SKILL.md). For changes where a diagram is genuinely noise, label the PR 'no-visual'."
-            exit 1
-          fi
-          python3 .claude/skills/visual-pr/check_svg.py "$FILE"
+      - uses: meawoppl/visual-pr@v1
+        with:
+          head-path: pr-head
+          style: .github/visual-pr/style.json
+          instructions: |
+            This is a Rust workspace (Axum backend, Yew/WASM frontend, launcher
+            daemon). Ground every identifier in the actual diff — real type,
+            function, table, and message names. Prefer the in-repo skill
+            (.claude/skills/visual-pr/SKILL.md), whose local validator matches
+            this check. Show the finished SVG in your portal session with
+            `agent-portal show`.

--- a/.github/workflows/visual-pr.yml
+++ b/.github/workflows/visual-pr.yml
@@ -1,0 +1,52 @@
+name: Visual PR
+
+# Every PR ships its own visual summary, committed at
+# 000-pr-visualization/<pr-number>.svg (the 000- prefix sorts it first in
+# GitHub's review file list, so the picture is the first thing a reviewer
+# sees). This check makes that a requirement.
+#
+# pull_request_target runs THIS file from the BASE branch, so the check exists
+# for every open PR the moment it lands on main — old branches don't need a
+# rebase to start reporting. The PR head is checked out as DATA only (an SVG
+# to look at); nothing from the head is ever executed, which is what makes
+# _target safe here. Keep it that way: never run scripts, build files, or
+# hooks from the head checkout in this workflow.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  visual-pr:
+    name: Visual PR attached
+    # Escape hatch for changes where a diagram is genuinely noise (bot bumps,
+    # typo fixes): label the PR `no-visual`. A skipped required job satisfies
+    # the ruleset, so the label is a real opt-out, not a dodge around a red X.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-visual') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the validator (base branch — trusted code)
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .claude/skills/visual-pr
+
+      - name: Check out the PR's visualization (head — data only)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          path: pr-head
+          sparse-checkout: 000-pr-visualization
+
+      - name: Require and validate the PR's SVG
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          FILE="pr-head/000-pr-visualization/${PR_NUMBER}.svg"
+          if [ ! -f "$FILE" ]; then
+            echo "::error::Missing 000-pr-visualization/${PR_NUMBER}.svg — every PR ships its visual summary (generate it with the visual-pr skill: .claude/skills/visual-pr/SKILL.md). For changes where a diagram is genuinely noise, label the PR 'no-visual'."
+            exit 1
+          fi
+          python3 .claude/skills/visual-pr/check_svg.py "$FILE"

--- a/000-pr-visualization/1811.svg
+++ b/000-pr-visualization/1811.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+    <marker id="arr-red" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#f7768e"/>
+    </marker>
+  </defs>
+
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1811 · Require a committed visual summary on every PR</text>
+
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Visual summaries lived one session in /tmp and depended on agent discipline; each PR now</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">commits its own SVG where review opens on it, enforced by a reusable checked requirement.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <!-- ==================== BEFORE ==================== -->
+  <g>
+    <rect x="80" y="250" width="840" height="160" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="104" y="292" font-size="26" fill="#7aa2f7">visual-pr skill → /tmp → agent-portal show</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">the SVG rendered once, inline in the portal session</text>
+    <text x="104" y="364" font-size="21" fill="#565f89">SKILL.md step 6: "keep the repo clean — do not commit generated SVGs"</text>
+  </g>
+
+  <line x1="500" y1="410" x2="500" y2="476" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+
+  <g>
+    <rect x="80" y="480" width="840" height="160" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="522" font-size="26" fill="#c0caf5">GitHub review sees none of it</text>
+    <text x="104" y="560" font-size="23" fill="#f7768e">the PR page is text only — the diagram never reaches the reviewer</text>
+    <text x="104" y="594" font-size="21" fill="#565f89">and the convention was AGENTS.md prose: skipping it failed nothing</text>
+  </g>
+
+  <line x1="500" y1="640" x2="500" y2="922" stroke="#f7768e" stroke-width="1.5" stroke-dasharray="4 6" marker-end="url(#arr-red)"/>
+
+  <g>
+    <rect x="80" y="930" width="840" height="150" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="976" font-size="26" fill="#c0caf5">coverage = agent discipline</text>
+    <text x="104" y="1014" font-size="23" fill="#f7768e">a forgotten visual is silent; the artifact evaporates with the session</text>
+    <text x="104" y="1048" font-size="21" fill="#565f89">no history, no enforcement, no reviewer-facing copy</text>
+  </g>
+
+  <!-- ==================== AFTER ==================== -->
+  <g>
+    <rect x="1065" y="250" width="860" height="160" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1089" y="292" font-size="26" fill="#9ece6a">000-pr-visualization/&lt;pr-number&gt;.svg — committed</text>
+    <text x="1089" y="330" font-size="23" fill="#a9b1d6">the 000- prefix sorts first in "Files changed" — review opens on it</text>
+    <text x="1089" y="364" font-size="21" fill="#565f89">merged SVGs accumulate as a visual history (~6-10 KB of text each)</text>
+  </g>
+
+  <line x1="1495" y1="410" x2="1495" y2="476" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <g>
+    <rect x="1065" y="480" width="860" height="230" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1089" y="522" font-size="26" fill="#9ece6a">meawoppl/visual-pr@v1 — reusable required check</text>
+    <text x="1089" y="560" font-size="23" fill="#a9b1d6">validates with check_svg.py against this repo's style artifact</text>
+    <text x="1089" y="594" font-size="23" fill="#a9b1d6">(.github/visual-pr/style.json) + injectable custom instructions</text>
+    <text x="1089" y="628" font-size="21" fill="#9ece6a">on failure it teaches the agent: spec + effective style + the exact</text>
+    <text x="1089" y="658" font-size="21" fill="#9ece6a">local check to run before pushing — the red X carries its own fix</text>
+    <text x="1089" y="692" font-size="21" fill="#565f89">pull_request_target: reports on every open PR at merge; head is data only</text>
+  </g>
+
+  <line x1="1495" y1="710" x2="1495" y2="922" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+  <text x="1520" y="820" font-size="21" fill="#565f89">no-visual label opts out — skipped job</text>
+  <text x="1520" y="850" font-size="21" fill="#565f89">still satisfies the ruleset</text>
+
+  <g>
+    <rect x="1065" y="930" width="860" height="150" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="976" font-size="26" fill="#c0caf5">every PR opens on its own picture</text>
+    <text x="1089" y="1014" font-size="23" fill="#9ece6a">this file is the first instance — the PR you are reviewing ships it</text>
+    <text x="1089" y="1048" font-size="21" fill="#565f89">any repo can adopt the action; the style and instructions are theirs</text>
+  </g>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">Not yet in pr-to-main's required list — 13 PRs are open and would strand; flip the ruleset when the queue drains. Dotfile paths still sort before 000-.</text>
+</svg>

--- a/000-pr-visualization/README.md
+++ b/000-pr-visualization/README.md
@@ -1,0 +1,21 @@
+# PR visualizations
+
+Every pull request ships a visual before/after summary of itself, committed
+here as `<pr-number>.svg` on the PR branch. The `000-` directory prefix sorts
+this path first in GitHub's review file list, so the picture is the first
+thing a reviewer sees when opening "Files changed".
+
+- **Generating one**: the `visual-pr` skill
+  ([.claude/skills/visual-pr/SKILL.md](../.claude/skills/visual-pr/SKILL.md))
+  reads the PR's actual diff, renders the SVG in the house style, and
+  validates it with `check_svg.py` — the same validator the CI check runs.
+- **Enforcement**: the `Visual PR attached` workflow
+  ([.github/workflows/visual-pr.yml](../.github/workflows/visual-pr.yml))
+  fails a PR that lacks its SVG or whose SVG fails validation.
+- **Opting out**: label a PR `no-visual` when a diagram is genuinely noise
+  (dependency bumps, typo fixes). The job skips, which satisfies the check.
+
+Merged SVGs accumulate here as a visual history of the repo's changes; they
+are small (6–10 KB of text each). One caveat on ordering: dotfile paths
+(`.claude/`, `.github/`) sort before `000-` in GitHub's list, so a PR touching
+those shows them first.

--- a/000-pr-visualization/README.md
+++ b/000-pr-visualization/README.md
@@ -11,7 +11,11 @@ thing a reviewer sees when opening "Files changed".
   validates it with `check_svg.py` — the same validator the CI check runs.
 - **Enforcement**: the `Visual PR attached` workflow
   ([.github/workflows/visual-pr.yml](../.github/workflows/visual-pr.yml))
-  fails a PR that lacks its SVG or whose SVG fails validation.
+  wires up the reusable [meawoppl/visual-pr](https://github.com/meawoppl/visual-pr)
+  action, which fails a PR that lacks its SVG or whose SVG fails validation —
+  and on failure emits the full authoring spec, this repo's style JSON
+  ([.github/visual-pr/style.json](../.github/visual-pr/style.json)), and the
+  exact local check to run.
 - **Opting out**: label a PR `no-visual` when a diagram is genuinely noise
   (dependency bumps, typo fixes). The job skips, which satisfies the check.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1072,11 +1072,16 @@ use uuid::Uuid;
 - **Titles**: describe the change, not the ticket. Don't reference issue/PR numbers — they're noise in the title.
 - **Bodies**: focus on *what* the change does and *why*. Keep it concise — no commit-by-commit play-by-play.
 - **No attribution footer**: don't add "Generated with Claude Code" (or similar) to PR titles or bodies.
-- **Visual PR summary**: when a PR is ready (right after `gh pr create`), invoke
-  the `visual-pr` skill (`.claude/skills/visual-pr/SKILL.md`). It reads the
-  actual diff and surrounding code, renders a before/after SVG in the house
-  style, validates it, and shows it inline via `agent-portal show`. Generated
-  SVGs live in `/tmp` — never commit them.
+- **Visual PR summary (required)**: when a PR is ready (right after
+  `gh pr create`), invoke the `visual-pr` skill
+  (`.claude/skills/visual-pr/SKILL.md`). It reads the actual diff and
+  surrounding code, renders a before/after SVG in the house style, validates
+  it, and **commits it to the PR branch as
+  `000-pr-visualization/<pr-number>.svg`** (the `000-` prefix sorts it first
+  in GitHub's review file list). The `Visual PR attached` CI check fails a PR
+  without a valid SVG; label a PR `no-visual` only when a diagram is genuinely
+  noise (dependency bumps, typo fixes). Also show it inline via
+  `agent-portal show`.
 
 ## SHIP Workflow
 


### PR DESCRIPTION
Reframes visual PRs as a **repo convention with a required check**, per discussion:

- Every PR commits its own summary at `000-pr-visualization/<pr-number>.svg`. The `000-` prefix sorts the image first in GitHub's "Files changed" list, so review opens on the picture. (Caveat: dotfile paths like `.github/` sort even earlier, so PRs touching those show them first.)
- A new **`Visual PR attached`** check requires the file and validates it with the same `check_svg.py` the skill uses (palette, canvas, overflow heuristics). It runs on `pull_request_target`, i.e. from the *base* branch — so it reports on every open PR the moment this merges, with no rebases needed. The PR head is checked out as data only (sparse, never executed), which is what keeps `_target` safe.
- **Escape hatch**: label a PR `no-visual` for changes where a diagram is genuinely noise (dependency bumps, typo fixes). The job skips, and a skipped required job satisfies the ruleset.
- The `visual-pr` skill and AGENTS.md now commit the SVG to the PR branch (instead of `/tmp`) and still show it inline in the session. Merged SVGs accumulate in `000-pr-visualization/` as a visual history (~6–10 KB of text each).

**Not done here**: adding `Visual PR attached` to the `pr-to-main` ruleset's required checks. There are 13 open PRs; flipping the ruleset now would gate them on a check they can satisfy only after this lands (and after they add SVGs or the label). Flip it once the queue drains.
