### PR TITLE
Give Range parse outcome its own enum

### DIFF
--- a/.0-pr-viz/001834.svg
+++ b/.0-pr-viz/001834.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1834 · Give Range parse outcome its own enum</text>
+
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Option-Result nesting hid three outcomes and needed a complexity allow;</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">now RangeOutcome names them, so both callers match on meaning.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="250" width="860" height="132" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="292" font-size="26" fill="#7aa2f7">Option-Result-nested triple</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">None vs Some(Err) vs Some(Ok) — decode the nesting</text>
+    <text x="104" y="364" font-size="22" fill="#565f89">media_store.rs, under allow(type_complexity)</text>
+  </g>
+  <g>
+    <rect x="80" y="402" width="860" height="132" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="444" font-size="26" fill="#7aa2f7">callers re-decode the shape</text>
+    <text x="104" y="482" font-size="23" fill="#a9b1d6">serve_media and bytes_response both match the nest</text>
+    <text x="104" y="516" font-size="22" fill="#565f89">meaning (200 / 206 / 416) buried in syntax</text>
+  </g>
+  <line x1="510" y1="534" x2="510" y2="940" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+  <g>
+    <rect x="80" y="960" width="860" height="120" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="1006" font-size="26" fill="#c0caf5">http meaning hidden in nesting</text>
+    <text x="104" y="1046" font-size="23" fill="#f7768e">a fourth outcome would not typecheck as new</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="250" width="860" height="132" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="292" font-size="26" fill="#9ece6a">RangeOutcome: Full / Partial / NotSatisfiable</text>
+    <text x="1089" y="330" font-size="23" fill="#a9b1d6">serve-200 / serve-206 / answer-416, by name</text>
+    <text x="1089" y="364" font-size="22" fill="#565f89">allow(type_complexity) deleted with the nest</text>
+  </g>
+  <g>
+    <rect x="1065" y="402" width="860" height="132" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="444" font-size="26" fill="#9ece6a">both callers match on meaning</text>
+    <text x="1089" y="482" font-size="23" fill="#a9b1d6">serve_media and history bytes_response updated</text>
+    <text x="1089" y="516" font-size="22" fill="#565f89">parse_range_variants asserts the enum cases</text>
+  </g>
+  <line x1="1495" y1="534" x2="1495" y2="940" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+  <g>
+    <rect x="1065" y="960" width="860" height="120" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="1006" font-size="26" fill="#9ece6a">callers match on meaning</text>
+    <text x="1089" y="1046" font-size="23" fill="#a9b1d6">318 backend lib tests green, clippy clean</text>
+  </g>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">Wire format unchanged; only the two in-repo callers and the unit test move.</text>
+</svg>

--- a/backend/src/handlers/history.rs
+++ b/backend/src/handlers/history.rs
@@ -46,7 +46,7 @@ use crate::archive::{
 };
 use crate::auth::extract_user;
 use crate::errors::AppError;
-use crate::handlers::media_store::parse_range;
+use crate::handlers::media_store::{parse_range, RangeOutcome};
 use crate::models::User;
 use crate::AppState;
 
