### PR TITLE
Dedupe single-user display name lookups

### DIFF
--- a/.0-pr-viz/001857.svg
+++ b/.0-pr-viz/001857.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <!-- Header -->
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1857 · Dedupe single-user display name lookups</text>
+
+  <!-- Thesis -->
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Two attribution sites each ran two user queries and skipped nicknames —</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">now helpers::user_display_name owns the lookup; each site keeps its fallback.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <!-- Panel labels + center divider -->
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <!-- ==================== BEFORE panel: x 55–945 ==================== -->
+
+  <g>
+    <rect x="80" y="250" width="810" height="235" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="290" font-size="26" fill="#7aa2f7">agent_comms.rs:45 · user_display_name</text>
+    <text x="104" y="330" font-size="23" fill="#f7768e">select(name) → none? select(email)</text>
+    <text x="104" y="366" font-size="23" fill="#f7768e">two round-trips; nickname never selected</text>
+    <text x="104" y="402" font-size="23" fill="#a9b1d6">nickname precedence (#1485) ignored here</text>
+    <text x="104" y="438" font-size="22" fill="#565f89">fallback "portal" for missing users</text>
+  </g>
+
+  <line x1="485" y1="485" x2="485" y2="525" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+
+  <g>
+    <rect x="80" y="545" width="810" height="200" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="585" font-size="26" fill="#7aa2f7">web_client_socket.rs:445 · inline</text>
+    <text x="104" y="625" font-size="23" fill="#f7768e">same name-then-email pair, pasted again</text>
+    <text x="104" y="661" font-size="23" fill="#f7768e">two round-trips; nickname never selected</text>
+    <text x="104" y="697" font-size="22" fill="#565f89">fallback "Unknown" for missing users</text>
+  </g>
+
+  <g>
+    <rect x="80" y="765" width="810" height="165" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="811" font-size="26" fill="#c0caf5">precedence lives in zero places</text>
+    <text x="104" y="851" font-size="23" fill="#f7768e">every site re-decides nickname vs name</text>
+    <text x="104" y="887" font-size="23" fill="#f7768e">a third caller means a third pasted pair</text>
+  </g>
+
+  <!-- ==================== AFTER panel: x 1040–1945 ==================== -->
+
+  <g>
+    <rect x="1065" y="250" width="810" height="200" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1089" y="290" font-size="26" fill="#7aa2f7">helpers.rs · user_display_name</text>
+    <text x="1089" y="330" font-size="23" fill="#9ece6a">pub fn (conn, user_id) -> Option&lt;String&gt;</text>
+    <text x="1089" y="366" font-size="23" fill="#a9b1d6">(nickname, name, email) in a single query</text>
+    <text x="1089" y="402" font-size="22" fill="#565f89">display_name() owns nickname-then-name</text>
+  </g>
+
+  <line x1="1470" y1="450" x2="1470" y2="490" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <g>
+    <rect x="1065" y="500" width="810" height="265" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="1089" y="540" font-size="26" fill="#c0caf5">two one-line call sites</text>
+    <text x="1089" y="580" font-size="23" fill="#9ece6a">helpers::user_display_name → "portal"</text>
+    <text x="1089" y="616" font-size="23" fill="#a9b1d6">agent path keeps its own fallback label</text>
+    <text x="1089" y="652" font-size="23" fill="#9ece6a">helpers::user_display_name → "Unknown"</text>
+    <text x="1089" y="688" font-size="23" fill="#a9b1d6">web path keeps its own fallback label</text>
+    <text x="1089" y="724" font-size="22" fill="#565f89">+19 / -29 lines across the three files</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="785" width="810" height="145" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="831" font-size="26" fill="#c0caf5">pinned by existing tests</text>
+    <text x="1089" y="871" font-size="23" fill="#9ece6a">nickname_is_preferred_then_name_then_email</text>
+    <text x="1089" y="907" font-size="22" fill="#565f89">+ blank_values_fall_through; 318 lib tests green</text>
+  </g>
+
+  <!-- Footer -->
+  <text x="55" y="1172" font-size="22" fill="#565f89">No dedicated DB test for the one-row lookup — a bad column list degrades silently to the "portal" / "Unknown" fallbacks.</text>
+</svg>

--- a/backend/src/handlers/agent_comms.rs
+++ b/backend/src/handlers/agent_comms.rs
@@ -41,22 +41,12 @@ pub(crate) fn resolve_user(
     crate::auth::extract_user_id(app_state, Some(headers), cookies)
 }
 
-/// Look up a display name for `user_id` (name, falling back to email).
+/// Look up a display name for `user_id`, keeping this path's `"portal"`
+/// fallback for unknown users. Resolution itself lives in
+/// [`crate::handlers::helpers::user_display_name`] (single query,
+/// nickname-then-name-then-email).
 fn user_display_name(conn: &mut crate::db::DbConnection, user_id: Uuid) -> String {
-    use crate::schema::users;
-    users::table
-        .find(user_id)
-        .select(users::name)
-        .first::<Option<String>>(conn)
-        .ok()
-        .flatten()
-        .or_else(|| {
-            users::table
-                .find(user_id)
-                .select(users::email)
-                .first::<String>(conn)
-                .ok()
-        })
+    crate::handlers::helpers::user_display_name(conn, user_id)
         .unwrap_or_else(|| "portal".to_string())
 }
 

--- a/backend/src/handlers/helpers.rs
+++ b/backend/src/handlers/helpers.rs
@@ -79,6 +79,19 @@ pub fn sender_names(conn: &mut PgConnection, message_list: &[Message]) -> HashMa
         .collect()
 }
 
+/// Load one user's display name in a single query, using the same
+/// nickname-then-name-then-email precedence as [`display_name`].
+/// Returns `None` when the user row is missing so callers keep their own
+/// fallback label for unknown users.
+pub fn user_display_name(conn: &mut PgConnection, user_id: Uuid) -> Option<String> {
+    users::table
+        .find(user_id)
+        .select((users::nickname, users::name, users::email))
+        .first::<(Option<String>, Option<String>, String)>(conn)
+        .ok()
+        .map(|(nickname, name, email)| display_name(nickname.as_deref(), name.as_deref(), &email))
+}
+
 /// Error type for helper operations
 pub struct DeleteSessionError(String);
 

--- a/backend/src/handlers/websocket/web_client_socket.rs
+++ b/backend/src/handlers/websocket/web_client_socket.rs
@@ -441,20 +441,7 @@ fn handle_web_input(
 
     // Track who sent this input so we can attribute the echoed user message
     if let Ok(mut conn) = db_pool.get() {
-        use crate::schema::users;
-        let display_name: String = users::table
-            .find(user_id)
-            .select(users::name)
-            .first::<Option<String>>(&mut conn)
-            .ok()
-            .flatten()
-            .or_else(|| {
-                users::table
-                    .find(user_id)
-                    .select(users::email)
-                    .first::<String>(&mut conn)
-                    .ok()
-            })
+        let display_name: String = crate::handlers::helpers::user_display_name(&mut conn, user_id)
             .unwrap_or_else(|| "Unknown".to_string());
         session_manager.set_last_input_sender(session_id, user_id, display_name);
     }


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/24fadee7b233dee2e5d28b57f8587c222a152fb1/.0-pr-viz/001857.svg)

Two call sites (agent_comms sender label, web_client input attribution) each ran two sequential user queries and ignored nicknames. Adds helpers::user_display_name (single query, nickname-then-name-then-email via display_name) and reuses it at both sites with their existing fallbacks preserved.