### PR TITLE
Inline format args in portal-update

### DIFF
--- a/.0-pr-viz/001842.svg
+++ b/.0-pr-viz/001842.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1842 · Inline format args in portal-update</text>
+
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Two format sites spelled variables positionally; now inlined captures,</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">so the strings read as written and the pedantic lint goes quiet.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="250" width="860" height="132" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="292" font-size="26" fill="#7aa2f7">positional args x2</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">binary_name_for plus the GitHub api_url</text>
+    <text x="104" y="364" font-size="22" fill="#565f89">portal-update/src/lib.rs</text>
+  </g>
+  <g>
+    <rect x="80" y="402" width="860" height="132" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="444" font-size="26" fill="#7aa2f7">api_url sprawled over 4 lines</text>
+    <text x="104" y="482" font-size="23" fill="#a9b1d6">format string plus a trailing GITHUB_REPO arg</text>
+    <text x="104" y="516" font-size="22" fill="#565f89">uninlined_format_args pedantic</text>
+  </g>
+  <line x1="510" y1="534" x2="510" y2="940" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+  <g>
+    <rect x="80" y="960" width="860" height="120" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="1006" font-size="26" fill="#c0caf5">noise around two strings</text>
+    <text x="104" y="1046" font-size="23" fill="#f7768e">eyes jump between template and arg list</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="250" width="860" height="132" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="292" font-size="26" fill="#9ece6a">inlined captures</text>
+    <text x="1089" y="330" font-size="23" fill="#a9b1d6">name-os-arch-ext on one line, api_url on one</text>
+    <text x="1089" y="364" font-size="22" fill="#565f89">output byte-identical, clippy clean</text>
+  </g>
+  <line x1="1495" y1="382" x2="1495" y2="940" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+  <g>
+    <rect x="1065" y="960" width="860" height="120" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="1006" font-size="26" fill="#9ece6a">strings read as written</text>
+    <text x="1089" y="1046" font-size="23" fill="#a9b1d6">template and values in one place</text>
+  </g>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">Cosmetic; no URL, filename, or update logic changes.</text>
+</svg>

--- a/portal-update/src/lib.rs
+++ b/portal-update/src/lib.rs
@@ -75,7 +75,7 @@ fn binary_name_for(binary_prefix: &str, os: &str, arch: &str) -> String {
         return binary_prefix.to_string();
     }
     let ext = if os == "windows" { ".exe" } else { "" };
-    format!("{}-{}-{}{}", binary_prefix, os, arch, ext)
+    format!("{binary_prefix}-{os}-{arch}{ext}")
 }
 
 /// GitHub release asset from the API
@@ -132,10 +132,7 @@ pub async fn check_for_update(binary_prefix: &str, check_only: bool) -> Result<U
         .context("Failed to create HTTP client")?;
 
     // Get the latest release from GitHub API
-    let api_url = format!(
-        "https://api.github.com/repos/{}/releases/tags/latest",
-        GITHUB_REPO
-    );
+    let api_url = format!("https://api.github.com/repos/{GITHUB_REPO}/releases/tags/latest");
 
     let resp = client
         .get(&api_url)


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/7597adb6165132260754ad5045351f69b8737b35/.0-pr-viz/001842.svg)

binary_name_for and the GitHub API URL used positional format args. Inlined (clippy::pedantic uninlined_format_args); the multi-line api_url format collapses to one line. Output identical.

cargo clippy -p portal-update clean.