### PR TITLE
Use map_or_else in canonicalize_timezone

### DIFF
--- a/.0-pr-viz/001836.svg
+++ b/.0-pr-viz/001836.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1836 · Use map_or_else in canonicalize_timezone</text>
+
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">map() then unwrap_or_else() did in two steps what one combinator</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">does; now map_or_else, so mapping and fallback read as one.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="250" width="860" height="132" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="292" font-size="26" fill="#7aa2f7">map, then unwrap_or_else</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">two combinators for one map-with-fallback idea</text>
+    <text x="104" y="364" font-size="22" fill="#565f89">canonicalize_timezone in shared/src/timezone.rs</text>
+  </g>
+  <line x1="510" y1="382" x2="510" y2="940" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+  <g>
+    <rect x="80" y="960" width="860" height="120" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="1006" font-size="26" fill="#c0caf5">fallback reads as an afterthought</text>
+    <text x="104" y="1046" font-size="23" fill="#f7768e">pedantic map_unwrap_or flags the two-step</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="250" width="860" height="132" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="292" font-size="26" fill="#9ece6a">one map_or_else call</text>
+    <text x="1089" y="330" font-size="23" fill="#a9b1d6">trim-fallback and mapping in a single combinator</text>
+    <text x="1089" y="364" font-size="22" fill="#565f89">5 timezone tests green, semantics identical</text>
+  </g>
+  <line x1="1495" y1="382" x2="1495" y2="940" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+  <g>
+    <rect x="1065" y="960" width="860" height="120" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="1006" font-size="26" fill="#9ece6a">mapping and fallback as one</text>
+    <text x="1089" y="1046" font-size="23" fill="#a9b1d6">known abbrevs map, the rest pass through trimmed</text>
+  </g>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">Cosmetic pedantic fix; mapping table and pass-through behavior unchanged.</text>
+</svg>

--- a/shared/src/timezone.rs
+++ b/shared/src/timezone.rs
@@ -44,9 +44,7 @@ pub fn abbrev_to_iana(input: &str) -> Option<&'static str> {
 /// name. Never fails — an unknown value is passed through verbatim so the caller
 /// can decide how to handle it.
 pub fn canonicalize_timezone(input: &str) -> String {
-    abbrev_to_iana(input)
-        .map(str::to_string)
-        .unwrap_or_else(|| input.trim().to_string())
+    abbrev_to_iana(input).map_or_else(|| input.trim().to_string(), str::to_string)
 }
 
 /// Common IANA zones offered as suggestions in the schedule dialog. Not


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/8f4f7ba43ad1da8063cfce9071692895d646fc77/.0-pr-viz/001836.svg)

canonicalize_timezone did .map(str::to_string).unwrap_or_else(...). map_or_else fuses the two (clippy::pedantic) with identical semantics: known abbrev maps, everything else passes through trimmed.

cargo test -p shared (5 timezone tests pass), cargo clippy -p shared clean.