### PR TITLE
Drop redundant continue/else in version scan

### DIFF
--- a/.0-pr-viz/001837.svg
+++ b/.0-pr-viz/001837.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1837 · Drop redundant continue/else in version scan</text>
+
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">The version-run terminator spelled continue-then-else-break; now a</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">bare break, so the loop's own fall-through does the continuing.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="250" width="860" height="132" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="292" font-size="26" fill="#7aa2f7">if empty, continue, else break</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">the continue restates the loop; the else wraps break</text>
+    <text x="104" y="364" font-size="22" fill="#565f89">extract_version token loop, model_version.rs</text>
+  </g>
+  <line x1="510" y1="382" x2="510" y2="940" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+  <g>
+    <rect x="80" y="960" width="860" height="120" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="1006" font-size="26" fill="#c0caf5">control flow louder than logic</text>
+    <text x="104" y="1046" font-size="23" fill="#f7768e">pedantic redundant-continue and redundant-else</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="250" width="860" height="132" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="292" font-size="26" fill="#9ece6a">if not-empty, break</text>
+    <text x="1089" y="330" font-size="23" fill="#a9b1d6">empty case falls through to the next token</text>
+    <text x="1089" y="364" font-size="22" fill="#565f89">13 model_version tests green</text>
+  </g>
+  <line x1="1495" y1="382" x2="1495" y2="940" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+  <g>
+    <rect x="1065" y="960" width="860" height="120" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="1006" font-size="26" fill="#9ece6a">loop reads as written</text>
+    <text x="1089" y="1046" font-size="23" fill="#a9b1d6">leading words skipped, version run ends cleanly</text>
+  </g>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">Cosmetic; token classification and join logic untouched.</text>
+</svg>

--- a/shared/src/model_version.rs
+++ b/shared/src/model_version.rs
@@ -81,9 +81,7 @@ pub fn compact_model_version(model_id: &str) -> Option<String> {
             // (so a trailing date or family suffix isn't mixed in). Before it
             // starts, skip leading family words.
             Kind::DateOrBuild | Kind::Other => {
-                if parts.is_empty() {
-                    continue;
-                } else {
+                if !parts.is_empty() {
                     break;
                 }
             }


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/9cacf2c7878eb42cb30d7ea0a7114eef5ac28f8f/.0-pr-viz/001837.svg)

The DateOrBuild|Other arm did if parts.is_empty() { continue } else { break }. The continue was redundant (loop continues anyway) and the else wrapped a bare break (clippy::pedantic redundant_continue/redundant_else). Now if !parts.is_empty() { break }.

cargo test -p shared (13 model_version tests pass), cargo clippy -p shared clean.