### PR TITLE
Exclude thinking markers from render budget

### DIFF
--- a/000-pr-visualization/1815.svg
+++ b/000-pr-visualization/1815.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect width="2000" height="1200" fill="#16161e"/>
+  <defs>
+    <marker id="red-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#f7768e"/></marker>
+    <marker id="green-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/></marker>
+  </defs>
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1815 · Exclude thinking markers from render budget</text>
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Bodyless Claude thinking markers consumed the 100-record DOM budget; weighted retention now</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">charges only substantive messages, preserving history while keeping the same rendered-content cap.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666"/>
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="255" width="840" height="175" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="108" y="302" font-size="26" fill="#7aa2f7">retain_newest_items</text>
+    <text x="108" y="345" font-size="23" fill="#a9b1d6">messages.len() &gt; MAX_MESSAGES_PER_SESSION</text>
+    <text x="108" y="388" font-size="21" fill="#565f89">every wire record had identical cost: 1</text>
+  </g>
+  <line x1="500" y1="430" x2="500" y2="510" stroke="#f7768e" stroke-width="2" marker-end="url(#red-arrow)"/>
+  <g>
+    <rect x="80" y="520" width="840" height="240" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+    <text x="108" y="567" font-size="26" fill="#c0caf5">One Claude turn can spend most slots</text>
+    <text x="108" y="612" font-size="23" fill="#f7768e">system / thinking_tokens → 1 slot each</text>
+    <text x="108" y="655" font-size="23" fill="#a9b1d6">the renderer later collapses the whole run into one chip</text>
+    <text x="108" y="698" font-size="21" fill="#565f89">compact output, but earlier user and assistant records are gone</text>
+    <text x="108" y="735" font-size="21" fill="#565f89">REST, reconnect, and live paths all enforce the same raw count</text>
+  </g>
+  <g>
+    <rect x="80" y="855" width="840" height="155" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="108" y="902" font-size="26" fill="#c0caf5">100 records ≠ 100 useful messages</text>
+    <text x="108" y="946" font-size="23" fill="#f7768e">bodyless accounting crowds substantive history out</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="255" width="860" height="175" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1093" y="302" font-size="26" fill="#7aa2f7">retain_newest_items_by_cost</text>
+    <text x="1093" y="345" font-size="23" fill="#a9b1d6">counts_toward_render_limit(&amp;message.content)</text>
+    <text x="1093" y="388" font-size="21" fill="#565f89">one retention primitive shared by all three ingestion paths</text>
+  </g>
+  <line x1="1495" y1="430" x2="1495" y2="510" stroke="#9ece6a" stroke-width="2" marker-end="url(#green-arrow)"/>
+  <g>
+    <rect x="1065" y="520" width="860" height="240" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1093" y="567" font-size="26" fill="#9ece6a">Cost follows rendered weight</text>
+    <text x="1093" y="612" font-size="23" fill="#a9b1d6">Claude system / thinking_tokens → 0</text>
+    <text x="1093" y="655" font-size="23" fill="#a9b1d6">every other valid, unknown, or malformed frame → 1</text>
+    <text x="1093" y="698" font-size="21" fill="#565f89">free markers stay between the newest 100 substantive messages</text>
+    <text x="1093" y="735" font-size="21" fill="#565f89">markers older than that retained tail are discarded as orphans</text>
+  </g>
+  <g>
+    <rect x="1065" y="855" width="860" height="155" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1093" y="902" font-size="26" fill="#c0caf5">100 substantive messages remain</text>
+    <text x="1093" y="946" font-size="23" fill="#9ece6a">thinking chips no longer evict useful transcript context</text>
+  </g>
+  <text x="55" y="1172" font-size="22" fill="#565f89">Scope: assistant thinking blocks with visible text still count; only bodyless Claude thinking-token markers are free.</text>
+</svg>

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -38,8 +38,8 @@ use super::permission_handler::{
     build_permission_response, PermissionHandler, PermissionResponseKind,
 };
 use super::state::{
-    insert_turn_metrics_sorted, push_message_with_limit, retain_newest_items,
-    sort_turn_metrics_by_start,
+    counts_toward_render_limit, insert_turn_metrics_sorted, push_message_with_cost_limit,
+    retain_newest_items_by_cost, sort_turn_metrics_by_start,
 };
 use super::tasks_panel::{derive_task_events, TasksInbound, TasksPanel};
 use super::types::{PendingPermission, WsSender, MAX_MESSAGES_PER_SESSION};
