### PR TITLE
Tell forked agents they are child sessions

### DIFF
--- a/000-pr-visualization/1814.svg
+++ b/000-pr-visualization/1814.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+  <defs>
+    <marker id="arrow-muted" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arrow-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1814 · Tell forked agents they are child sessions</text>
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">A fork without a divergence prompt started silently; every child now receives lineage and role context,</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">while an optional UI prompt replaces only the default request to await the user.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="260" width="840" height="155" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="108" y="305" font-size="26" fill="#7aa2f7">ForkSessionRequest.divergence_prompt</text>
+    <text x="108" y="345" font-size="23" fill="#a9b1d6">None or blank</text>
+    <text x="108" y="382" font-size="21" fill="#565f89">the normal default from the UI</text>
+  </g>
+  <line x1="500" y1="415" x2="500" y2="505" stroke="#565f89" stroke-width="2" marker-end="url(#arrow-muted)"/>
+  <g>
+    <rect x="80" y="515" width="840" height="175" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+    <text x="108" y="562" font-size="26" fill="#c0caf5">No input enqueued</text>
+    <text x="108" y="605" font-size="23" fill="#f7768e">the child inherits history with no explanation of the split</text>
+    <text x="108" y="646" font-size="21" fill="#565f89">source identity, child role, and next action are all absent</text>
+  </g>
+  <line x1="500" y1="690" x2="500" y2="835" stroke="#f7768e" stroke-width="2" stroke-dasharray="5 7" marker-end="url(#arrow-muted)"/>
+  <g>
+    <rect x="80" y="845" width="840" height="165" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="108" y="892" font-size="26" fill="#c0caf5">Ambiguous continuation</text>
+    <text x="108" y="935" font-size="23" fill="#a9b1d6">the agent may act as though it is still the source thread</text>
+    <text x="108" y="976" font-size="21" fill="#565f89">a custom prompt worked, but supplying one was required</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="260" width="860" height="155" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="1093" y="305" font-size="26" fill="#7aa2f7">fork_child_notice(source_name, source_id, prompt)</text>
+    <text x="1093" y="345" font-size="23" fill="#a9b1d6">called for every accepted fork</text>
+    <text x="1093" y="382" font-size="21" fill="#565f89">the existing optional API field remains unchanged</text>
+  </g>
+  <line x1="1495" y1="415" x2="1495" y2="505" stroke="#9ece6a" stroke-width="2" marker-end="url(#arrow-green)"/>
+  <g>
+    <rect x="1065" y="515" width="860" height="240" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1093" y="562" font-size="26" fill="#9ece6a">One durable fork notice is enqueued</text>
+    <text x="1093" y="605" font-size="23" fill="#a9b1d6">identifies source session name + UUID</text>
+    <text x="1093" y="646" font-size="23" fill="#a9b1d6">states “You are the child session”</text>
+    <text x="1093" y="687" font-size="23" fill="#a9b1d6">states the source thread continues independently</text>
+    <text x="1093" y="728" font-size="21" fill="#565f89">set_last_input_sender records the synthetic “Fork notice”</text>
+  </g>
+  <line x1="1495" y1="755" x2="1495" y2="835" stroke="#9ece6a" stroke-width="2" marker-end="url(#arrow-green)"/>
+  <g>
+    <rect x="1065" y="845" width="860" height="165" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1093" y="892" font-size="26" fill="#c0caf5">Direction is explicit</text>
+    <text x="1093" y="935" font-size="23" fill="#9ece6a">blank → await the user; supplied → use the divergence prompt</text>
+    <text x="1093" y="976" font-size="21" fill="#565f89">custom direction never removes lineage or child-role context</text>
+  </g>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">Scope: the notice is an ordinary queued user input; this PR does not add a new protocol role or enable Muse forking.</text>
+</svg>

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -343,26 +343,22 @@ pub async fn fork_session(
             .set(sessions::fork_create_worktree.eq(true))
             .execute(&mut conn)?;
     }
-    if let Some(prompt) = req
-        .divergence_prompt
-        .as_deref()
-        .map(str::trim)
-        .filter(|prompt| !prompt.is_empty())
-    {
-        app_state.session_manager.set_last_input_sender(
-            session_id,
-            user_id,
-            "Fork divergence prompt".to_string(),
-        );
-        app_state.session_manager.enqueue_input(
-            &app_state.db_pool,
-            &session_id.to_string(),
-            session_id,
-            serde_json::Value::String(prompt.to_string()),
-            None,
-            None,
-        );
-    }
+    let fork_notice = fork_child_notice(
+        &source.session_name,
+        source_id,
+        req.divergence_prompt.as_deref(),
+    );
+    app_state
+        .session_manager
+        .set_last_input_sender(session_id, user_id, "Fork notice".to_string());
+    app_state.session_manager.enqueue_input(
+        &app_state.db_pool,
+        &session_id.to_string(),
+        session_id,
+        serde_json::Value::String(fork_notice),
+        None,
+        None,
+    );
     app_state
         .session_manager
         .register_launch_session(request_id, session_id);
@@ -420,6 +416,21 @@ fn apply_model_override(args: Vec<String>, agent_type: AgentType, model: String)
         AgentType::Muse => {}
     }
     next
+}
+
+fn fork_child_notice(
+    source_name: &str,
+    source_id: Uuid,
+    divergence_prompt: Option<&str>,
+) -> String {
+    let direction = divergence_prompt
+        .map(str::trim)
+        .filter(|prompt| !prompt.is_empty())
+        .unwrap_or("Please await new directions from the user.");
+    format!(
+        "This session was forked from Agent Portal session \"{source_name}\" ({source_id}). \
+         You are the child session, and the source thread is continuing independently. {direction}"
+    )
 }
 
 fn resolve_launch_target(
@@ -982,5 +993,30 @@ mod tests {
             "new".into(),
         );
         assert_eq!(codex, ["--yolo", "-c", "model=new"]);
+    }
+
+    #[test]
+    fn fork_notice_identifies_child_and_defaults_to_waiting() {
+        let source_id = Uuid::from_u128(0x11111111222233334444555555555555);
+        assert_eq!(
+            fork_child_notice("research", source_id, None),
+            "This session was forked from Agent Portal session \"research\" \
+             (11111111-2222-3333-4444-555555555555). You are the child session, and the \
+             source thread is continuing independently. Please await new directions from the user."
+        );
+    }
+
+    #[test]
+    fn divergence_prompt_replaces_only_default_direction() {
+        let source_id = Uuid::nil();
+        let notice = fork_child_notice(
+            "implementation",
+            source_id,
+            Some("  Explore the alternate storage design.  "),
+        );
+        assert!(notice.contains("You are the child session"));
+        assert!(notice.contains("source thread is continuing independently"));
+        assert!(notice.ends_with("Explore the alternate storage design."));
+        assert!(!notice.contains("await new directions"));
     }
 }


### PR DESCRIPTION
Every fork now begins with an injected child-session notice that identifies the source session and explains that its thread continues independently.

When the UI supplies a divergence prompt, it replaces only the default request to await user directions; lineage and child-role context remain present.

Includes focused tests for default and custom directions.