### PR TITLE
Mark pure shared helpers must_use

### DIFF
--- a/.0-pr-viz/001839.svg
+++ b/.0-pr-viz/001839.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1839 · Mark pure shared helpers must_use</text>
+
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">18 pure helpers let callers silently drop their answers; now</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">must_use, so a discarded result warns instead of hiding.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="250" width="860" height="132" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="292" font-size="26" fill="#7aa2f7">pure returns, silently droppable</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">magic sniffers, metadata, time, and tz helpers</text>
+    <text x="104" y="364" font-size="22" fill="#565f89">media.rs, message_metadata.rs, time.rs, timezone.rs</text>
+  </g>
+  <line x1="510" y1="382" x2="510" y2="940" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+  <g>
+    <rect x="80" y="960" width="860" height="120" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="1006" font-size="26" fill="#c0caf5">dropped checks compile quietly</text>
+    <text x="104" y="1046" font-size="23" fill="#f7768e">a forgotten sniff result is a latent bug</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="250" width="860" height="132" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="292" font-size="26" fill="#9ece6a">must_use on all 18</text>
+    <text x="1089" y="330" font-size="23" fill="#a9b1d6">discarded results become compiler warnings</text>
+    <text x="1089" y="364" font-size="22" fill="#565f89">workspace clippy: zero unused_must_use</text>
+  </g>
+  <line x1="1495" y1="382" x2="1495" y2="940" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+  <g>
+    <rect x="1065" y="960" width="860" height="120" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="1006" font-size="26" fill="#9ece6a">dropped results get flagged</text>
+    <text x="1089" y="1046" font-size="23" fill="#a9b1d6">187 shared tests green, no caller edits needed</text>
+  </g>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">Warning-level only; no runtime behavior changes and no caller needed edits.</text>
+</svg>

--- a/shared/src/media.rs
+++ b/shared/src/media.rs
@@ -52,6 +52,7 @@ pub const RIZZMA_HTML_CARRIER_OPEN: &str =
     r#"<script type="application/vnd.rizzma.figure+base64" id="riz">"#;
 
 /// Classify a supported content type, or return `None`.
