### PR TITLE
Inline format args across proxy

### DIFF
--- a/.0-pr-viz/001848.svg
+++ b/.0-pr-viz/001848.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1848 · Inline format args across proxy</text>
+
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Seven format sites spelled variables positionally across four</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">files; now inlined captures, one mechanical theme.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="250" width="860" height="132" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="292" font-size="26" fill="#7aa2f7">positional args x7</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">config, shim, ui, and util all spell them out</text>
+    <text x="104" y="364" font-size="22" fill="#565f89">pid, bail, errors, Backend line, port</text>
+  </g>
+  <line x1="510" y1="382" x2="510" y2="940" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+  <g>
+    <rect x="80" y="960" width="860" height="120" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="1006" font-size="26" fill="#c0caf5">same nit in four files</text>
+    <text x="104" y="1046" font-size="23" fill="#f7768e">uninlined_format_args pedantic x7</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="250" width="860" height="132" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="292" font-size="26" fill="#9ece6a">inlined captures x7</text>
+    <text x="1089" y="330" font-size="23" fill="#a9b1d6">one theme, applied file by file</text>
+    <text x="1089" y="364" font-size="22" fill="#565f89">7 proxy tests green, output identical</text>
+  </g>
+  <line x1="1495" y1="382" x2="1495" y2="940" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+  <g>
+    <rect x="1065" y="960" width="860" height="120" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="1006" font-size="26" fill="#9ece6a">one theme, four files</text>
+    <text x="1089" y="1046" font-size="23" fill="#a9b1d6">user-visible strings byte-identical</text>
+  </g>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">Cosmetic; user-visible strings byte-identical.</text>
+</svg>

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -86,7 +86,7 @@ impl ConfigLock {
                 Ok(mut file) => {
                     // Write our PID to the lock file
                     let pid = std::process::id();
-                    writeln!(file, "{}", pid)?;
+                    writeln!(file, "{pid}")?;
                     file.flush()?;
 
                     return Ok(ConfigLock {
@@ -117,8 +117,7 @@ impl ConfigLock {
                     attempts += 1;
                     if attempts >= max_attempts {
                         anyhow::bail!(
-                            "Failed to acquire config lock after {} attempts",
-                            max_attempts
+                            "Failed to acquire config lock after {max_attempts} attempts"
                         );
                     }
                     std::thread::sleep(Duration::from_millis(100));

--- a/proxy/src/shim.rs
+++ b/proxy/src/shim.rs
@@ -77,7 +77,7 @@ pub async fn run_shim(config: ProxySessionConfig) -> Result<()> {
     let stderr_task = tokio::spawn(async move {
         let mut reader = BufReader::new(claude_stderr).lines();
         while let Ok(Some(line)) = reader.next_line().await {
-            eprintln!("{}", line);
+            eprintln!("{line}");
         }
     });
 
@@ -149,7 +149,7 @@ fn spawn_claude(
     );
 
     cmd.spawn()
-        .map_err(|e| anyhow::anyhow!("Failed to spawn claude: {}", e))
+        .map_err(|e| anyhow::anyhow!("Failed to spawn claude: {e}"))
 }
 
 /// Main shim loop with WebSocket reconnection.

--- a/proxy/src/ui.rs
+++ b/proxy/src/ui.rs
@@ -128,7 +128,7 @@ pub fn print_init_start(email: &str) {
 /// Print init complete
 pub fn print_init_complete(email: &str, backend_url: &str) {
     println!("{} Configuration saved for {}", "✓".bright_green(), email);
-    println!("  Backend: {}", backend_url);
+    println!("  Backend: {backend_url}");
     println!();
     println!(
         "You can now run {} without arguments.",

--- a/proxy/src/util.rs
+++ b/proxy/src/util.rs
@@ -42,14 +42,14 @@ fn parse_init_url(value: &str) -> Result<(Option<String>, String)> {
         "{}://{}{}",
         ws_scheme,
         url.host_str().unwrap_or("localhost"),
-        url.port().map(|p| format!(":{}", p)).unwrap_or_default()
+        url.port().map(|p| format!(":{p}")).unwrap_or_default()
     );
 
     // Extract config from path (expected: /p/{config})
     let path = url.path();
     if let Some(config_part) = path.strip_prefix("/p/") {
         let config = ProxyInitConfig::decode(config_part)
-            .map_err(|e| anyhow::anyhow!("Failed to decode init config from URL: {}", e))?;
+            .map_err(|e| anyhow::anyhow!("Failed to decode init config from URL: {e}"))?;
 
         return Ok((Some(ws_url), config.token));
     }
@@ -91,7 +91,7 @@ fn base64_url_decode(input: &str) -> Result<Vec<u8>> {
         .collect();
     BASE64_URL
         .decode(filtered)
-        .map_err(|e| anyhow::anyhow!("Invalid base64url: {}", e))
+        .map_err(|e| anyhow::anyhow!("Invalid base64url: {e}"))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/02ea82a41eebb32ecfb5fe75dfa2dfc9c8b54913/.0-pr-viz/001848.svg)

Seven positional format args across config, shim, ui, and util inlined (clippy::pedantic uninlined_format_args): lock-file pid, lock-attempts bail, stderr passthrough, spawn error, Backend line, port, and two anyhow contexts. Output identical.

cargo test -p claude-portal (7 pass), clippy clean.