### PR TITLE
Extract stub-frontend-dist into shared CI action

### DIFF
--- a/.0-pr-viz/001853.svg
+++ b/.0-pr-viz/001853.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <!-- Header -->
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1853 · Extract stub-frontend-dist into shared CI action</text>
+
+  <!-- Thesis -->
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">The mkdir -p frontend/dist stub was pasted in four jobs — three copies of a 5-line</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">comment plus one bare; now one composite action owns the why, each job is one line.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <!-- Panel labels + center divider -->
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <!-- ==================== BEFORE panel: x 55–945 ==================== -->
+
+  <g>
+    <rect x="80" y="250" width="810" height="200" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="290" font-size="26" fill="#7aa2f7">clippy · build-backend · test</text>
+    <text x="104" y="330" font-size="23" fill="#f7768e">- name: Stub frontend dist</text>
+    <text x="104" y="366" font-size="23" fill="#f7768e"># Backend embeds frontend/dist … (5 lines)</text>
+    <text x="104" y="402" font-size="23" fill="#f7768e">run: mkdir -p frontend/dist</text>
+  </g>
+
+  <g>
+    <rect x="80" y="470" width="810" height="165" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="510" font-size="26" fill="#7aa2f7">e2e-tests</text>
+    <text x="104" y="550" font-size="23" fill="#f7768e">- name: Stub frontend dist</text>
+    <text x="104" y="586" font-size="23" fill="#f7768e">run: mkdir -p frontend/dist  (no comment)</text>
+  </g>
+
+  <line x1="485" y1="635" x2="485" y2="675" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+
+  <g>
+    <rect x="80" y="695" width="810" height="200" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="741" font-size="26" fill="#c0caf5">four copies of one step</text>
+    <text x="104" y="781" font-size="23" fill="#f7768e">a rationale edit must land in three places —</text>
+    <text x="104" y="817" font-size="23" fill="#f7768e">the fourth already drifted (comment lost)</text>
+    <text x="104" y="857" font-size="22" fill="#565f89">+19 / -4 lines across ci.yml either way</text>
+  </g>
+
+  <!-- ==================== AFTER panel: x 1040–1945 ==================== -->
+
+  <g>
+    <rect x="1065" y="250" width="810" height="200" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1089" y="290" font-size="26" fill="#7aa2f7">.github/actions/stub-frontend-dist</text>
+    <text x="1089" y="330" font-size="23" fill="#9ece6a">runs: mkdir -p frontend/dist (composite)</text>
+    <text x="1089" y="366" font-size="23" fill="#a9b1d6">the 5-line why lives here, exactly once</text>
+    <text x="1089" y="402" font-size="22" fill="#565f89">#1165 item 1: backend lanes need no real bundle</text>
+  </g>
+
+  <line x1="1470" y1="450" x2="1470" y2="490" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <g>
+    <rect x="1065" y="500" width="810" height="230" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="1089" y="540" font-size="26" fill="#c0caf5">clippy · build-backend · test · e2e-tests</text>
+    <text x="1089" y="580" font-size="23" fill="#a9b1d6">- name: Stub frontend dist</text>
+    <text x="1089" y="616" font-size="23" fill="#9ece6a">  uses: ./.github/actions/stub-frontend-dist</text>
+    <text x="1089" y="656" font-size="22" fill="#565f89">same command, same step order — placement only</text>
+    <text x="1089" y="692" font-size="22" fill="#565f89">local ref resolves: step still runs after checkout</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="760" width="810" height="135" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="806" font-size="26" fill="#c0caf5">a single source of truth</text>
+    <text x="1089" y="846" font-size="23" fill="#9ece6a">next rationale edit touches one file, not four</text>
+  </g>
+
+  <!-- Footer -->
+  <text x="55" y="1172" font-size="22" fill="#565f89">No behavior change: identical shell command in all four jobs; the fetch-depth repetitions are left alone.</text>
+</svg>

--- a/.github/actions/stub-frontend-dist/action.yml
+++ b/.github/actions/stub-frontend-dist/action.yml
@@ -1,0 +1,14 @@
+name: Stub frontend dist
+description: >
+  Create an empty frontend/dist so the backend (which embeds
+  frontend/dist at build time, with memory_serve falling back to dynamic
+  loading when it is empty) compiles without depending on — and waiting
+  for — the real build-frontend bundle. Keeps backend lanes independent
+  of frontend/CSS failures (#1165 item 1).
+
+runs:
+  using: composite
+  steps:
+    - name: Stub frontend dist
+      shell: bash
+      run: mkdir -p frontend/dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,12 +96,7 @@ jobs:
           fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
 
       - name: Stub frontend dist
-        # Backend embeds frontend/dist at build time, but memory_serve falls
-        # back to dynamic loading when it is empty. CI compile/test checks do
-        # not need the real bundle, so stub it instead of depending on (and
-        # waiting for) build-frontend. Keeps backend lanes independent of
-        # frontend/CSS failures (#1165 item 1).
-        run: mkdir -p frontend/dist
+        uses: ./.github/actions/stub-frontend-dist
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -122,12 +117,7 @@ jobs:
           fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
 
       - name: Stub frontend dist
-        # Backend embeds frontend/dist at build time, but memory_serve falls
-        # back to dynamic loading when it is empty. CI compile/test checks do
-        # not need the real bundle, so stub it instead of depending on (and
-        # waiting for) build-frontend. Keeps backend lanes independent of
-        # frontend/CSS failures (#1165 item 1).
-        run: mkdir -p frontend/dist
+        uses: ./.github/actions/stub-frontend-dist
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -147,12 +137,7 @@ jobs:
           fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
 
       - name: Stub frontend dist
-        # Backend embeds frontend/dist at build time, but memory_serve falls
-        # back to dynamic loading when it is empty. CI compile/test checks do
-        # not need the real bundle, so stub it instead of depending on (and
-        # waiting for) build-frontend. Keeps backend lanes independent of
-        # frontend/CSS failures (#1165 item 1).
-        run: mkdir -p frontend/dist
+        uses: ./.github/actions/stub-frontend-dist
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -192,7 +177,7 @@ jobs:
           fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
 
       - name: Stub frontend dist
-        run: mkdir -p frontend/dist
+        uses: ./.github/actions/stub-frontend-dist
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/edcbfb12b5df6bae704d2ccf896295e6b85ee35c/.0-pr-viz/001853.svg)

Dedups the copy-pasted `mkdir -p frontend/dist` step (4 jobs: clippy, build-backend, test, e2e) into `.github/actions/stub-frontend-dist`. The 5-line rationale comment now lives once in the action; the e2e job's bare copy gains the documented context too. Same command, same step order — no behavior change.