@@ -435,13 +435,13 @@ pub async fn get_history_media(
 fn bytes_response(bytes: &[u8], content_type: &str, headers: &HeaderMap) -> Response {
     let total = bytes.len() as u64;
     let mut response = match parse_range(headers, total) {
-        Some(Err(())) => Response::builder()
+        RangeOutcome::NotSatisfiable => Response::builder()
             .status(StatusCode::RANGE_NOT_SATISFIABLE)
             .header(header::ACCEPT_RANGES, "bytes")
             .header(header::CONTENT_RANGE, format!("bytes */{total}"))
             .body(Body::empty())
             .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response()),
-        Some(Ok((start, end))) => {
+        RangeOutcome::Partial { start, end } => {
             let slice = bytes[start as usize..=end as usize].to_vec();
             let len = end - start + 1;
             Response::builder()
@@ -456,7 +456,7 @@ fn bytes_response(bytes: &[u8], content_type: &str, headers: &HeaderMap) -> Resp
                 .body(Body::from(slice))
                 .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
         }
-        None => Response::builder()
+        RangeOutcome::Full => Response::builder()
             .status(StatusCode::OK)
             .header(header::CONTENT_TYPE, content_type)
             .header(header::ACCEPT_RANGES, "bytes")

--- a/backend/src/handlers/media_store.rs
+++ b/backend/src/handlers/media_store.rs
@@ -230,40 +230,53 @@ impl MediaStore {
     }
 }
 
+/// Outcome of parsing a single-range `Range: bytes=start-end` header against
+/// `total` bytes. A dedicated enum instead of `Option<Result<_, ()>>`: the
+/// three cases (serve whole file / serve one range / answer 416) are what both
+/// callers match on, and the type no longer trips the complexity lint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RangeOutcome {
+    /// Header absent or malformed: serve the whole file with 200.
+    Full,
+    /// Satisfiable single range: serve inclusive `start..=end` with 206.
+    Partial { start: u64, end: u64 },
+    /// Syntactically valid but unsatisfiable: answer 416.
+    NotSatisfiable,
+}
+
 /// Parse a single-range `Range: bytes=start-end` header against `total` bytes.
-/// Returns the inclusive `(start, end)` byte range, or `None` when the header
-/// is absent/malformed (caller then serves the whole file). Returns
-/// `Some(Err(()))` when the range is syntactically valid but unsatisfiable.
-#[allow(clippy::type_complexity)]
-pub(crate) fn parse_range(headers: &HeaderMap, total: u64) -> Option<Result<(u64, u64), ()>> {
-    let raw = headers.get(header::RANGE)?.to_str().ok()?;
-    let spec = raw.strip_prefix("bytes=")?;
-    // Only a single range is supported; reject multi-range specs.
-    if spec.contains(',') {
-        return Some(Err(()));
-    }
-    let (start_s, end_s) = spec.split_once('-')?;
-    let (start, end) = if start_s.is_empty() {
-        // Suffix range: bytes=-N → last N bytes.
-        let n: u64 = end_s.parse().ok()?;
-        if n == 0 || total == 0 {
-            return Some(Err(()));
+pub(crate) fn parse_range(headers: &HeaderMap, total: u64) -> RangeOutcome {
+    let outcome = (|| {
+        let raw = headers.get(header::RANGE)?.to_str().ok()?;
+        let spec = raw.strip_prefix("bytes=")?;
+        // Only a single range is supported; reject multi-range specs.
+        if spec.contains(',') {
+            return Some(RangeOutcome::NotSatisfiable);
         }
-        let n = n.min(total);
-        (total - n, total - 1)
-    } else {
-        let start: u64 = start_s.parse().ok()?;
-        let end: u64 = if end_s.is_empty() {
-            total.saturating_sub(1)
+        let (start_s, end_s) = spec.split_once('-')?;
+        let (start, end) = if start_s.is_empty() {
+            // Suffix range: bytes=-N → last N bytes.
+            let n: u64 = end_s.parse().ok()?;
+            if n == 0 || total == 0 {
+                return Some(RangeOutcome::NotSatisfiable);
+            }
+            let n = n.min(total);
+            (total - n, total - 1)
         } else {
-            end_s.parse().ok()?
+            let start: u64 = start_s.parse().ok()?;
+            let end: u64 = if end_s.is_empty() {
+                total.saturating_sub(1)
+            } else {
+                end_s.parse().ok()?
+            };
+            (start, end.min(total.saturating_sub(1)))
         };
-        (start, end.min(total.saturating_sub(1)))
-    };
-    if total == 0 || start > end || start >= total {
-        return Some(Err(()));
-    }
-    Some(Ok((start, end)))
+        if total == 0 || start > end || start >= total {
+            return Some(RangeOutcome::NotSatisfiable);
+        }
+        Some(RangeOutcome::Partial { start, end })
+    })();
+    outcome.unwrap_or(RangeOutcome::Full)
 }
 
 /// GET /api/media/{id} — serve a stored video, with HTTP Range support so
@@ -310,7 +323,7 @@ pub async fn serve_media(
     let range = parse_range(&headers, total);
 
     match range {
-        Some(Err(())) => {
+        RangeOutcome::NotSatisfiable => {
             // Syntactically valid but unsatisfiable range.
             Ok(Response::builder()
                 .status(StatusCode::RANGE_NOT_SATISFIABLE)
@@ -318,7 +331,7 @@ pub async fn serve_media(
                 .body(Body::empty())
                 .map_err(|e| AppError::Internal(format!("build range response: {e}")))?)
         }
-        Some(Ok((start, end))) => {
+        RangeOutcome::Partial { start, end } => {
             let len = end - start + 1;
             let mut file = tokio::fs::File::open(&meta.path)
                 .await
@@ -344,7 +357,7 @@ pub async fn serve_media(
             response.headers_mut().extend(security);
             Ok(response)
         }
-        None => {
+        RangeOutcome::Full => {
             let file = tokio::fs::File::open(&meta.path)
                 .await
                 .map_err(|_| AppError::NotFound("Media not found"))?;
@@ -430,27 +443,39 @@ mod tests {
     fn parse_range_variants() {
         let mut headers = HeaderMap::new();
         // No Range header → whole file.
-        assert!(parse_range(&headers, 100).is_none());
+        assert_eq!(parse_range(&headers, 100), RangeOutcome::Full);
 
         headers.insert(header::RANGE, "bytes=0-49".parse().unwrap());
-        assert_eq!(parse_range(&headers, 100), Some(Ok((0, 49))));
+        assert_eq!(
+            parse_range(&headers, 100),
+            RangeOutcome::Partial { start: 0, end: 49 }
+        );
 
         headers.insert(header::RANGE, "bytes=50-".parse().unwrap());
-        assert_eq!(parse_range(&headers, 100), Some(Ok((50, 99))));
+        assert_eq!(
+            parse_range(&headers, 100),
+            RangeOutcome::Partial { start: 50, end: 99 }
+        );
 
         headers.insert(header::RANGE, "bytes=-20".parse().unwrap());
-        assert_eq!(parse_range(&headers, 100), Some(Ok((80, 99))));
+        assert_eq!(
+            parse_range(&headers, 100),
+            RangeOutcome::Partial { start: 80, end: 99 }
+        );
 
         // End past EOF clamps to last byte.
         headers.insert(header::RANGE, "bytes=90-200".parse().unwrap());
-        assert_eq!(parse_range(&headers, 100), Some(Ok((90, 99))));
+        assert_eq!(
+            parse_range(&headers, 100),
+            RangeOutcome::Partial { start: 90, end: 99 }
+        );
 
         // Start past EOF is unsatisfiable.
         headers.insert(header::RANGE, "bytes=200-".parse().unwrap());
-        assert_eq!(parse_range(&headers, 100), Some(Err(())));
+        assert_eq!(parse_range(&headers, 100), RangeOutcome::NotSatisfiable);
 
         // Multi-range unsupported.
         headers.insert(header::RANGE, "bytes=0-10,20-30".parse().unwrap());
-        assert_eq!(parse_range(&headers, 100), Some(Err(())));
+        assert_eq!(parse_range(&headers, 100), RangeOutcome::NotSatisfiable);
     }
 }


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/4d1cdc64cdbb92555fb88540a897573a5c98e2d1/.0-pr-viz/001834.svg)

parse_range returned Option<Result<(u64, u64), ()>> and needed allow(clippy::type_complexity). New RangeOutcome enum (Full / Partial { start, end } / NotSatisfiable) says what both callers match on. Updated serve_media, history bytes_response, and the parse_range_variants test; behavior identical.

cargo test -p backend --lib (318 pass incl. parse_range_variants), cargo clippy -p backend clean, cargo fmt clean.