### PR TITLE
Drop redundant syntax in launcher

### DIFF
--- a/.0-pr-viz/001845.svg
+++ b/.0-pr-viz/001845.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1845 · Drop redundant syntax in launcher</text>
+
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">An ack handler nested if/else around diverging breaks, and a raw</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">string wore unneeded hashes; now flat flow, plain raw string.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="250" width="860" height="132" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="292" font-size="26" fill="#7aa2f7">else around breaks, hashes around text</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">ack loop nests twice; unit file needs no hashes</text>
+    <text x="104" y="364" font-size="22" fill="#565f89">connection.rs plus service.rs</text>
+  </g>
+  <line x1="510" y1="382" x2="510" y2="940" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+  <g>
+    <rect x="80" y="960" width="860" height="120" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="1006" font-size="26" fill="#c0caf5">syntax louder than logic</text>
+    <text x="104" y="1046" font-size="23" fill="#f7768e">two redundant_else plus raw-string pedantics</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="250" width="860" height="132" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="292" font-size="26" fill="#9ece6a">flat ifs, plain raw string</text>
+    <text x="1089" y="330" font-size="23" fill="#a9b1d6">breaks diverge, so nesting says nothing</text>
+    <text x="1089" y="364" font-size="22" fill="#565f89">12 connection tests green</text>
+  </g>
+  <line x1="1495" y1="382" x2="1495" y2="940" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+  <g>
+    <rect x="1065" y="960" width="860" height="120" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="1006" font-size="26" fill="#9ece6a">syntax says what it means</text>
+    <text x="1089" y="1046" font-size="23" fill="#a9b1d6">unit output byte-identical</text>
+  </g>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">Cosmetic; registration flow and unit output byte-identical.</text>
+</svg>

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -140,16 +140,14 @@ pub async fn run_launcher_loop(
                             if success {
                                 info!("Registration successful");
                                 break Ok(true);
-                            } else {
-                                let msg = error.unwrap_or_default();
-                                if fatal {
-                                    error!("Registration rejected (fatal): {}", msg);
-                                    break Err(classify_fatal(reject_reason, &msg));
-                                } else {
-                                    error!("Registration failed: {}", msg);
-                                    break Ok(false);
-                                }
                             }
+                            let msg = error.unwrap_or_default();
+                            if fatal {
+                                error!("Registration rejected (fatal): {}", msg);
+                                break Err(classify_fatal(reject_reason, &msg));
+                            }
+                            error!("Registration failed: {}", msg);
+                            break Ok(false);
                         }
                         Some(Ok(_)) => continue,
                         Some(Err(e)) => {

--- a/launcher/src/service.rs
+++ b/launcher/src/service.rs
@@ -77,7 +77,7 @@ fn service_file_path() -> Result<std::path::PathBuf> {
 fn generate_unit(binary_path: &str) -> String {
     let path = service_path(binary_path);
     format!(
-        r#"[Unit]
+        r"[Unit]
 Description=Agent Launcher
 After=network-online.target
 Wants=network-online.target
@@ -91,7 +91,7 @@ RestartSec=5
 
 [Install]
 WantedBy=default.target
-"#
+"
     )
 }
 


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/de71a2a876fb3053731a3e09a4ef282ebc277fe4/.0-pr-viz/001845.svg)

Two pedantic nits: the registration-ack handler nested if/else around breaks that already diverge (un-nested, behavior identical), and generate_unit used r#"..."# hashes around a unit file containing no double quotes. 12 connection tests pass, clippy clean.