### PR TITLE
Add AgentType::display_name, dedupe label matches

### DIFF
--- a/.0-pr-viz/001854.svg
+++ b/.0-pr-viz/001854.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <!-- Header -->
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1854 · Add AgentType::display_name, dedupe label matches</text>
+
+  <!-- Thesis -->
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Three call sites re-matched AgentType just to capitalize the wire name —</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">now shared::AgentType::display_name owns the label, each site is one line.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <!-- Panel labels + center divider -->
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <!-- ==================== BEFORE panel: x 55–945 ==================== -->
+
+  <g>
+    <rect x="80" y="250" width="810" height="235" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="290" font-size="26" fill="#7aa2f7">turn_metrics_display.rs:64</text>
+    <text x="104" y="330" font-size="23" fill="#f7768e">(Claude, None) =&gt; "Claude", … ×3</text>
+    <text x="104" y="366" font-size="23" fill="#a9b1d6">(_, Some(m)) if is_displayable_model(m) =&gt; m</text>
+    <text x="104" y="402" font-size="23" fill="#f7768e">(Claude, Some(_)) =&gt; "Claude", … ×3</text>
+    <text x="104" y="438" font-size="22" fill="#565f89">7 arms to say: model, else agent</text>
+  </g>
+
+  <line x1="485" y1="485" x2="485" y2="525" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+
+  <g>
+    <rect x="80" y="545" width="810" height="200" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="585" font-size="26" fill="#7aa2f7">launch_dialog.rs:699 · demo.rs:758</text>
+    <text x="104" y="625" font-size="23" fill="#f7768e">Claude =&gt; "Claude" / Codex =&gt; "Codex"</text>
+    <text x="104" y="661" font-size="23" fill="#f7768e">Muse =&gt; "Muse" — pasted twice over</text>
+    <text x="104" y="697" font-size="22" fill="#565f89">as_str() gives "claude"; all sites re-capitalize</text>
+  </g>
+
+  <g>
+    <rect x="80" y="765" width="810" height="165" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="811" font-size="26" fill="#c0caf5">a fourth agent means four edits</text>
+    <text x="104" y="851" font-size="23" fill="#f7768e">the label lives nowhere — every match drifts</text>
+    <text x="104" y="887" font-size="23" fill="#f7768e">separately, e.g. grouping.rs already forgot Muse</text>
+  </g>
+
+  <!-- ==================== AFTER panel: x 1040–1945 ==================== -->
+
+  <g>
+    <rect x="1065" y="250" width="810" height="200" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1089" y="290" font-size="26" fill="#7aa2f7">shared/src/lib.rs · AgentType</text>
+    <text x="1089" y="330" font-size="23" fill="#9ece6a">pub fn display_name(self) -&gt; &amp;'static str</text>
+    <text x="1089" y="366" font-size="23" fill="#a9b1d6">Claude/Codex/Muse =&gt; "Claude"/"Codex"/"Muse"</text>
+    <text x="1089" y="402" font-size="22" fill="#565f89">next to as_str(); WASM-safe, no new deps</text>
+  </g>
+
+  <line x1="1470" y1="450" x2="1470" y2="490" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <g>
+    <rect x="1065" y="500" width="810" height="265" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="1089" y="540" font-size="26" fill="#c0caf5">three one-line call sites</text>
+    <text x="1089" y="580" font-size="23" fill="#a9b1d6">model.filter(is_displayable_model), else</text>
+    <text x="1089" y="616" font-size="23" fill="#9ece6a">agent_type.display_name() // metrics chip</text>
+    <text x="1089" y="652" font-size="23" fill="#9ece6a">agent_type.display_name() // launch dialog</text>
+    <text x="1089" y="688" font-size="23" fill="#9ece6a">peer_agent_type.display_name() // demo</text>
+    <text x="1089" y="724" font-size="22" fill="#565f89">7-arm + 3-arm + 3-arm matches all collapse</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="785" width="810" height="145" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="831" font-size="26" fill="#c0caf5">pinned by a unit test</text>
+    <text x="1089" y="871" font-size="23" fill="#9ece6a">agent_type_display_names_are_capitalized</text>
+    <text x="1089" y="907" font-size="22" fill="#565f89">+ existing performance_panel pair-label tests</text>
+  </g>
+
+  <!-- Footer -->
+  <text x="55" y="1172" font-size="22" fill="#565f89">No behavior change: identical strings at every site; +31 / -18 lines.</text>
+</svg>

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -696,11 +696,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
     };
     let selected_agent_missing = agent_installed(&agent_installs, *agent_type) == Some(false);
     let still_probing = *probing_agents && agent_installs.is_empty();
