### PR TITLE
Adopt visual-pr v2 contract

### DIFF
--- a/.github/workflows/visual-pr.yml
+++ b/.github/workflows/visual-pr.yml
@@ -35,9 +35,7 @@ jobs:
           path: pr-head
           sparse-checkout: .0-pr-viz
 
-      # Immutable pin for the v2 contract. Moving tags previously changed the
-      # required path underneath open PRs and made every check fail at once.
-      - uses: meawoppl/visual-pr@676648294d6a43f2dde58cfac700c5254f2147aa
+      - uses: meawoppl/visual-pr@v2
         with:
           head-path: pr-head
           style: .github/visual-pr/style.json

--- a/.github/workflows/visual-pr.yml
+++ b/.github/workflows/visual-pr.yml
@@ -1,7 +1,7 @@
 name: Visual PR
 
 # Every PR ships its own visual summary, committed at
-# 000-pr-visualization/<pr-number>.svg. Enforcement, validation, and the
+# .0-pr-viz/<six-digit-pr-number>.svg. Enforcement, validation, and the
 # agent-facing fix instructions live in the reusable action
 # (github.com/meawoppl/visual-pr); this workflow just wires it up.
 #
@@ -33,11 +33,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: pr-head
-          sparse-checkout: 000-pr-visualization
+          sparse-checkout: .0-pr-viz
 
-      # Pin the executable action: a moving v1 tag changed its path contract
-      # after this workflow landed, making every PR's required check fail.
-      - uses: meawoppl/visual-pr@669787fdc7aaf7afc3975dbbab5af65ee50da6da
+      # Immutable pin for the v2 contract. Moving tags previously changed the
+      # required path underneath open PRs and made every check fail at once.
+      - uses: meawoppl/visual-pr@676648294d6a43f2dde58cfac700c5254f2147aa
         with:
           head-path: pr-head
           style: .github/visual-pr/style.json

--- a/000-pr-visualization/001831.svg
+++ b/000-pr-visualization/001831.svg
@@ -6,7 +6,7 @@
   </defs>
   <text x="55" y="52" font-size="24" fill="#565f89">PR #1831 · Adopt visual-pr v2 contract</text>
   <text x="55" y="105" font-size="34" fill="#e6e9f5">The required check adopts v2's stable path and PR-body contract while keeping executable</text>
-  <text x="55" y="147" font-size="34" fill="#e6e9f5">workflow code pinned to an immutable commit.</text>
+  <text x="55" y="147" font-size="34" fill="#e6e9f5">workflow code following the maintained v2 release tag.</text>
   <line x1="55" y1="175" x2="1945" y2="175" stroke="#3d4666"/>
   <text x="70" y="230" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
   <text x="1040" y="230" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
@@ -22,9 +22,9 @@
   <text x="115" y="780" font-size="23" fill="#a9b1d6">PR body image not required</text>
 
   <rect x="1065" y="285" width="860" height="210" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
-  <text x="1100" y="345" font-size="27" fill="#c0caf5">visual-pr v2 immutable commit</text>
-  <text x="1100" y="397" font-size="23" fill="#9ece6a">676648294d6a43f2dde58cfac700c5254f2147aa</text>
-  <text x="1100" y="445" font-size="21" fill="#565f89">workflow behavior cannot drift underneath open PRs</text>
+  <text x="1100" y="345" font-size="27" fill="#c0caf5">meawoppl/visual-pr@v2</text>
+  <text x="1100" y="397" font-size="23" fill="#9ece6a">maintained v2 release channel</text>
+  <text x="1100" y="445" font-size="21" fill="#565f89">compatible v2 updates arrive without repository edits</text>
   <line x1="1495" y1="495" x2="1495" y2="600" stroke="#9ece6a" stroke-width="2" marker-end="url(#green)"/>
   <rect x="1065" y="615" width="860" height="230" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
   <text x="1100" y="675" font-size="27" fill="#7aa2f7">One explicit v2 contract</text>

