### PR TITLE
Borrow string args in portal-stt

### DIFF
--- a/.0-pr-viz/001844.svg
+++ b/.0-pr-viz/001844.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1844 · Borrow string args in portal-stt</text>
+
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Two fns took owned strings they only read; now borrows, so callers</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">stop moving allocations the callee never needed to own.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="250" width="860" height="132" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="292" font-size="26" fill="#7aa2f7">term: String, headers: Vec</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">push_term plus signed_request move to read</text>
+    <text x="104" y="364" font-size="22" fill="#565f89">needless_pass_by_value pedantic</text>
+  </g>
+  <line x1="510" y1="382" x2="510" y2="940" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+  <g>
+    <rect x="80" y="960" width="860" height="120" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="1006" font-size="26" fill="#c0caf5">temporaries allocated to be moved</text>
+    <text x="104" y="1046" font-size="23" fill="#f7768e">to_string at the call, to_string in the body</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="250" width="860" height="132" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="292" font-size="26" fill="#9ece6a">term: str, headers: slice</text>
+    <text x="1089" y="330" font-size="23" fill="#a9b1d6">5 plus 3 call sites pass borrows</text>
+    <text x="1089" y="364" font-size="22" fill="#565f89">74 portal-stt tests green</text>
+  </g>
+  <line x1="1495" y1="382" x2="1495" y2="940" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+  <g>
+    <rect x="1065" y="960" width="860" height="120" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="1006" font-size="26" fill="#9ece6a">no more needless moves</text>
+    <text x="1089" y="1046" font-size="23" fill="#a9b1d6">one allocation per term instead of two</text>
+  </g>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">No behavior change; temporaries at two call sites disappear.</text>
+</svg>

--- a/portal-stt/src/keyterms.rs
+++ b/portal-stt/src/keyterms.rs
@@ -35,21 +35,21 @@ pub fn session_keyterms(
     let mut terms: Vec<String> = Vec::new();
 
     if let Some(repo) = repo_url.and_then(repo_name) {
-        push_term(&mut terms, repo);
+        push_term(&mut terms, &repo);
     }
     if let Some(branch) = git_branch {
         // A branch like `meawoppl/multi-provider-identity-model` is a phrase
         // someone will dictate almost verbatim, so contribute both the whole
         // slug and its words.
-        push_term(&mut terms, branch.to_string());
+        push_term(&mut terms, branch);
         for word in split_slug(branch) {
-            push_term(&mut terms, word);
+            push_term(&mut terms, &word);
         }
     }
     if let Some(leaf) = path_leaf(working_directory) {
-        push_term(&mut terms, leaf);
+        push_term(&mut terms, &leaf);
     }
-    push_term(&mut terms, agent_type.to_string());
+    push_term(&mut terms, agent_type);
 
     terms.truncate(MAX_KEYTERMS);
     terms
@@ -57,7 +57,7 @@ pub fn session_keyterms(
 
 /// Add a term unless it is empty, a stop word, or already present
 /// (case-insensitively).
-fn push_term(terms: &mut Vec<String>, term: String) {
+fn push_term(terms: &mut Vec<String>, term: &str) {
     let term = term.trim().trim_matches('/').to_string();
     if term.len() < 3 || term.len() > 64 {
         return;

--- a/portal-stt/src/providers/aws.rs
+++ b/portal-stt/src/providers/aws.rs
@@ -231,7 +231,7 @@ impl AwsStt {
             ("x-amz-target".to_string(), format!("Transcribe.{target}")),
         ];
 
-        let request = self.signed_request("POST", &url, headers, body, "transcribe")?;
+        let request = self.signed_request("POST", &url, &headers, body, "transcribe")?;
         let response = self.http.execute(request).await.map_err(transport)?;
         ensure_ok(response).await?.text().await.map_err(decode)
     }
@@ -244,14 +244,14 @@ impl AwsStt {
     ) -> Result<(), SttError> {
         let url = self.object_url(key);
         let headers = vec![("content-type".to_string(), content_type.to_string())];
-        let request = self.signed_request("PUT", &url, headers, audio.to_vec(), "s3")?;
+        let request = self.signed_request("PUT", &url, &headers, audio.to_vec(), "s3")?;
         let response = self.http.execute(request).await.map_err(transport)?;
         ensure_ok(response).await.map(|_| ())
     }
 
     async fn delete_object(&self, key: &str) -> Result<(), SttError> {
         let url = self.object_url(key);
-        let request = self.signed_request("DELETE", &url, Vec::new(), Vec::new(), "s3")?;
+        let request = self.signed_request("DELETE", &url, &[], Vec::new(), "s3")?;
         let response = self.http.execute(request).await.map_err(transport)?;
         ensure_ok(response).await.map(|_| ())
     }
@@ -269,7 +269,7 @@ impl AwsStt {
         &self,
         method: &str,
         url: &str,
-        headers: Vec<(String, String)>,
+        headers: &[(String, String)],
         body: Vec<u8>,
         service: &str,
     ) -> Result<reqwest::Request, SttError> {
@@ -308,7 +308,7 @@ impl AwsStt {
             .into_parts();
 
         let mut builder = http::Request::builder().method(method).uri(url);
-        for (name, value) in &headers {
+        for (name, value) in headers {
             builder = builder.header(name, value);
         }
         let mut http_request = builder


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/6d4aac0e9bfa7a27ec3045e109d1e17a087e8670/.0-pr-viz/001844.svg)

push_term took term: String but only needed &str (5 callers updated; the branch/agent temporaries no longer allocate at the call). signed_request took headers: Vec but only iterated it (3 callers pass &headers / &[]; the & removed from the in-body loop). clippy::pedantic needless_pass_by_value gone.

cargo test -p portal-stt --lib (74 pass), clippy clean.