### PR TITLE
Document proxy token encode/decode errors

### DIFF
--- a/.0-pr-viz/001838.svg
+++ b/.0-pr-viz/001838.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1838 · Document proxy token encode/decode errors</text>
+
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">encode/decode returned Result with no Errors section; now each</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">names its failure modes, so callers know what the error can be.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="250" width="860" height="132" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="292" font-size="26" fill="#7aa2f7">Result with no Errors section x2</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">encode and decode: what fails is undocumented</text>
+    <text x="104" y="364" font-size="22" fill="#565f89">missing_errors_doc pedantic warnings</text>
+  </g>
+  <g>
+    <rect x="80" y="402" width="860" height="132" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="444" font-size="26" fill="#7aa2f7">bare table name in docs</text>
+    <text x="104" y="482" font-size="23" fill="#a9b1d6">proxy_auth_tokens missing its backticks</text>
+    <text x="104" y="516" font-size="22" fill="#565f89">doc_markdown pedantic warning</text>
+  </g>
+  <line x1="510" y1="534" x2="510" y2="940" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+  <g>
+    <rect x="80" y="960" width="860" height="120" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="1006" font-size="26" fill="#c0caf5">error surface described nowhere</text>
+    <text x="104" y="1046" font-size="23" fill="#f7768e">callers guess what the boxed error holds</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="250" width="860" height="132" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="292" font-size="26" fill="#9ece6a">Errors sections name the modes</text>
+    <text x="1089" y="330" font-size="23" fill="#a9b1d6">base64, UTF-8, and JSON failures spelled out</text>
+    <text x="1089" y="364" font-size="22" fill="#565f89">table name in backticks</text>
+  </g>
+  <line x1="1495" y1="382" x2="1495" y2="940" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+  <g>
+    <rect x="1065" y="960" width="860" height="120" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="1006" font-size="26" fill="#9ece6a">docs satisfy the lint</text>
+    <text x="1089" y="1046" font-size="23" fill="#a9b1d6">6 proxy_token tests green, docs only</text>
+  </g>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">Docs only; signatures, encoding, and the token format are unchanged.</text>
+</svg>

--- a/shared/src/proxy_tokens.rs
+++ b/shared/src/proxy_tokens.rs
@@ -17,7 +17,7 @@ pub const TOKEN_TYPE_MOBILE: &str = "mobile";
 /// JWT claims for proxy authentication tokens
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProxyTokenClaims {
-    /// Token ID (for revocation lookup in proxy_auth_tokens table)
+    /// Token ID (for revocation lookup in `proxy_auth_tokens` table)
     pub jti: Uuid,
     /// User ID
     pub sub: Uuid,
@@ -52,12 +52,22 @@ pub struct ProxyInitConfig {
 
 impl ProxyInitConfig {
     /// Encode the config as base64url for use in URLs
+    ///
+    /// # Errors
+    ///
+    /// Returns the [`serde_json::Error`] when the config cannot be serialized
+    /// (unreachable for this struct shape, but surfaced rather than panicked on).
     pub fn encode(&self) -> Result<String, serde_json::Error> {
         let json = serde_json::to_string(self)?;
         Ok(base64_url_encode(json.as_bytes()))
     }
 
     /// Decode the config from base64url
+    ///
+    /// # Errors
+    ///
+    /// Returns a boxed error when the input is not valid base64url, is not
+    /// UTF-8, or does not deserialize into a [`ProxyInitConfig`].
     pub fn decode(encoded: &str) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let bytes = base64_url_decode(encoded)?;
         let json = String::from_utf8(bytes)?;


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/3e576eef68ba0235dfc6d509bac69a442341d638/.0-pr-viz/001838.svg)

ProxyInitConfig::encode/decode return Result with no # Errors docs, and the jti doc referenced proxy_auth_tokens without backticks (clippy::pedantic missing_errors_doc/doc_markdown). Added both sections describing the base64/UTF-8/JSON failure modes, plus backticks. Docs only.

cargo test -p shared (6 proxy_token tests pass), pedantic warnings for this file gone.