--- a/000-pr-visualization/001831.svg
+++ b/000-pr-visualization/001831.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200" font-family="'Segoe UI','Noto Sans','DejaVu Sans',sans-serif">
+  <rect width="2000" height="1200" fill="#16161e"/>
+  <defs>
+    <marker id="red" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0 0L10 5L0 10z" fill="#f7768e"/></marker>
+    <marker id="green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0 0L10 5L0 10z" fill="#9ece6a"/></marker>
+  </defs>
+  <text x="55" y="52" font-size="24" fill="#565f89">PR #1831 · Adopt visual-pr v2 contract</text>
+  <text x="55" y="105" font-size="34" fill="#e6e9f5">The required check adopts v2's stable path and PR-body contract while keeping executable</text>
+  <text x="55" y="147" font-size="34" fill="#e6e9f5">workflow code pinned to an immutable commit.</text>
+  <line x1="55" y1="175" x2="1945" y2="175" stroke="#3d4666"/>
+  <text x="70" y="230" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="230" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="205" x2="1000" y2="1110" stroke="#3d4666" stroke-dasharray="2 6"/>
+  <rect x="80" y="285" width="840" height="210" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+  <text x="115" y="345" font-size="27" fill="#c0caf5">visual-pr v1 compatibility pin</text>
+  <text x="115" y="397" font-size="23" fill="#a9b1d6">000-pr-visualization/&lt;number&gt;.svg</text>
+  <text x="115" y="445" font-size="21" fill="#565f89">older filename and presentation contract</text>
+  <line x1="500" y1="495" x2="500" y2="600" stroke="#f7768e" stroke-width="2" marker-end="url(#red)"/>
+  <rect x="80" y="615" width="840" height="230" fill="#1e202e" stroke="#3d4666"/>
+  <text x="115" y="675" font-size="27" fill="#7aa2f7">Contributor instructions</text>
+  <text x="115" y="730" font-size="23" fill="#a9b1d6">path documented without six-digit example</text>
+  <text x="115" y="780" font-size="23" fill="#a9b1d6">PR body image not required</text>
+
+  <rect x="1065" y="285" width="860" height="210" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+  <text x="1100" y="345" font-size="27" fill="#c0caf5">visual-pr v2 immutable commit</text>
+  <text x="1100" y="397" font-size="23" fill="#9ece6a">676648294d6a43f2dde58cfac700c5254f2147aa</text>
+  <text x="1100" y="445" font-size="21" fill="#565f89">workflow behavior cannot drift underneath open PRs</text>
+  <line x1="1495" y1="495" x2="1495" y2="600" stroke="#9ece6a" stroke-width="2" marker-end="url(#green)"/>
+  <rect x="1065" y="615" width="860" height="230" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+  <text x="1100" y="675" font-size="27" fill="#7aa2f7">One explicit v2 contract</text>
+  <text x="1100" y="730" font-size="23" fill="#a9b1d6">.0-pr-viz/&lt;six-digit-number&gt;.svg</text>
+  <text x="1100" y="780" font-size="23" fill="#a9b1d6">PR description opens with the committed image</text>
+  <rect x="1065" y="900" width="860" height="120" fill="#1e202e" stroke="#9ece6a"/>
+  <text x="1100" y="970" font-size="24" fill="#9ece6a">Workflow and AGENTS.md now agree.</text>
+  <text x="55" y="1160" font-size="22" fill="#565f89">Scope: visual-summary enforcement only; application builds and runtime behavior are unchanged.</text>
+</svg>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1071,8 +1071,9 @@ use uuid::Uuid;
 - **Bodies**: focus on *what* the change does and *why*. Keep it concise — no commit-by-commit play-by-play.
 - **No attribution footer**: don't add "Generated with Claude Code" (or similar) to PR titles or bodies.
 - **Visual PR summary (required)**: every PR commits a before/after summary
-  SVG of itself at `000-pr-visualization/<pr-number>.svg` (the `000-` prefix
-  sorts it first in GitHub's review file list). The tooling lives upstream in
+  SVG of itself at `.0-pr-viz/<six-digit-pr-number>.svg` (for example, PR 412
+  uses `.0-pr-viz/000412.svg`) and opens its PR body with an image of that SVG.
+  The tooling lives upstream in
   [meawoppl/visual-pr](https://github.com/meawoppl/visual-pr): read its
   `SPEC.md` for the authoring rules, ground every identifier in the actual
   diff, and verify with its `check_svg.py` (this repo's style artifact is


### PR DESCRIPTION
Upgrade the required visual-summary check to the maintained `v2` release tag.

The workflow and contributor instructions now use `.0-pr-viz/<six-digit>.svg`, and v2 requires the PR description to open with the committed visual.