### PR TITLE
Bundle proxy message context into ProxyCtx

### DIFF
--- a/.0-pr-viz/001840.svg
+++ b/.0-pr-viz/001840.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1840 · Bundle proxy message context into ProxyCtx</text>
+
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">handle_proxy_message took 9 params under an argument-count allow;</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">now a Copy ProxyCtx carries the 5 shared refs, so dispatch reads clean.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="250" width="860" height="132" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="292" font-size="26" fill="#7aa2f7">9 params plus an allow</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">app_state, session_manager, db_pool, tx, cancel, 3 muts</text>
+    <text x="104" y="364" font-size="22" fill="#565f89">allow(clippy::too_many_arguments) on the handler</text>
+  </g>
+  <line x1="510" y1="382" x2="510" y2="940" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+  <g>
+    <rect x="80" y="960" width="860" height="120" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="1006" font-size="26" fill="#c0caf5">every downstream call re-lists the refs</text>
+    <text x="104" y="1046" font-size="23" fill="#f7768e">context and per-message state indistinguishable</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="250" width="860" height="132" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="292" font-size="26" fill="#9ece6a">Copy ProxyCtx plus 3 muts</text>
+    <text x="1089" y="330" font-size="23" fill="#a9b1d6">body destructures ctx, logic byte-identical</text>
+    <text x="1089" y="364" font-size="22" fill="#565f89">mirrors WebClientCtx on the web-client side</text>
+  </g>
+  <line x1="1495" y1="382" x2="1495" y2="940" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+  <g>
+    <rect x="1065" y="960" width="860" height="120" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="1006" font-size="26" fill="#9ece6a">5 params, no allow</text>
+    <text x="1089" y="1046" font-size="23" fill="#a9b1d6">318 backend lib tests confirm parity</text>
+  </g>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">Body untouched via destructure; the ctx is built fresh per message at the call site.</text>
+</svg>

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -63,13 +63,16 @@ pub async fn handle_session_socket(socket: WebSocket, app_state: Arc<AppState>) 
                 if let Some(key) = session_key.as_ref() {
                     session_manager.touch_session(key);
                 }
+                let ctx = ProxyCtx {
+                    app_state: &app_state,
+                    session_manager: &session_manager,
+                    db_pool: &db_pool,
+                    tx: &tx,
+                    cancel: &cancel,
+                };
                 let flow = handle_proxy_message(
                     proxy_msg,
-                    &app_state,
-                    &session_manager,
-                    &db_pool,
-                    &tx,
-                    &cancel,
+                    ctx,
                     &mut session_key,
                     &mut db_session_id,
                     &mut connection_gen,
@@ -177,18 +180,34 @@ pub async fn handle_session_socket(socket: WebSocket, app_state: Arc<AppState>) 
     let _ = send_task.await;
 }
 
-#[allow(clippy::too_many_arguments)]
+/// Shared per-connection context for the proxy message handlers below.
+/// Bundled so the handler signatures stay under the argument-count lint;
+/// `Copy` so dispatch can pass it down freely. Mirrors `WebClientCtx` on the
+/// web-client side. The three `&mut` connection states stay as separate
+/// params — they are per-message mutable borrows, not shared context.
+#[derive(Clone, Copy)]
+struct ProxyCtx<'a> {
+    app_state: &'a AppState,
+    session_manager: &'a SessionManager,
+    db_pool: &'a crate::db::DbPool,
+    tx: &'a ProxySender,
+    cancel: &'a tokio_util::sync::CancellationToken,
+}
+
 fn handle_proxy_message(
     proxy_msg: ProxyToServer,
-    app_state: &AppState,
-    session_manager: &SessionManager,
-    db_pool: &crate::db::DbPool,
-    tx: &ProxySender,
-    cancel: &tokio_util::sync::CancellationToken,
+    ctx: ProxyCtx<'_>,
     session_key: &mut Option<SessionId>,
     db_session_id: &mut Option<Uuid>,
     connection_gen: &mut Option<u64>,
 ) -> ControlFlow<()> {
+    let ProxyCtx {
+        app_state,
+        session_manager,
+        db_pool,
+        tx,
+        cancel,
+    } = ctx;
     match proxy_msg {
         ProxyToServer::Register(shared::RegisterFields {
             session_id: claude_session_id,


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/e07436d9fded8166ecd285dcf2a754a1c33aad94/.0-pr-viz/001840.svg)

handle_proxy_message took 9 params and needed allow(clippy::too_many_arguments). New Copy ProxyCtx bundles the 5 shared refs (app_state, session_manager, db_pool, tx, cancel), mirroring WebClientCtx; the 3 &mut connection states stay separate. The body destructures the ctx so all downstream logic is byte-identical.

cargo test -p backend --lib (318 pass), cargo clippy -p backend clean, cargo fmt clean.