@@ -812,7 +812,11 @@ impl SessionView {
                 // live-output cleanup path.
                 self.muse_live_turn = MuseLiveTurn::default();
                 self.messages.extend(messages);
-                retain_newest_items(&mut self.messages, MAX_MESSAGES_PER_SESSION);
+                retain_newest_items_by_cost(
+                    &mut self.messages,
+                    MAX_MESSAGES_PER_SESSION,
+                    |message| counts_toward_render_limit(&message.content),
+                );
                 // Set the reconnect-replay watermark to the server-assigned
                 // timestamp of the latest message in the batch (closes
                 // #784). Empty batches (or a pre-#784 backend that didn't
@@ -1081,9 +1085,9 @@ impl SessionView {
         mut messages: Vec<MessageData>,
         last_timestamp: Option<String>,
     ) {
-        if messages.len() > MAX_MESSAGES_PER_SESSION {
-            retain_newest_items(&mut messages, MAX_MESSAGES_PER_SESSION);
-        }
+        retain_newest_items_by_cost(&mut messages, MAX_MESSAGES_PER_SESSION, |message| {
+            counts_toward_render_limit(&message.content)
+        });
         let session_id = ctx.props().session.id;
         self.dispatch_tasks(TasksInbound::ClearForReplay);
         for msg in &messages {
@@ -1216,7 +1220,12 @@ impl SessionView {
         self.ephemeral_status = None;
         self.muse_live_turn.clear_if_terminal(&output.content);
 
-        push_message_with_limit(&mut self.messages, output, MAX_MESSAGES_PER_SESSION);
+        push_message_with_cost_limit(
+            &mut self.messages,
+            output,
+            MAX_MESSAGES_PER_SESSION,
+            |message| counts_toward_render_limit(&message.content),
+        );
         true
     }
 

--- a/frontend/src/pages/dashboard/session_view/state.rs
+++ b/frontend/src/pages/dashboard/session_view/state.rs
@@ -6,22 +6,58 @@
 
 use shared::TurnMetrics;
 
-/// Trim a newest-first-retained message buffer to `max_len`.
+/// Trim a chronological buffer to at most `max_cost` counted items.
 ///
-/// `SessionView` appends messages in chronological order, so retaining the
-/// tail keeps the newest rows and drops only old history.
-pub(super) fn retain_newest_items<T>(items: &mut Vec<T>, max_len: usize) {
-    if items.len() > max_len {
-        let excess = items.len() - max_len;
-        items.drain(0..excess);
+/// Items for which `counts_toward_limit` is false remain alongside the newest
+/// counted tail without displacing it. Free items older than that tail are
+/// discarded too, preventing detached metadata from growing without bound.
+pub(super) fn retain_newest_items_by_cost<T>(
+    items: &mut Vec<T>,
+    max_cost: usize,
+    counts_toward_limit: impl Fn(&T) -> bool,
+) {
+    let excess = items
+        .iter()
+        .filter(|item| counts_toward_limit(item))
+        .count()
+        .saturating_sub(max_cost);
+    if excess == 0 {
+        return;
     }
+
+    let mut counted = 0;
+    let keep_from = items
+        .iter()
+        .position(|item| {
+            if counts_toward_limit(item) {
+                counted += 1;
+            }
+            counted == excess
+        })
+        .map_or(items.len(), |index| index + 1);
+    items.drain(0..keep_from);
 }
 
 /// Append one live message and apply the same retention rule as history
 /// hydration and replay batches.
-pub(super) fn push_message_with_limit<T>(messages: &mut Vec<T>, message: T, max_len: usize) {
+pub(super) fn push_message_with_cost_limit<T>(
+    messages: &mut Vec<T>,
+    message: T,
+    max_cost: usize,
+    counts_toward_limit: impl Fn(&T) -> bool,
+) {
     messages.push(message);
-    retain_newest_items(messages, max_len);
+    retain_newest_items_by_cost(messages, max_cost, counts_toward_limit);
+}
+
+/// Claude emits many bodyless cumulative thinking-token markers during one
+/// turn. They render as one compact chip and therefore cost nothing against
+/// the live DOM budget.
+pub(super) fn counts_toward_render_limit(content: &str) -> bool {
+    !matches!(
+        serde_json::from_str::<shared::ClaudeOutput>(content),
+        Ok(shared::ClaudeOutput::System(message)) if message.is_thinking_tokens()
+    )
 }
 
 /// Insert one live `TurnMetrics` into the buffer, preserving `started_at ASC`
@@ -76,10 +112,10 @@ mod tests {
     }
 
     #[test]
-    fn retain_newest_items_keeps_tail() {
+    fn retain_newest_items_keeps_counted_tail() {
         let mut messages = vec!["old".to_string(), "middle".to_string(), "new".to_string()];
 
-        retain_newest_items(&mut messages, 2);
+        retain_newest_items_by_cost(&mut messages, 2, |_| true);
 
         assert_eq!(messages, vec!["middle", "new"]);
     }
@@ -88,7 +124,7 @@ mod tests {
     fn retain_newest_items_noops_when_within_limit() {
         let mut messages = vec!["one".to_string(), "two".to_string()];
 
-        retain_newest_items(&mut messages, 2);
+        retain_newest_items_by_cost(&mut messages, 2, |_| true);
 
         assert_eq!(messages, vec!["one", "two"]);
     }
@@ -97,9 +133,38 @@ mod tests {
     fn push_message_with_limit_appends_then_trims_oldest() {
         let mut messages = vec!["one".to_string(), "two".to_string()];
 
-        push_message_with_limit(&mut messages, "three".to_string(), 2);
+        push_message_with_cost_limit(&mut messages, "three".to_string(), 2, |_| true);
 
         assert_eq!(messages, vec!["two", "three"]);
+    }
+
+    #[test]
+    fn free_items_do_not_displace_counted_history() {
+        let mut messages = vec!["old", "free-a", "middle", "free-b", "new"];
+
+        retain_newest_items_by_cost(&mut messages, 2, |message| !message.starts_with("free"));
+
+        assert_eq!(messages, vec!["free-a", "middle", "free-b", "new"]);
+    }
+
+    #[test]
+    fn free_items_before_the_retained_tail_are_discarded() {
+        let mut messages = vec!["orphan-free", "old", "middle", "new"];
+
+        retain_newest_items_by_cost(&mut messages, 2, |message| !message.ends_with("free"));
+
+        assert_eq!(messages, vec!["middle", "new"]);
+    }
+
+    #[test]
+    fn only_claude_thinking_token_markers_are_free() {
+        let thinking = r#"{"type":"system","subtype":"thinking_tokens","estimated_tokens":150,"estimated_tokens_delta":50,"session_id":"01890000-0000-7000-8000-000000000001","uuid":"01890000-0000-7000-8000-000000000002"}"#;
+
+        assert!(!counts_toward_render_limit(thinking));
+        assert!(counts_toward_render_limit(
+            r#"{"type":"system","subtype":"init","session_id":"s"}"#
+        ));
+        assert!(counts_toward_render_limit("not json"));
     }
 
     #[test]


### PR DESCRIPTION
Claude emits many bodyless `system/thinking_tokens` markers that collapse into one compact chip, but each previously consumed one of the frontend's 100 rendered-message slots.

Apply one weighted retention rule across REST hydration, reconnect replay, and live appends: substantive messages count toward the cap; thinking-token markers do not. The cutoff remains anchored to the oldest retained substantive message so unrelated ancient markers are not retained.

Includes focused accounting and classifier regressions.