### PR TITLE
Pin visual PR action contract

### DIFF
--- a/.github/workflows/visual-pr.yml
+++ b/.github/workflows/visual-pr.yml
@@ -35,7 +35,9 @@ jobs:
           path: pr-head
           sparse-checkout: 000-pr-visualization
 
-      - uses: meawoppl/visual-pr@v1
+      # Pin the executable action: a moving v1 tag changed its path contract
+      # after this workflow landed, making every PR's required check fail.
+      - uses: meawoppl/visual-pr@669787fdc7aaf7afc3975dbbab5af65ee50da6da
         with:
           head-path: pr-head
           style: .github/visual-pr/style.json


### PR DESCRIPTION
The mutable `meawoppl/visual-pr@v1` tag changed its expected directory and filename contract after this workflow landed. The workflow still sparsely checks out `000-pr-visualization`, so every required visual check became impossible to satisfy.

Pin the last action commit matching the repository's documented `000-pr-visualization/<number>.svg` contract. This restores the required gate and prevents upstream tag movement from changing executable CI behavior without review.