### PR TITLE
Collect reminder strips directly to String

### DIFF
--- a/.0-pr-viz/001835.svg
+++ b/.0-pr-viz/001835.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1835 · Collect reminder strips directly to String</text>
+
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Two strip fns built a Vec just to join it; now one collect to String,</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">so no intermediate allocation sits on the strip path.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="250" width="860" height="132" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="292" font-size="26" fill="#7aa2f7">collect to Vec, then join</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">iterator of text refs becomes a throwaway Vec</text>
+    <text x="104" y="364" font-size="22" fill="#565f89">strip_system_reminders + strip_collapsible_notices</text>
+  </g>
+  <line x1="510" y1="382" x2="510" y2="940" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+  <g>
+    <rect x="80" y="960" width="860" height="120" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="1006" font-size="26" fill="#c0caf5">a Vec per strip call</text>
+    <text x="104" y="1046" font-size="23" fill="#f7768e">allocated only to be joined and dropped</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="250" width="860" height="132" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="292" font-size="26" fill="#9ece6a">collect to String in one pass</text>
+    <text x="1089" y="330" font-size="23" fill="#a9b1d6">identical output, no middleman allocation</text>
+    <text x="1089" y="364" font-size="22" fill="#565f89">shared/src/system_reminder.rs, both sites</text>
+  </g>
+  <line x1="1495" y1="382" x2="1495" y2="940" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+  <g>
+    <rect x="1065" y="960" width="860" height="120" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="1006" font-size="26" fill="#9ece6a">same string, no middleman</text>
+    <text x="1089" y="1046" font-size="23" fill="#a9b1d6">11 system_reminder tests green</text>
+  </g>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">Micro-allocation cleanup only; the early-return fast path is untouched.</text>
+</svg>

--- a/shared/src/system_reminder.rs
+++ b/shared/src/system_reminder.rs
@@ -139,8 +139,7 @@ pub fn strip_system_reminders(text: &str) -> String {
             Segment::Reminder(_) => None,
             Segment::TaskNotification(_) => unreachable!("system-reminder-only split"),
         })
-        .collect::<Vec<_>>()
-        .join("")
+        .collect::<String>()
 }
 
 /// The prose of `text` with every complete collapsible notice removed.
@@ -154,8 +153,7 @@ pub fn strip_collapsible_notices(text: &str) -> String {
             Segment::Text(text) => Some(text),
             Segment::Reminder(_) | Segment::TaskNotification(_) => None,
         })
-        .collect::<Vec<_>>()
-        .join("")
+        .collect::<String>()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/6ecd4fdc6e14c84d648c81dba49c3c89a786bcbe/.0-pr-viz/001835.svg)

strip_system_reminders and strip_collapsible_notices did collect::<Vec<_>>().join("") on an iterator of &str. collect::<String>() does it in one pass with no intermediate allocation (clippy::pedantic). Behavior identical.

cargo test -p shared (11 system_reminder tests pass), cargo clippy -p shared clean.