### PR TITLE
Update codex-codes to 0.151.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.151.2"
+version = "0.151.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c055e7cb9fac8a4a5372ebf0aeb4baf7949ff0cbffd97c1a6cc435c526ce3778"
+checksum = "db8beaa298da6a6ed6bf10b8ebe5db335257cf484de5a429a11754f8f4d32202"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ claude-codes = { version = "2.1.259", default-features = false, features = ["typ
 
 # Muse CLI integration
 muse-codes = { version = "1.0.2", default-features = false, features = ["types"] }
-codex-codes = { version = "0.151.2", default-features = false, features = ["types"] }
+codex-codes = { version = "0.151.5", default-features = false, features = ["types"] }
 
 # Web Push (VAPID + RFC8291 encryption). `default-features = false` drops the
 # bundled HTTP clients (isahc/libcurl and hyper) — we build the message here and


### PR DESCRIPTION
Update `codex-codes` from 0.151.2 to 0.151.5, bringing in rate-limit/thread metadata, WebMCP policy, executor-path types, and the expanded model catalog consumed by the portal model picker.

Reviewed the [upstream changelog](https://github.com/meawoppl/rust-code-agent-sdks/blob/main/codex-codes/CHANGELOG.md): the portal does not call the changed `account_rate_limits_read` method or construct Guardian actions; permissions approval already extracts the path string through `.0`. No production call-site changes are required. Model selection still defaults to the agent default; catalog entries remain subject to account access.

Validation: `cargo fmt --all`; `cargo test -p codex-session-lib -p shared -p frontend --lib` (906 tests passed). `cargo check -p frontend --target wasm32-unknown-unknown` passed.

Supersedes the older 0.151.4 bump in #1804.
