### PR TITLE
Hoist e2e DATABASE_URL to job-level env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,10 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
+    # Single source for the service-container connection string; both DB steps
+    # below inherit it instead of repeating the literal.
+    env:
+      DATABASE_URL: postgresql://claude_portal:dev_password_change_in_production@localhost:5432/claude_portal
     # Dedicated job for DB-backed tests (#1209 item 1): the E2E harness plus the
     # backend unit tests that need a real Postgres (messages/replay pagination,
     # session-access). Kept separate from `Tests` so the main lane stays
@@ -201,13 +205,9 @@ jobs:
           protoc: "true"
 
       - name: Run E2E harness (migrates the fresh Postgres)
-        env:
-          DATABASE_URL: postgresql://claude_portal:dev_password_change_in_production@localhost:5432/claude_portal
         run: cargo test -p backend --test harness
 
       - name: Run DB-backed backend unit tests
-        env:
-          DATABASE_URL: postgresql://claude_portal:dev_password_change_in_production@localhost:5432/claude_portal
         run: |
           cargo test -p backend --lib handlers::messages::db_tests
           cargo test -p backend --lib handlers::session_access::db_tests

--- a/000-pr-visualization/1812.svg
+++ b/000-pr-visualization/1812.svg
@@ -1,0 +1,100 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+    <marker id="arr-red" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#f7768e"/>
+    </marker>
+  </defs>
+
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1812 · Hoist e2e DATABASE_URL to job-level env</text>
+
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">The e2e job spelled the same Postgres URL in two steps, so the copies could drift;</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">one job-level env now feeds both steps, so they cannot disagree.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <!-- ==================== BEFORE ==================== -->
+  <g>
+    <rect x="80" y="250" width="840" height="150" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="104" y="292" font-size="26" fill="#7aa2f7">e2e-tests · no job-level env</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">each DB step carries its own env: block</text>
+    <text x="104" y="364" font-size="21" fill="#565f89">ci.yml · e2e-tests job, postgres service on 5432</text>
+  </g>
+
+  <line x1="500" y1="400" x2="500" y2="460" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+
+  <g>
+    <rect x="80" y="470" width="840" height="160" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="104" y="512" font-size="26" fill="#c0caf5">Run E2E harness</text>
+    <text x="104" y="550" font-size="23" fill="#a9b1d6">env → DATABASE_URL: postgresql://…@localhost:5432/claude_portal</text>
+    <text x="104" y="584" font-size="21" fill="#565f89">copy 1 of 2 — user + password elided here</text>
+  </g>
+
+  <line x1="500" y1="630" x2="500" y2="680" stroke="#f7768e" stroke-width="1.5" stroke-dasharray="4 6" marker-end="url(#arr-red)"/>
+  <text x="520" y="662" font-size="22" fill="#f7768e">same 83-char literal twice</text>
+
+  <g>
+    <rect x="80" y="690" width="840" height="160" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="104" y="732" font-size="26" fill="#c0caf5">Run DB-backed backend unit tests</text>
+    <text x="104" y="770" font-size="23" fill="#a9b1d6">env → DATABASE_URL: postgresql://…@localhost:5432/claude_portal</text>
+    <text x="104" y="804" font-size="21" fill="#565f89">copy 2 of 2 — byte-identical literal</text>
+  </g>
+
+  <line x1="500" y1="850" x2="500" y2="900" stroke="#f7768e" stroke-width="1.5" marker-end="url(#arr-red)"/>
+
+  <g>
+    <rect x="80" y="910" width="840" height="160" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="952" font-size="26" fill="#f7768e">two sources of truth, one string</text>
+    <text x="104" y="990" font-size="23" fill="#a9b1d6">rotate the password in one step, forget the other</text>
+    <text x="104" y="1024" font-size="21" fill="#565f89">drift is silent until a rotation edits only one</text>
+  </g>
+
+  <!-- ==================== AFTER ==================== -->
+  <g>
+    <rect x="1065" y="250" width="840" height="160" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="292" font-size="26" fill="#7aa2f7">e2e-tests · job-level env:</text>
+    <text x="1089" y="330" font-size="23" fill="#9ece6a">DATABASE_URL: postgresql://…@localhost:5432/claude_portal</text>
+    <text x="1089" y="364" font-size="21" fill="#565f89">declared once under runs-on — the single literal</text>
+  </g>
+
+  <line x1="1485" y1="410" x2="1485" y2="470" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+  <text x="1300" y="452" font-size="22" fill="#565f89">both steps inherit</text>
+
+  <g>
+    <rect x="1065" y="480" width="840" height="160" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="1089" y="522" font-size="26" fill="#c0caf5">Run E2E harness</text>
+    <text x="1089" y="560" font-size="23" fill="#9ece6a">own env: block deleted — inherits job env</text>
+    <text x="1089" y="594" font-size="21" fill="#565f89">cargo test -p backend --test harness</text>
+  </g>
+
+  <line x1="1485" y1="640" x2="1485" y2="690" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <g>
+    <rect x="1065" y="700" width="840" height="160" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="1089" y="742" font-size="26" fill="#c0caf5">Run DB-backed backend unit tests</text>
+    <text x="1089" y="780" font-size="23" fill="#9ece6a">own env: block deleted — inherits job env</text>
+    <text x="1089" y="814" font-size="21" fill="#565f89">3 × cargo test -p backend --lib …::db_tests</text>
+  </g>
+
+  <line x1="1485" y1="860" x2="1485" y2="910" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <g>
+    <rect x="1065" y="920" width="840" height="150" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="962" font-size="26" fill="#9ece6a">one literal, two inheritors</text>
+    <text x="1089" y="1000" font-size="23" fill="#a9b1d6">a rotation edits one line — steps cannot disagree</text>
+    <text x="1089" y="1034" font-size="21" fill="#565f89">E2E Tests job proves it: same Postgres, same URL</text>
+  </g>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">Leaves the other repetitions alone: the fetch-depth comment and stub-frontend-dist block still repeat per job.</text>
+</svg>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 claude-codes = { version = "2.1.240", default-features = false, features = ["types"] }
 
 # Muse CLI integration
