### PR TITLE
Document portal-update error modes

### DIFF
--- a/.0-pr-viz/001843.svg
+++ b/.0-pr-viz/001843.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1843 · Document portal-update error modes</text>
+
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Two Result-returning fns never said when they fail; now Errors</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">sections name the modes, so callers know what failure can be.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="250" width="860" height="132" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="292" font-size="26" fill="#7aa2f7">Result with no Errors x2</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">check_for_update plus startup_auto_update</text>
+    <text x="104" y="364" font-size="22" fill="#565f89">missing_errors_doc pedantic warnings</text>
+  </g>
+  <line x1="510" y1="382" x2="510" y2="940" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+  <g>
+    <rect x="80" y="960" width="860" height="120" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="1006" font-size="26" fill="#c0caf5">failure modes live only in code</text>
+    <text x="104" y="1046" font-size="23" fill="#f7768e">callers grep bodies to learn what Err means</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="250" width="860" height="132" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="292" font-size="26" fill="#9ece6a">Errors sections name the modes</text>
+    <text x="1089" y="330" font-size="23" fill="#a9b1d6">fetch, read, platform, install failures listed</text>
+    <text x="1089" y="364" font-size="22" fill="#565f89">propagation vs swallowed swap spelled out</text>
+  </g>
+  <line x1="1495" y1="382" x2="1495" y2="940" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+  <g>
+    <rect x="1065" y="960" width="860" height="120" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="1006" font-size="26" fill="#9ece6a">failure modes documented</text>
+    <text x="1089" y="1046" font-size="23" fill="#a9b1d6">cargo doc clean, docs only</text>
+  </g>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">Docs only; signatures and update behavior unchanged.</text>
+</svg>

--- a/portal-update/src/lib.rs
+++ b/portal-update/src/lib.rs
@@ -107,6 +107,12 @@ fn sha256_hex(bytes: &[u8]) -> String {
 ///
 /// `binary_prefix` is the base name (e.g. "claude-portal" or "agent-portal").
 /// If `check_only` is true, reports availability without installing.
+///
+/// # Errors
+///
+/// Returns `Err` when the current executable can't be located or read, the
+/// platform is unsupported, or any step of the GitHub fetch / download /
+/// install fails (network, non-2xx status, unparseable JSON, filesystem).
 pub async fn check_for_update(binary_prefix: &str, check_only: bool) -> Result<UpdateResult> {
     let self_path = std::env::current_exe().context("Failed to get current executable path")?;
     let self_bytes = fs::read(&self_path).context("Failed to read current binary")?;
@@ -419,6 +425,11 @@ fn apply_pending_update() -> Result<bool> {
 /// Returns `Ok(true)` when the binary was replaced and the process should
 /// restart, `Ok(false)` when it is already current (or `check` is false).
 /// Callers decide whether a check failure is fatal.
+///
+/// # Errors
+///
+/// Propagates the [`check_for_update`] failure when `check` is true. A pending
+/// Windows swap that can't be applied is swallowed (logged, retried next run).
 pub async fn startup_auto_update(binary_prefix: &str, check: bool) -> Result<bool> {
     // Failure to apply a pending update is non-fatal; the swap is logged
     // and retried on the next startup.


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/b4e2f9af7080b0965f17403606be234c0964eebd/.0-pr-viz/001843.svg)

check_for_update and startup_auto_update return Result with no # Errors section (clippy::pedantic missing_errors_doc). Added both: fetch/read/platform/install failures for the former, check-propagation vs swallowed swap failure for the latter. Docs only; cargo doc clean.