### PR TITLE
Unnest or-patterns in match arms

### DIFF
--- a/.0-pr-viz/001846.svg
+++ b/.0-pr-viz/001846.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1846 · Unnest or-patterns in match arms</text>
+
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Two arms or-ed whole wrappers; now the or sits inside, so each</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">pattern nests once instead of twice.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="250" width="860" height="132" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="292" font-size="26" fill="#7aa2f7">or outside the wrapper x2</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">Some-or-Some in media and pending checks</text>
+    <text x="104" y="364" font-size="22" fill="#565f89">unnested_or_patterns pedantic</text>
+  </g>
+  <line x1="510" y1="382" x2="510" y2="940" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+  <g>
+    <rect x="80" y="960" width="860" height="120" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="1006" font-size="26" fill="#c0caf5">wrapper repeated per alternative</text>
+    <text x="104" y="1046" font-size="23" fill="#f7768e">two Some spellings for one idea</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="250" width="860" height="132" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="292" font-size="26" fill="#9ece6a">or inside the wrapper x2</text>
+    <text x="1089" y="330" font-size="23" fill="#a9b1d6">one Some around the alternatives</text>
+    <text x="1089" y="364" font-size="22" fill="#565f89">187 shared plus 9 media tests green</text>
+  </g>
+  <line x1="1495" y1="382" x2="1495" y2="940" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+  <g>
+    <rect x="1065" y="960" width="860" height="120" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="1006" font-size="26" fill="#9ece6a">one nesting level</text>
+    <text x="1089" y="1046" font-size="23" fill="#a9b1d6">matched values unchanged</text>
+  </g>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">Cosmetic; matched values unchanged.</text>
+</svg>

--- a/launcher/src/media.rs
+++ b/launcher/src/media.rs
@@ -51,7 +51,7 @@ pub(crate) fn detect_content_type(path: &Path, bytes: &[u8]) -> Result<&'static 
 
     let (content_type, magic_ok) = match ext.as_deref() {
         Some("png") => ("image/png", has_png_magic(bytes)),
-        Some("jpg") | Some("jpeg") => ("image/jpeg", has_jpeg_magic(bytes)),
+        Some("jpg" | "jpeg") => ("image/jpeg", has_jpeg_magic(bytes)),
         Some("gif") => ("image/gif", has_gif_magic(bytes)),
         Some("webp") => ("image/webp", has_webp_magic(bytes)),
         Some("svg") => ("image/svg+xml", looks_like_svg(bytes)),

--- a/shared/src/endpoints/client.rs
+++ b/shared/src/endpoints/client.rs
@@ -102,7 +102,7 @@ impl DeliveryMeta {
     pub fn pending(&self) -> bool {
         !matches!(
             self.stage,
-            Some(InputDeliveryStage::AgentAccepted) | Some(InputDeliveryStage::Failed)
+            Some(InputDeliveryStage::AgentAccepted | InputDeliveryStage::Failed)
         )
     }
 }


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/f9caa2d13eebfe032c5a99df2ca74b11c928129c/.0-pr-viz/001846.svg)

Some("jpg") | Some("jpeg") and Some(Accepted) | Some(Failed) nested the or outside the wrapper. Un-nested to Some("jpg" | "jpeg") and Some(Accepted | Failed) (clippy::pedantic). Same matches, less nesting.

cargo test -p shared --lib (187 pass), launcher media tests (9 pass).