### PR TITLE
Extract stub-frontend-dist into composite action

### DIFF
--- a/.0-pr-viz/001858.svg
+++ b/.0-pr-viz/001858.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <!-- Header -->
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1858 · Extract stub-frontend-dist into composite action</text>
+
+  <!-- Thesis -->
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Four CI jobs pasted the same frontend/dist stub step —</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">now one composite action owns it; each job keeps a one-line reference.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <!-- Panel labels + center divider -->
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <!-- ==================== BEFORE panel: x 55–945 ==================== -->
+
+  <g>
+    <rect x="80" y="250" width="810" height="200" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="290" font-size="26" fill="#7aa2f7">ci.yml · clippy / build-backend / test</text>
+    <text x="104" y="330" font-size="23" fill="#f7768e">- name: Stub frontend dist  +  5-line comment</text>
+    <text x="104" y="366" font-size="23" fill="#f7768e">run: mkdir -p frontend/dist, pasted 3x</text>
+    <text x="104" y="402" font-size="22" fill="#565f89">rationale (#1165 item 1) tripled, drifts apart</text>
+  </g>
+
+  <line x1="485" y1="450" x2="485" y2="490" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+
+  <g>
+    <rect x="80" y="510" width="810" height="200" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="550" font-size="26" fill="#7aa2f7">ci.yml · e2e-tests</text>
+    <text x="104" y="590" font-size="23" fill="#f7768e">- name: Stub frontend dist, no comment</text>
+    <text x="104" y="626" font-size="23" fill="#f7768e">run: mkdir -p frontend/dist, pasted a 4th time</text>
+    <text x="104" y="662" font-size="22" fill="#565f89">already diverged: why the stub is unexplained</text>
+  </g>
+
+  <g>
+    <rect x="80" y="730" width="810" height="165" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="776" font-size="26" fill="#c0caf5">rationale lives in zero places</text>
+    <text x="104" y="816" font-size="23" fill="#f7768e">edit the wording, touch four jobs</text>
+    <text x="104" y="852" font-size="23" fill="#f7768e">a fifth backend lane means a fifth paste</text>
+  </g>
+
+  <!-- ==================== AFTER panel: x 1040–1945 ==================== -->
+
+  <g>
+    <rect x="1065" y="250" width="810" height="200" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1089" y="290" font-size="26" fill="#7aa2f7">stub-frontend-dist/action.yml</text>
+    <text x="1089" y="330" font-size="23" fill="#9ece6a">composite action, same setup-rust pattern</text>
+    <text x="1089" y="366" font-size="23" fill="#a9b1d6">description carries the #1165 rationale once</text>
+    <text x="1089" y="402" font-size="22" fill="#565f89">one step: mkdir -p frontend/dist</text>
+  </g>
+
+  <line x1="1470" y1="450" x2="1470" y2="490" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <g>
+    <rect x="1065" y="500" width="810" height="265" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="1089" y="540" font-size="26" fill="#c0caf5">four one-line call sites</text>
+    <text x="1089" y="580" font-size="23" fill="#9ece6a">uses: ./.github/actions/stub-frontend-dist</text>
+    <text x="1089" y="616" font-size="23" fill="#a9b1d6">clippy · build-backend · test · e2e-tests</text>
+    <text x="1089" y="652" font-size="23" fill="#9ece6a">same command, same runner, same position</text>
+    <text x="1089" y="688" font-size="23" fill="#a9b1d6">e2e regains the rationale for free</text>
+    <text x="1089" y="724" font-size="22" fill="#565f89">19 insertions / 19 deletions, net zero</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="785" width="810" height="145" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="831" font-size="26" fill="#c0caf5">pinned by CI itself</text>
+    <text x="1089" y="871" font-size="23" fill="#9ece6a">clippy + backend + tests + e2e all exercise it</text>
+    <text x="1089" y="907" font-size="22" fill="#565f89">zero behavior change: refactor only</text>
+  </g>
+
+  <!-- Footer -->
+  <text x="55" y="1172" font-size="22" fill="#565f89">YAML safe-loads locally; any breakage fails loudly in the four jobs that consume the action.</text>
+</svg>

--- a/.github/actions/stub-frontend-dist/action.yml
+++ b/.github/actions/stub-frontend-dist/action.yml
@@ -1,0 +1,15 @@
+name: Stub frontend dist
+description: >
+  Create an empty frontend/dist so backend lanes can compile without the real
+  WASM bundle. The backend embeds frontend/dist at build time, but memory_serve
+  falls back to dynamic loading when it is empty, so CI compile/test checks do
+  not need the real bundle. This keeps backend lanes independent of (and not
+  waiting for) build-frontend, and independent of frontend/CSS failures
+  (#1165 item 1).
+
+runs:
+  using: composite
+  steps:
+    - name: Stub frontend dist
+      shell: bash
+      run: mkdir -p frontend/dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,12 +96,7 @@ jobs:
           fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
 
       - name: Stub frontend dist
-        # Backend embeds frontend/dist at build time, but memory_serve falls
-        # back to dynamic loading when it is empty. CI compile/test checks do
-        # not need the real bundle, so stub it instead of depending on (and
-        # waiting for) build-frontend. Keeps backend lanes independent of
-        # frontend/CSS failures (#1165 item 1).
-        run: mkdir -p frontend/dist
+        uses: ./.github/actions/stub-frontend-dist
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -122,12 +117,7 @@ jobs:
           fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
 
       - name: Stub frontend dist
-        # Backend embeds frontend/dist at build time, but memory_serve falls
-        # back to dynamic loading when it is empty. CI compile/test checks do
-        # not need the real bundle, so stub it instead of depending on (and
-        # waiting for) build-frontend. Keeps backend lanes independent of
-        # frontend/CSS failures (#1165 item 1).
-        run: mkdir -p frontend/dist
+        uses: ./.github/actions/stub-frontend-dist
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -147,12 +137,7 @@ jobs:
           fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
 
       - name: Stub frontend dist
-        # Backend embeds frontend/dist at build time, but memory_serve falls
-        # back to dynamic loading when it is empty. CI compile/test checks do
-        # not need the real bundle, so stub it instead of depending on (and
-        # waiting for) build-frontend. Keeps backend lanes independent of
-        # frontend/CSS failures (#1165 item 1).
-        run: mkdir -p frontend/dist
+        uses: ./.github/actions/stub-frontend-dist
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -192,7 +177,7 @@ jobs:
           fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
 
       - name: Stub frontend dist
-        run: mkdir -p frontend/dist
+        uses: ./.github/actions/stub-frontend-dist
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/d54083b1c6b391ab7f848150924cac4c8692ba27/.0-pr-viz/001858.svg)

The 'Stub frontend dist' step (mkdir -p frontend/dist plus its rationale comment) was copy-pasted across four CI jobs (clippy, build-backend, test, e2e), and the e2e copy had already lost the explanatory comment.

This extracts it into .github/actions/stub-frontend-dist (same composite-action pattern as setup-rust) and references it from all four jobs. Zero behavior change: same command, same runner, same position in each job's steps.