### PR TITLE
Simplify two shim matches

### DIFF
--- a/.0-pr-viz/001847.svg
+++ b/.0-pr-viz/001847.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1847 · Simplify two shim matches</text>
+
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">A match used only to continue on Err, and twin arms with one body;</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">now let-else and a single combined arm.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="250" width="860" height="132" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="292" font-size="26" fill="#7aa2f7">match only to continue on Err</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">raw-JSON fallback spells Ok-continue by hand</text>
+    <text x="104" y="364" font-size="22" fill="#565f89">proxy/src/shim.rs reader loop</text>
+  </g>
+  <g>
+    <rect x="80" y="402" width="860" height="132" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="444" font-size="26" fill="#7aa2f7">twin arms, one request_id body</text>
+    <text x="104" y="482" font-size="23" fill="#a9b1d6">Success and Error arms differ only in variant</text>
+    <text x="104" y="516" font-size="22" fill="#565f89">identical match arms pedantic</text>
+  </g>
+  <line x1="510" y1="534" x2="510" y2="940" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+  <g>
+    <rect x="80" y="960" width="860" height="120" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="1006" font-size="26" fill="#c0caf5">ceremony around two outcomes</text>
+    <text x="104" y="1046" font-size="23" fill="#f7768e">four lines where one shape fits</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="250" width="860" height="132" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="292" font-size="26" fill="#9ece6a">let Ok(raw) else continue</text>
+    <text x="1089" y="330" font-size="23" fill="#a9b1d6">non-JSON lines skip the portal path as before</text>
+    <text x="1089" y="364" font-size="22" fill="#565f89">clippy-prescribed rewrite</text>
+  </g>
+  <g>
+    <rect x="1065" y="402" width="860" height="132" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="444" font-size="26" fill="#9ece6a">Success | Error in one arm</text>
+    <text x="1089" y="482" font-size="23" fill="#a9b1d6">request_id binds once for both variants</text>
+    <text x="1089" y="516" font-size="22" fill="#565f89">shim tests green</text>
+  </g>
+  <line x1="1495" y1="534" x2="1495" y2="940" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+  <g>
+    <rect x="1065" y="960" width="860" height="120" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="1006" font-size="26" fill="#9ece6a">clippy-prescribed shapes</text>
+    <text x="1089" y="1046" font-size="23" fill="#a9b1d6">same outcomes, half the match</text>
+  </g>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">Behavior identical; stdout parsing and permission tracking untouched.</text>
+</svg>

--- a/proxy/src/shim.rs
+++ b/proxy/src/shim.rs
@@ -307,9 +307,8 @@ async fn run_shim_loop(
                 // pre-refactor behavior). The `stream_event` filter from before the
                 // refactor is preserved here for parity.
                 None => {
-                    let raw = match serde_json::from_str::<serde_json::Value>(&line) {
-                        Ok(v) => v,
-                        Err(_) => continue, // non-JSON: don't forward to portal
+                    let Ok(raw) = serde_json::from_str::<serde_json::Value>(&line) else {
+                        continue; // non-JSON: don't forward to portal
                     };
                     let msg_type = raw.get("type").and_then(|t| t.as_str());
                     if matches!(msg_type, Some("stream_event")) {
@@ -343,8 +342,8 @@ async fn run_shim_loop(
                 serde_json::from_str::<ClaudeOutput>(&line)
             {
                 let request_id = match &resp.response {
-                    ControlResponsePayload::Success { request_id, .. } => request_id,
-                    ControlResponsePayload::Error { request_id, .. } => request_id,
+                    ControlResponsePayload::Success { request_id, .. }
+                    | ControlResponsePayload::Error { request_id, .. } => request_id,
                 };
                 let mut perms = permissions_for_stdin.lock().await;
                 if let Some(state) = perms.get_mut(request_id) {


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/a399be31b71589dc1d76bc2cb0e7dce42d02f259/.0-pr-viz/001847.svg)

The raw-JSON fallback used match/Ok/Err-continue where let-else says it directly (clippy-prescribed rewrite), and the ControlResponse request_id match had two identical arms differing only in variant (combined with |). Behavior identical.

cargo test -p claude-portal (shim tests pass), clippy clean.