### PR TITLE
Decode refuse reason without Result

### DIFF
--- a/.0-pr-viz/001850.svg
+++ b/.0-pr-viz/001850.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1850 · Decode refuse reason without Result</text>
+
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Every decode arm was Ok, so the Result could never fail; now a plain</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">return, and the twin Protocol arm folds into the wildcard.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="250" width="860" height="132" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="292" font-size="26" fill="#7aa2f7">Result with all-Ok arms</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">refuse_reason_from_code cannot produce Err</text>
+    <text x="104" y="364" font-size="22" fill="#565f89">shared/src/endpoints/tunnel.rs</text>
+  </g>
+  <g>
+    <rect x="80" y="402" width="860" height="132" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="444" font-size="26" fill="#7aa2f7">twin Protocol arms</text>
+    <text x="104" y="482" font-size="23" fill="#a9b1d6">3 maps to Protocol, wildcard maps to Protocol</text>
+    <text x="104" y="516" font-size="22" fill="#565f89">identical-arms plus wrapped-result pedantics</text>
+  </g>
+  <line x1="510" y1="534" x2="510" y2="940" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+  <g>
+    <rect x="80" y="960" width="860" height="120" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="1006" font-size="26" fill="#c0caf5">degrade path wears error clothes</text>
+    <text x="104" y="1046" font-size="23" fill="#f7768e">callers ? on a failure that cannot happen</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="250" width="860" height="132" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="292" font-size="26" fill="#9ece6a">plain TunnelRefuseReason return</text>
+    <text x="1089" y="330" font-size="23" fill="#a9b1d6">call site drops the question mark</text>
+    <text x="1089" y="364" font-size="22" fill="#565f89">16 tunnel tests green</text>
+  </g>
+  <g>
+    <rect x="1065" y="402" width="860" height="132" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="444" font-size="26" fill="#9ece6a">wildcard covers code 3</text>
+    <text x="1089" y="482" font-size="23" fill="#a9b1d6">unknown reasons still degrade to Protocol</text>
+    <text x="1089" y="516" font-size="22" fill="#565f89">documented degrade-by-design preserved</text>
+  </g>
+  <line x1="1495" y1="534" x2="1495" y2="940" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+  <g>
+    <rect x="1065" y="960" width="860" height="120" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="1006" font-size="26" fill="#9ece6a">unrepresentable Err gone</text>
+    <text x="1089" y="1046" font-size="23" fill="#a9b1d6">type says total, body stays total</text>
+  </g>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">Wire contract unchanged: unknown reasons still degrade, never strand.</text>
+</svg>

--- a/shared/src/endpoints/tunnel.rs
+++ b/shared/src/endpoints/tunnel.rs
@@ -197,16 +197,15 @@ fn refuse_reason_code(reason: TunnelRefuseReason) -> u8 {
     }
 }
 
-fn refuse_reason_from_code(code: u8) -> Result<TunnelRefuseReason, DecodeError> {
+fn refuse_reason_from_code(code: u8) -> TunnelRefuseReason {
     match code {
-        0 => Ok(TunnelRefuseReason::NoListener),
-        1 => Ok(TunnelRefuseReason::StreamLimit),
-        2 => Ok(TunnelRefuseReason::NotForwarded),
-        3 => Ok(TunnelRefuseReason::Protocol),
+        0 => TunnelRefuseReason::NoListener,
+        1 => TunnelRefuseReason::StreamLimit,
+        2 => TunnelRefuseReason::NotForwarded,
         // A newer peer sent a reason this build doesn't know. Degrade to
         // `Protocol` rather than dropping the frame: the stream still has to be
         // failed, and inventing a decode error would strand it half-open.
-        _ => Ok(TunnelRefuseReason::Protocol),
+        _ => TunnelRefuseReason::Protocol,
     }
 }
 
@@ -318,7 +317,7 @@ impl WsCodec for TunnelFrame {
                 exact_len(&body[n..], 1, "Refused")?;
                 Ok(Self::Refused {
                     stream_id,
-                    reason: refuse_reason_from_code(body[n])?,
+                    reason: refuse_reason_from_code(body[n]),
                 })
             }
             TAG_DATA => {


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/8b027afd50ab1640f9e90fb2060427beb625e8f0/.0-pr-viz/001850.svg)

refuse_reason_from_code returned Result but every arm was Ok (unknown codes degrade to Protocol by documented design, so Err is unrepresentable). Now returns TunnelRefuseReason directly; the call site drops the ?. The 3 => arm merged into the wildcard (they had identical bodies). Wire behavior identical.

cargo test -p shared --lib tunnel (16 pass), pedantic lints gone.