### PR TITLE
Return PathBuf directly from config_path

### DIFF
--- a/.0-pr-viz/001849.svg
+++ b/.0-pr-viz/001849.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1849 · Return PathBuf directly from config_path</text>
+
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">config_path wrapped an infallible join in Result; now PathBuf, so</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">four callers drop the ?, and the phantom failure mode is gone.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="250" width="860" height="132" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="292" font-size="26" fill="#7aa2f7">Ok(join) plus four ? marks</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">load, save, and locked variants all unwrap air</text>
+    <text x="104" y="364" font-size="22" fill="#565f89">unnecessary_wrapped_result pedantic</text>
+  </g>
+  <line x1="510" y1="382" x2="510" y2="940" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+  <g>
+    <rect x="80" y="960" width="860" height="120" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="1006" font-size="26" fill="#c0caf5">a failure mode that never was</text>
+    <text x="104" y="1046" font-size="23" fill="#f7768e">readers brace for an error join cannot make</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="250" width="860" height="132" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="292" font-size="26" fill="#9ece6a">plain PathBuf return</text>
+    <text x="1089" y="330" font-size="23" fill="#a9b1d6">config_dir is infallible, so the join is too</text>
+    <text x="1089" y="364" font-size="22" fill="#565f89">7 proxy tests green</text>
+  </g>
+  <line x1="1495" y1="382" x2="1495" y2="940" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+  <g>
+    <rect x="1065" y="960" width="860" height="120" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="1006" font-size="26" fill="#9ece6a">no phantom failure</text>
+    <text x="1089" y="1046" font-size="23" fill="#a9b1d6">four callers drop the question mark</text>
+  </g>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">No other callers workspace-wide; stored config format untouched.</text>
+</svg>

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -136,12 +136,12 @@ impl Drop for ConfigLock {
 }
 
 impl ProxyConfig {
-    pub fn config_path() -> Result<PathBuf> {
-        Ok(session_lib::paths::config_dir().join("config.json"))
+    pub fn config_path() -> PathBuf {
+        session_lib::paths::config_dir().join("config.json")
     }
 
     pub fn load() -> Result<Self> {
-        let path = Self::config_path()?;
+        let path = Self::config_path();
 
         if !path.exists() {
             return Ok(Self::default());
@@ -158,7 +158,7 @@ impl ProxyConfig {
     /// Atomically save the config with file locking
     /// This prevents race conditions when multiple proxy instances run in the same directory
     pub fn atomic_save(&self) -> Result<()> {
-        let path = Self::config_path()?;
+        let path = Self::config_path();
         let lock = ConfigLock::acquire(&path)?;
         self.save_with_lock(&lock)
         // Lock is released on drop
@@ -166,7 +166,7 @@ impl ProxyConfig {
 
     /// Load config with file locking (for read-modify-write operations)
     pub fn load_locked() -> Result<(Self, ConfigLock)> {
-        let path = Self::config_path()?;
+        let path = Self::config_path();
         let lock = ConfigLock::acquire(&path)?;
 
         let config = if path.exists() {
@@ -181,7 +181,7 @@ impl ProxyConfig {
 
     /// Save config while holding a lock
     pub fn save_with_lock(&self, _lock: &ConfigLock) -> Result<()> {
-        let path = Self::config_path()?;
+        let path = Self::config_path();
 
         // Create parent directory if it doesn't exist
         if let Some(parent) = path.parent() {


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/535e52d93135dc131795af59fb4abaf27f6dc023/.0-pr-viz/001849.svg)

ProxyConfig::config_path wrapped an infallible join in Result (clippy::pedantic unnecessary_wrapped_result). Now returns PathBuf; the four callers (load, atomic_save, load_locked, save_with_lock) drop the ?. No other callers in the workspace.

cargo test -p claude-portal (7 pass), clippy clean.