### PR TITLE
Bundle SessionUpdate payload into struct

### DIFF
--- a/.0-pr-viz/001841.svg
+++ b/.0-pr-viz/001841.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1841 · Bundle SessionUpdate payload into struct</text>
+
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">handle_session_update took 9 params lifted from one message</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">variant; now a payload struct carries the 5, so it takes data.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="250" width="860" height="132" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="292" font-size="26" fill="#7aa2f7">5 payload fields as params</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">id, branch, pr_url, repo_url, open_prs re-listed</text>
+    <text x="104" y="364" font-size="22" fill="#565f89">destructured at the call, re-listed in the signature</text>
+  </g>
+  <line x1="510" y1="382" x2="510" y2="940" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+  <g>
+    <rect x="80" y="960" width="860" height="120" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="1006" font-size="26" fill="#c0caf5">variant shape copied by hand</text>
+    <text x="104" y="1046" font-size="23" fill="#f7768e">a new SessionUpdate field means two edits</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="250" width="860" height="132" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="292" font-size="26" fill="#9ece6a">SessionUpdatePayload struct</text>
+    <text x="1089" y="330" font-size="23" fill="#a9b1d6">diesel update and broadcast logic unchanged</text>
+    <text x="1089" y="364" font-size="22" fill="#565f89">single call site builds it from the variant</text>
+  </g>
+  <line x1="1495" y1="382" x2="1495" y2="940" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+  <g>
+    <rect x="1065" y="960" width="860" height="120" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="1006" font-size="26" fill="#9ece6a">5 params, no allow</text>
+    <text x="1089" y="1046" font-size="23" fill="#a9b1d6">318 backend lib tests green</text>
+  </g>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">Single call site; wire shape and stored columns unchanged.</text>
+</svg>

--- a/backend/src/handlers/websocket/proxy_socket.rs
+++ b/backend/src/handlers/websocket/proxy_socket.rs
@@ -381,11 +381,13 @@ fn handle_proxy_message(
                 session_key,
                 *db_session_id,
                 db_pool,
-                update_session_id,
-                git_branch,
-                pr_url,
-                repo_url,
-                open_prs,
+                SessionUpdatePayload {
+                    update_session_id,
+                    git_branch,
+                    pr_url,
+                    repo_url,
+                    open_prs,
+                },
             );
         }
         ProxyToServer::InputAck {
@@ -564,18 +566,30 @@ fn handle_proxy_message(
     ControlFlow::Continue(())
 }
 
-#[allow(clippy::too_many_arguments)]
-fn handle_session_update(
-    session_manager: &SessionManager,
-    session_key: &Option<SessionId>,
-    db_session_id: Option<Uuid>,
-    db_pool: &crate::db::DbPool,
+/// Payload of a `ProxyToServer::SessionUpdate` frame, bundled so
+/// `handle_session_update` stays under the argument-count lint.
+struct SessionUpdatePayload {
     update_session_id: Uuid,
     git_branch: Option<String>,
     pr_url: Option<String>,
     repo_url: Option<String>,
     open_prs: Vec<shared::PrRef>,
+}
+
+fn handle_session_update(
+    session_manager: &SessionManager,
+    session_key: &Option<SessionId>,
+    db_session_id: Option<Uuid>,
+    db_pool: &crate::db::DbPool,
+    payload: SessionUpdatePayload,
 ) {
+    let SessionUpdatePayload {
+        update_session_id,
+        git_branch,
+        pr_url,
+        repo_url,
+        open_prs,
+    } = payload;
     let Some(current_session_id) = db_session_id else {
         return;
     };


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/c205b74ec28a514934e5cd8240ae42fd0e6ec85c/.0-pr-viz/001841.svg)

handle_session_update took 9 params and needed allow(clippy::too_many_arguments). The 5 payload fields come straight from the ProxyToServer::SessionUpdate variant, so new SessionUpdatePayload carries them; the body destructures it and all downstream logic (mismatch guard, diesel update, broadcast) is unchanged.

cargo test -p backend --lib (318 pass), cargo clippy -p backend clean, cargo fmt clean.