-    let selected_agent_label = match *agent_type {
-        AgentType::Claude => "Claude",
-        AgentType::Codex => "Codex",
-        AgentType::Muse => "Muse",
-    };
+    let selected_agent_label = agent_type.display_name();
 
     // Pre-compute directory listing HTML
     let dir_listing_html = if *dir.loading {

--- a/frontend/src/components/turn_metrics_display.rs
+++ b/frontend/src/components/turn_metrics_display.rs
@@ -61,14 +61,9 @@ pub(crate) fn format_agent_model_tier_label(
     model: &Option<String>,
     tier: &Option<String>,
 ) -> String {
-    let base = match (agent_type, model.as_deref()) {
-        (AgentType::Claude, None) => "Claude".to_string(),
-        (AgentType::Codex, None) => "Codex".to_string(),
-        (AgentType::Muse, None) => "Muse".to_string(),
-        (_, Some(model)) if is_displayable_model(model) => model.to_string(),
-        (AgentType::Claude, Some(_)) => "Claude".to_string(),
-        (AgentType::Codex, Some(_)) => "Codex".to_string(),
-        (AgentType::Muse, Some(_)) => "Muse".to_string(),
+    let base = match model.as_deref().filter(|m| is_displayable_model(m)) {
+        Some(model) => model.to_string(),
+        None => agent_type.display_name().to_string(),
     };
     append_nonstandard_tier(base, tier.as_deref())
 }

--- a/frontend/src/pages/demo.rs
+++ b/frontend/src/pages/demo.rs
@@ -755,11 +755,7 @@ fn radio_messages(
     peer_session_id: Uuid,
     peer_agent_type: AgentType,
 ) -> Vec<DemoMessage> {
-    let peer_label = match peer_agent_type {
-        AgentType::Claude => "Claude",
-        AgentType::Codex => "Codex",
-        AgentType::Muse => "Muse",
-    };
+    let peer_label = peer_agent_type.display_name();
     let mut messages = vec![
         user(
             "2026-07-20T04:01:07.000000Z",

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -214,6 +214,17 @@ impl AgentType {
         }
     }
 
+    /// Human-facing label ("Claude", "Codex", "Muse") for dropdowns, chips,
+    /// and settings titles. Single source of truth so the frontend never
+    /// re-matches the enum just to capitalize the wire name.
+    pub fn display_name(self) -> &'static str {
+        match self {
+            AgentType::Claude => "Claude",
+            AgentType::Codex => "Codex",
+            AgentType::Muse => "Muse",
+        }
+    }
+
     /// The command that installs this agent's CLI, as structured data so the
     /// launcher (which runs it) and the frontend (which displays it for the
     /// user to confirm) agree on exactly one thing.
@@ -1389,6 +1400,21 @@ mod tests {
 
         let replaced: SessionStatus = serde_json::from_str("\"replaced\"").unwrap();
         assert_eq!(replaced, SessionStatus::Replaced);
+    }
+
+    #[test]
+    fn agent_type_display_names_are_capitalized() {
+        // `display_name` is the single source of truth for the human label;
+        // it must stay the capitalized wire name for every variant.
+        for agent in [AgentType::Claude, AgentType::Codex, AgentType::Muse] {
+            let wire = agent.as_str();
+            let mut expected = String::from(&wire[..1].to_ascii_uppercase());
+            expected.push_str(&wire[1..]);
+            assert_eq!(agent.display_name(), expected);
+        }
+        assert_eq!(AgentType::Claude.display_name(), "Claude");
+        assert_eq!(AgentType::Codex.display_name(), "Codex");
+        assert_eq!(AgentType::Muse.display_name(), "Muse");
     }
 
     #[test]


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/a133615ba4d3a24126a5575972bbefb52e8c159f/.0-pr-viz/001854.svg)

Small DRY cleanup, no behavior change.

- Adds `AgentType::display_name()` in `shared` next to `as_str()`: single source of truth for the human-facing "Claude"/"Codex"/"Muse" labels.
- Collapses the 7-arm `format_agent_model_tier_label` match in `turn_metrics_display.rs` to a model-first check with agent fallback (same outputs; covered by the existing `performance_panel` pair-label tests).
- Replaces two identical inline matches (`launch_dialog.rs` selected-agent label, `demo.rs` peer label) with the helper.
- Adds a `shared` unit test pinning each display name.

Verified locally: `cargo test -p frontend` (681 passed), `cargo test -p shared` (188 passed), `cargo clippy --workspace --all-targets` clean, `cargo fmt --check` clean, WASM check of `shared` passes.