+#[must_use]
 pub fn media_kind(content_type: &str) -> Option<MediaKind> {
     let ct = content_type.trim();
     if SUPPORTED_IMAGE_TYPES.contains(&ct) {
@@ -76,38 +77,46 @@ pub const SUPPORTED_FORMATS_HINT: &str =
 // recovers a content type when a blob's sidecar is missing. Both live here so
 // the two can't drift (see the module docs).
 
+#[must_use]
 pub fn has_png_magic(b: &[u8]) -> bool {
     b.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
 }
 
+#[must_use]
 pub fn has_jpeg_magic(b: &[u8]) -> bool {
     b.starts_with(&[0xFF, 0xD8, 0xFF])
 }
 
+#[must_use]
 pub fn has_gif_magic(b: &[u8]) -> bool {
     b.starts_with(b"GIF87a") || b.starts_with(b"GIF89a")
 }
 
+#[must_use]
 pub fn has_webp_magic(b: &[u8]) -> bool {
     b.len() >= 12 && &b[0..4] == b"RIFF" && &b[8..12] == b"WEBP"
 }
 
+#[must_use]
 pub fn has_mp4_magic(b: &[u8]) -> bool {
     // ISO Base Media: an `ftyp` box at offset 4.
     b.len() >= 12 && &b[4..8] == b"ftyp"
 }
 
+#[must_use]
 pub fn has_webm_magic(b: &[u8]) -> bool {
     // EBML header (Matroska/WebM).
     b.starts_with(&[0x1A, 0x45, 0xDF, 0xA3])
 }
 
+#[must_use]
 pub fn has_rizzma_magic(b: &[u8]) -> bool {
     b.starts_with(b"RZFG")
 }
 
 /// Fast declared-wrapper check used by the launcher before upload. Full HTML
 /// carrier validation and artifact validation remain backend responsibilities.
+#[must_use]
 pub fn has_rizzma_html_carrier(b: &[u8]) -> bool {
     let Ok(text) = std::str::from_utf8(b) else {
         return false;
@@ -119,6 +128,7 @@ pub fn has_rizzma_html_carrier(b: &[u8]) -> bool {
 /// SVG is XML text, so there's no single magic number. Skip a UTF-8 BOM and
 /// leading whitespace, then look for an `<svg` (or `<?xml` prolog) near the
 /// start.
+#[must_use]
 pub fn looks_like_svg(b: &[u8]) -> bool {
     let b = b.strip_prefix(&[0xEF, 0xBB, 0xBF]).unwrap_or(b);
     let head = &b[..b.len().min(1024)];
@@ -139,6 +149,7 @@ pub fn looks_like_svg(b: &[u8]) -> bool {
 /// heuristic goes last because it's the loosest. Returns `None` for anything
 /// outside the supported set, leaving the caller to pick a fallback — never
 /// invent a type for bytes we don't recognize.
+#[must_use]
 pub fn sniff_content_type(bytes: &[u8]) -> Option<&'static str> {
     if has_png_magic(bytes) {
         Some("image/png")

--- a/shared/src/message_metadata.rs
+++ b/shared/src/message_metadata.rs
@@ -4,12 +4,14 @@
 use crate::{HistoryEntry, MessageSource, PortalMeta};
 
 /// Extract the server-created timestamp from an optional metadata sidecar.
+#[must_use]
 pub fn created_at_iso(meta: Option<&PortalMeta>) -> Option<&str> {
     meta.and_then(PortalMeta::created_at_iso)
 }
 
 /// Parse stored message content as JSON, falling back to a typed envelope when
 /// the persisted row predates strict JSON storage or contains raw text.
+#[must_use]
 pub fn content_value_or_fallback(role: &str, content: &str) -> serde_json::Value {
     #[derive(serde::Serialize)]
     struct FallbackMessageContent<'a> {
@@ -29,12 +31,14 @@ pub fn content_value_or_fallback(role: &str, content: &str) -> serde_json::Value
 
 impl PortalMeta {
     /// Server-assigned persisted-row timestamp as an ISO string.
+    #[must_use]
     pub fn created_at_iso(&self) -> Option<&str> {
         self.created_at.as_deref()
     }
 
     /// Typed origin/attribution for this message, when it is not the session's
     /// own agent output.
+    #[must_use]
     pub fn source(&self) -> Option<&MessageSource> {
         self.source.as_ref()
     }
@@ -42,6 +46,7 @@ impl PortalMeta {
 
 impl HistoryEntry {
     /// Server-assigned timestamp from this historical row's metadata sidecar.
+    #[must_use]
     pub fn created_at_iso(&self) -> Option<&str> {
         created_at_iso(self.meta.as_ref())
     }

--- a/shared/src/time.rs
+++ b/shared/src/time.rs
@@ -4,6 +4,7 @@
 /// read as UTC rather than local time. A designator is a `Z` or a `+`/`-`
 /// offset in the time portion (after `T`); date hyphens don't count.
 /// Date-only values (no `T`) are left untouched and returned as `Borrowed`.
+#[must_use]
 pub fn normalize_iso_utc(iso: &str) -> std::borrow::Cow<'_, str> {
     let Some((_, time)) = iso.split_once('T') else {
         return std::borrow::Cow::Borrowed(iso);

--- a/shared/src/timezone.rs
+++ b/shared/src/timezone.rs
@@ -18,6 +18,7 @@
 /// Abbreviations are inherently ambiguous (e.g. `CST` is US Central *or* China
 /// Standard); these resolve to the North American zones this tool's users mean.
 /// Anything not listed should be treated as an IANA name by the caller.
+#[must_use]
 pub fn abbrev_to_iana(input: &str) -> Option<&'static str> {
     let key = input.trim().to_ascii_uppercase();
     Some(match key.as_str() {


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/e85afcd6cb2d70575fcfcc0ef1281d8b9712b5e4/.0-pr-viz/001839.svg)

18 pure predicate/converter helpers in shared (media magic-byte sniffers, media_kind, sniff_content_type, message_metadata accessors, normalize_iso_utc, abbrev_to_iana) returned values the compiler let callers silently drop. Added #[must_use] (clippy::pedantic). Verified no caller ignores a return: full workspace clippy shows zero unused_must_use warnings.

cargo test -p shared --lib (187 pass), workspace clippy clean.