### PR TITLE
Recover heartbeat lock after holder panic

### DIFF
--- a/.0-pr-viz/001832.svg
+++ b/.0-pr-viz/001832.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1832 · Recover heartbeat lock after holder panic</text>
+
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">One holder panic poisoned the heartbeat Mutex, and lock().unwrap() turned</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">every later check into a panic; now the guard recovers, so tracking survives.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="250" width="860" height="132" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="292" font-size="26" fill="#7aa2f7">lock().unwrap() x3 in heartbeat.rs</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">received / is_expired / elapsed_secs all panic</text>
+    <text x="104" y="364" font-size="22" fill="#565f89">session-lib/src/heartbeat.rs</text>
+  </g>
+  <g>
+    <rect x="80" y="402" width="860" height="132" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="444" font-size="26" fill="#7aa2f7">poisoning is sticky</text>
+    <text x="104" y="482" font-size="23" fill="#a9b1d6">first panic wedges every future heartbeat call</text>
+    <text x="104" y="516" font-size="22" fill="#565f89">proxy never notices death — or recovery</text>
+  </g>
+  <line x1="510" y1="534" x2="510" y2="940" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+  <g>
+    <rect x="80" y="960" width="860" height="120" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="1006" font-size="26" fill="#c0caf5">dead connection invisible, live one un-clearable</text>
+    <text x="104" y="1046" font-size="23" fill="#f7768e">one panicking holder ends all liveness tracking</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="250" width="860" height="132" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="292" font-size="26" fill="#9ece6a">lock_timestamp() recovers the guard</text>
+    <text x="1089" y="330" font-size="23" fill="#a9b1d6">unwrap_or_else(PoisonError::into_inner)</text>
+    <text x="1089" y="364" font-size="22" fill="#565f89">value preserved, tracking continues</text>
+  </g>
+  <g>
+    <rect x="1065" y="402" width="860" height="132" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="444" font-size="26" fill="#9ece6a">regression test poisons the lock</text>
+    <text x="1089" y="482" font-size="23" fill="#a9b1d6">catch_unwind panic, then all three methods still work</text>
+    <text x="1089" y="516" font-size="22" fill="#565f89">heartbeat::tests::poisoned_lock_still_tracks</text>
+  </g>
+  <line x1="1495" y1="534" x2="1495" y2="940" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+  <g>
+    <rect x="1065" y="960" width="860" height="120" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="1006" font-size="26" fill="#9ece6a">heartbeats survive a holder panic</text>
+    <text x="1089" y="1046" font-size="23" fill="#a9b1d6">recovery, not a wedge: state stays readable</text>
+  </g>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">Recovers the timestamp value only; a holder that keeps panicking still needs its own fix.</text>
+</svg>

--- a/session-lib/src/heartbeat.rs
+++ b/session-lib/src/heartbeat.rs
@@ -1,5 +1,13 @@
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, PoisonError};
 use std::time::{Duration, Instant};
+
+/// Lock the heartbeat timestamp, recovering the guarded value when a previous
+/// holder panicked. Poisoning is sticky: without recovery every later
+/// `received`/`is_expired` call would panic and the proxy would never notice
+/// a dead connection (or never stop seeing one as dead).
+fn lock_timestamp(mutex: &Mutex<Instant>) -> std::sync::MutexGuard<'_, Instant> {
+    mutex.lock().unwrap_or_else(PoisonError::into_inner)
+}
 
 pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(1);
 pub const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(15);
@@ -29,16 +37,37 @@ impl HeartbeatTracker {
 
     /// Called when a heartbeat echo is received from the backend.
     pub fn received(&self) {
-        *self.last_received.lock().unwrap() = Instant::now();
+        *lock_timestamp(&self.last_received) = Instant::now();
     }
 
     /// Returns true if no heartbeat echo has been received within the timeout.
     pub fn is_expired(&self) -> bool {
-        self.last_received.lock().unwrap().elapsed() > HEARTBEAT_TIMEOUT
+        lock_timestamp(&self.last_received).elapsed() > HEARTBEAT_TIMEOUT
     }
 
     /// Seconds since last heartbeat echo, for logging.
     pub fn elapsed_secs(&self) -> u64 {
-        self.last_received.lock().unwrap().elapsed().as_secs()
+        lock_timestamp(&self.last_received).elapsed().as_secs()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn poisoned_lock_still_tracks_heartbeats() {
+        let tracker = HeartbeatTracker::new();
+        let poisoned = tracker.clone();
+        let _ = std::panic::catch_unwind(move || {
+            let _guard = poisoned.last_received.lock().unwrap();
+            panic!("simulated holder panic");
+        });
+        assert!(tracker.last_received.is_poisoned());
+
+        // Recovery, not a wedge: all three methods keep working.
+        tracker.received();
+        assert!(!tracker.is_expired());
+        assert!(tracker.elapsed_secs() < HEARTBEAT_TIMEOUT.as_secs());
     }
 }


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/11409439c652d3d27fe5c65beb77141f74245301/.0-pr-viz/001832.svg)

HeartbeatTracker used lock().unwrap() in all three methods. A panic while holding the guard poisons the Mutex permanently, so every later received()/is_expired()/elapsed_secs() call panics too and the proxy can never observe or clear a dead connection. New lock_timestamp() helper recovers via PoisonError::into_inner, plus a regression test that poisons the lock with catch_unwind and asserts all three methods still work.

cargo test -p session-lib (heartbeat test passes), cargo clippy -p session-lib clean, cargo fmt clean.