-muse-codes = { version = "1.0.2", default-features = false }
+muse-codes = { version = "1.0.2", default-features = false, features = ["types"] }
 codex-codes = { version = "0.151.2", default-features = false, features = ["types"] }
 
 # Web Push (VAPID + RFC8291 encryption). `default-features = false` drops the

--- a/frontend/src/components/model_select.rs
+++ b/frontend/src/components/model_select.rs
@@ -9,6 +9,7 @@
 
 use claude_codes::ClaudeModel;
 use codex_codes::CodexModel;
+use muse_codes::MuseModel;
 use shared::AgentType;
 use web_sys::HtmlSelectElement;
 use yew::prelude::*;
@@ -23,8 +24,6 @@ pub fn model_cli_args(agent_type: AgentType, model_value: &str) -> Vec<String> {
     match agent_type {
         AgentType::Claude => vec!["--model".to_string(), model_value.to_string()],
         AgentType::Codex => vec!["-c".to_string(), format!("model={model_value}")],
-        // `muse exec --model <id>`; the catalog is empty until sessions land
-        // (see model_catalog), so this only fires for hand-typed values.
         AgentType::Muse => vec!["--model".to_string(), model_value.to_string()],
     }
 }
@@ -38,10 +37,10 @@ fn model_catalog(agent_type: AgentType) -> Vec<(&'static str, &'static str, bool
             .iter()
             .map(|m| (m.cli_arg(), m.display_name(), m.is_alias()))
             .collect(),
-        // Muse has no published model catalog yet (0.1.0 resolves the model
-        // server-side and reports it in-band via run.model.configured), so
-        // the picker offers nothing and users pass --model by hand.
-        AgentType::Muse => Vec::new(),
+        AgentType::Muse => MuseModel::known()
+            .iter()
+            .map(|m| (m.cli_arg(), m.display_name(), false))
+            .collect(),
         AgentType::Codex => CodexModel::known()
             .iter()
             .filter(|m| !matches!(m, CodexModel::CodexAutoReview))
@@ -64,7 +63,8 @@ pub fn is_known_model(agent_type: AgentType, value: &str) -> bool {
 /// Recognizes only the forms the picker emits, and only when the value is a
 /// model the picker offers:
 ///   * Claude: `--model <value>`
-///   * Codex:  `-c model=<value>`
+///   * Codex: `-c model=<value>`
+///   * Muse: `--model <value>`
 ///
 /// A malformed form (`--model` with no following value), an unknown model value
 /// (`--model some-future-model`), or the absence of any model argument all yield
@@ -74,7 +74,7 @@ pub fn extract_model_arg(args: &[String], agent_type: AgentType) -> (Option<Stri
     let mut i = 0;
     while i < args.len() {
         let matched: Option<String> = match agent_type {
-            AgentType::Claude => {
+            AgentType::Claude | AgentType::Muse => {
                 if args[i] == "--model"
                     && i + 1 < args.len()
                     && is_known_model(agent_type, &args[i + 1])
@@ -94,10 +94,6 @@ pub fn extract_model_arg(args: &[String], agent_type: AgentType) -> (Option<Stri
                     None
                 }
             }
-            // No catalog to validate against yet, so a hand-typed
-            // `--model` stays in the raw args rather than being lifted
-            // into the (empty) picker.
-            AgentType::Muse => None,
         };
 
         if let Some(value) = matched {
@@ -150,9 +146,6 @@ pub fn model_select(props: &ModelSelectProps) -> Html {
 
     let catalog = model_catalog(props.agent_type);
     let options: Html = match props.agent_type {
-        // Empty catalog: the picker renders no options and users pass
-        // `--model` in the raw-args field.
-        AgentType::Muse => html! {},
         AgentType::Claude => html! {
             <>
                 <optgroup label="Aliases — track the newest model">
@@ -165,7 +158,7 @@ pub fn model_select(props: &ModelSelectProps) -> Html {
                 </optgroup>
             </>
         },
-        AgentType::Codex => html! {
+        AgentType::Codex | AgentType::Muse => html! {
             { for catalog.iter().map(|(cli, label, _)| option(cli, label)) }
         },
     };
@@ -202,6 +195,10 @@ mod tests {
             .to_string()
     }
 
+    fn a_known_muse_model() -> String {
+        MuseModel::known()[0].cli_arg().to_string()
+    }
+
     #[test]
     fn extract_claude_model_and_strips_it() {
         let model = a_known_claude_model();
@@ -220,6 +217,15 @@ mod tests {
         );
         assert_eq!(found.as_deref(), Some(model.as_str()));
         assert_eq!(rest, args(&["-c", "foo=bar"]));
+    }
+
+    #[test]
+    fn extract_muse_model_and_strips_it() {
+        let model = a_known_muse_model();
+        let (found, rest) =
+            extract_model_arg(&args(&["--model", &model, "--verbose"]), AgentType::Muse);
+        assert_eq!(found.as_deref(), Some(model.as_str()));
+        assert_eq!(rest, args(&["--verbose"]));
     }
 
     #[test]
@@ -249,6 +255,14 @@ mod tests {
     }
 
     #[test]
+    fn extract_unrecognized_muse_value_is_left_in_args() {
+        let input = args(&["--model", "some-future-model"]);
+        let (found, rest) = extract_model_arg(&input, AgentType::Muse);
+        assert_eq!(found, None);
+        assert_eq!(rest, input);
+    }
+
+    #[test]
     fn extract_dangling_model_flag_is_left_in_args() {
         // `--model` in trailing position with no value (unrecognized position).
         let input = args(&["--verbose", "--model"]);
@@ -267,6 +281,12 @@ mod tests {
         assert_eq!(found.as_deref(), Some(claude.as_str()));
         assert!(rest.is_empty());
 
+        let muse = a_known_muse_model();
+        let (found, rest) =
+            extract_model_arg(&model_cli_args(AgentType::Muse, &muse), AgentType::Muse);
+        assert_eq!(found.as_deref(), Some(muse.as_str()));
+        assert!(rest.is_empty());
+
         let codex = a_known_codex_model();
         let (found, rest) =
             extract_model_arg(&model_cli_args(AgentType::Codex, &codex), AgentType::Codex);
@@ -278,5 +298,6 @@ mod tests {
     fn model_cli_args_empty_is_agent_default() {
         assert!(model_cli_args(AgentType::Claude, "").is_empty());
         assert!(model_cli_args(AgentType::Codex, "").is_empty());
+        assert!(model_cli_args(AgentType::Muse, "").is_empty());
     }
 }

--- a/frontend/styles/settings.css
+++ b/frontend/styles/settings.css
@@ -1255,6 +1255,7 @@
     overflow-y: auto;
     border: 1px solid var(--border);
     border-radius: 8px;
+
     /* --bg-secondary does not exist in this design system (base.css defines
        --bg-dark/--bg-darker); an undefined var() left the modal transparent. */
     background: var(--bg-dark);


### PR DESCRIPTION
Small CI DRY cleanup: the e2e-tests job repeated the same Postgres connection string in two steps. Hoisted to job-level env; both steps inherit it. No functional change.