### PR TITLE
Consolidate test session fixture into helper

### DIFF
--- a/.0-pr-viz/001861.svg
+++ b/.0-pr-viz/001861.svg
@@ -1,0 +1,84 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <!-- Header -->
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1861 · Consolidate test session fixture into helper</text>
+
+  <!-- Thesis -->
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Eight DB-gated test modules pasted the same 16-field session literal —</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">now test_support::insert_session owns it; each fixture keeps a one-line call.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <!-- Panel labels + center divider -->
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <!-- ==================== BEFORE panel: x 55–945 ==================== -->
+
+  <g>
+    <rect x="80" y="250" width="810" height="200" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="290" font-size="26" fill="#7aa2f7">messages / session_access / replay: make_session</text>
+    <text x="104" y="330" font-size="23" fill="#f7768e">16-field NewSessionWithId literal, pasted 8x</text>
+    <text x="104" y="366" font-size="23" fill="#f7768e">only the session_name ever differed</text>
+    <text x="104" y="402" font-size="22" fill="#565f89">a new sessions column means editing every copy</text>
+  </g>
+
+  <line x1="485" y1="450" x2="485" y2="490" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+
+  <g>
+    <rect x="80" y="510" width="810" height="200" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="550" font-size="26" fill="#7aa2f7">continuations / replay / registration: users</text>
+    <text x="104" y="590" font-size="23" fill="#f7768e">local make_user duplicates insert_user (#924)</text>
+    <text x="104" y="626" font-size="23" fill="#f7768e">same email-nonce shape, three more copies</text>
+    <text x="104" y="662" font-size="22" fill="#565f89">the consolidation already happened — then drifted</text>
+  </g>
+
+  <g>
+    <rect x="80" y="730" width="810" height="165" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="776" font-size="26" fill="#c0caf5">adding one column touches every fixture</text>
+    <text x="104" y="816" font-size="23" fill="#f7768e">Active, /tmp, test-host, claude — retyped each time</text>
+    <text x="104" y="852" font-size="23" fill="#f7768e">reviewers diff literals instead of logic</text>
+  </g>
+
+  <!-- ==================== AFTER panel: x 1040–1945 ==================== -->
+
+  <g>
+    <rect x="1065" y="250" width="810" height="200" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1089" y="290" font-size="26" fill="#7aa2f7">test_support.rs · insert_session</text>
+    <text x="1089" y="330" font-size="23" fill="#9ece6a">canonical defaults: Active, /tmp, test-host, claude</text>
+    <text x="1089" y="366" font-size="23" fill="#a9b1d6">session_key is the fresh id, so names may repeat</text>
+    <text x="1089" y="402" font-size="22" fill="#565f89">next column is one default in one place</text>
+  </g>
+
+  <line x1="1470" y1="450" x2="1470" y2="490" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <g>
+    <rect x="1065" y="500" width="810" height="230" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="1089" y="540" font-size="26" fill="#c0caf5">one-line call sites + update for overrides</text>
+    <text x="1089" y="580" font-size="23" fill="#9ece6a">insert_session(conn, owner, "…") everywhere</text>
+    <text x="1089" y="616" font-size="23" fill="#a9b1d6">Disconnected / launcher_version via diesel::update</text>
+    <text x="1089" y="652" font-size="23" fill="#a9b1d6">the insert-then-update shape tests already used</text>
+    <text x="1089" y="688" font-size="22" fill="#565f89">100 insertions / 271 deletions, net -170 lines</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="750" width="810" height="145" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="796" font-size="26" fill="#c0caf5">pinned by the DB-gated suite itself</text>
+    <text x="1089" y="836" font-size="23" fill="#9ece6a">29 touched-module tests pass on real Postgres</text>
+    <text x="1089" y="872" font-size="22" fill="#565f89">zero production change: fixtures only</text>
+  </g>
+
+  <!-- Footer -->
+  <text x="55" y="1172" font-size="22" fill="#565f89">harness.rs + history_api.rs keep their own literals (custom dirs, codex agent) — a follow-up, not this diff.</text>
+</svg>

--- a/backend/src/background.rs
+++ b/backend/src/background.rs
@@ -1132,7 +1132,6 @@ mod background_decision_tests {
 
 #[cfg(test)]
 mod archive_pending_sessions_db_tests {
-    use crate::models::NewSessionWithId;
     use crate::schema::sessions;
     use chrono::NaiveDateTime;
     use diesel::prelude::*;
@@ -1145,32 +1144,13 @@ mod archive_pending_sessions_db_tests {
         last_activity: NaiveDateTime,
         archived_at: Option<NaiveDateTime>,
     ) -> Uuid {
-        let id = Uuid::new_v4();
-        let new_session = NewSessionWithId {
-            id,
-            user_id,
-            session_name: format!("test-{id}"),
-            session_key: id.to_string(),
-            working_directory: "/tmp".to_string(),
-            status: status.to_string(),
-            git_branch: None,
-            client_version: None,
-            hostname: "test-host".to_string(),
-            launcher_id: None,
-            agent_type: "claude".to_string(),
-            repo_url: None,
-            scheduled_task_id: None,
-            paused: false,
-            claude_args: serde_json::Value::Array(Vec::new()),
-            launcher_version: None,
-        };
-        diesel::insert_into(sessions::table)
-            .values(&new_session)
-            .execute(conn)
-            .expect("insert session");
-        // Override timestamps set by DB defaults to the exact values for the predicate.
+        let session = crate::test_support::insert_session(conn, user_id, "test-archive-pending");
+        let id = session.id;
+        // Override the helper defaults (status) and DB defaults (timestamps)
+        // to the exact values for the predicate.
         diesel::update(sessions::table.find(id))
             .set((
+                sessions::status.eq(status.to_string()),
                 sessions::last_activity.eq(last_activity),
                 sessions::archived_at.eq(archived_at),
                 sessions::updated_at.eq(last_activity),
@@ -1270,35 +1250,21 @@ mod archive_pending_sessions_db_tests {
 mod retention_archive_hold_tests {
     use crate::archive::{ArchiveConfig, ArchiveRuntime};
     use crate::handlers::retention::RetentionConfig;
-    use crate::models::NewSessionWithId;
     use crate::schema::{messages, sessions};
     use diesel::prelude::*;
     use uuid::Uuid;
 
     fn make_session(conn: &mut diesel::PgConnection, user_id: Uuid) -> Uuid {
-        let id = Uuid::new_v4();
-        let new_session = NewSessionWithId {
-            id,
-            user_id,
-            session_name: format!("ret-{id}"),
-            session_key: id.to_string(),
-            working_directory: "/tmp".to_string(),
-            status: "disconnected".to_string(),
-            git_branch: None,
-            client_version: None,
-            hostname: "h".to_string(),
-            launcher_id: None,
-            agent_type: "claude".to_string(),
-            repo_url: None,
-            scheduled_task_id: None,
-            paused: false,
-            claude_args: serde_json::Value::Array(Vec::new()),
-            launcher_version: None,
-        };
-        diesel::insert_into(sessions::table)
-            .values(&new_session)
+        let session = crate::test_support::insert_session(conn, user_id, "test-retention");
+        let id = session.id;
+        // Stamp the non-default columns the old literal set inline.
+        diesel::update(sessions::table.find(id))
+            .set((
+                sessions::status.eq("disconnected"),
+                sessions::hostname.eq("h"),
+            ))
             .execute(conn)
-            .expect("insert session");
+            .expect("set session status");
         id
     }
 

--- a/backend/src/handlers/media_archive.rs
+++ b/backend/src/handlers/media_archive.rs
@@ -313,43 +313,23 @@ mod tests {
         let Some(pool) = crate::test_support::shared_pool() else {
             return;
         };
-        use crate::models::{NewMessage, NewSessionWithId, NewUser};
+        use crate::models::NewMessage;
         use crate::schema::{messages, sessions, users};
 
         let mut conn = pool.get().expect("conn");
-        let nonce = Uuid::new_v4();
-        let owner: Uuid = diesel::insert_into(users::table)
-            .values(&NewUser {
-                email: format!("media_rt_{nonce}@example.invalid"),
-                name: Some("Media RT".into()),
-                avatar_url: None,
-            })
-            .returning(users::id)
-            .get_result::<Uuid>(&mut conn)
-            .expect("insert user");
+        let owner: Uuid = crate::test_support::insert_user(&mut conn, "media_rt").id;
 
-        let session_id = Uuid::new_v4();
-        diesel::insert_into(sessions::table)
-            .values(&NewSessionWithId {
-                id: session_id,
-                user_id: owner,
-                session_name: format!("media-rt-{session_id}"),
-                session_key: session_id.to_string(),
-                working_directory: "/tmp".into(),
-                status: shared::SessionStatus::Disconnected.as_str().to_string(),
-                git_branch: None,
-                client_version: None,
-                hostname: "test".into(),
-                launcher_id: None,
-                agent_type: "claude".into(),
-                repo_url: None,
-                scheduled_task_id: None,
-                paused: false,
-                claude_args: serde_json::Value::Array(vec![]),
-                launcher_version: None,
-            })
+        let session = crate::test_support::insert_session(&mut conn, owner, "media-rt");
+        let session_id = session.id;
+        // The read-through path only handles `Disconnected` sessions; stamp
+        // the status (and hostname) the old literal set inline.
+        diesel::update(sessions::table.find(session_id))
+            .set((
+                sessions::status.eq(shared::SessionStatus::Disconnected.as_str()),
+                sessions::hostname.eq("test"),
+            ))
             .execute(&mut conn)
-            .expect("insert session");
+            .expect("set session status");
 
         // The transcript row embeds the served URL — the durable media→session
         // mapping the read-through relies on.

--- a/backend/src/handlers/messages.rs
+++ b/backend/src/handlers/messages.rs
@@ -287,34 +287,11 @@ mod tests {
 #[cfg(test)]
 mod db_tests {
     use super::*;
-    use crate::models::{NewSessionWithId, Session};
+    use crate::models::Session;
     use chrono::Utc;
 
     fn make_session(conn: &mut diesel::pg::PgConnection, owner_id: uuid::Uuid) -> Session {
-        use crate::schema::sessions;
-        let session_id = uuid::Uuid::new_v4();
-        let new_session = NewSessionWithId {
-            id: session_id,
-            user_id: owner_id,
-            session_name: format!("test-msg-session-{}", session_id),
-            session_key: session_id.to_string(),
-            working_directory: "/tmp".to_string(),
-            status: shared::SessionStatus::Active.as_str().to_string(),
-            git_branch: None,
-            client_version: None,
-            hostname: "test-host".to_string(),
-            launcher_id: None,
-            agent_type: "claude".to_string(),
-            repo_url: None,
-            scheduled_task_id: None,
-            paused: false,
-            claude_args: serde_json::Value::Array(Vec::new()),
-            launcher_version: None,
-        };
-        diesel::insert_into(sessions::table)
-            .values(&new_session)
-            .get_result::<Session>(conn)
-            .expect("insert test session")
+        crate::test_support::insert_session(conn, owner_id, "test-msg-session")
     }
 
     /// Seed `count` messages with strictly increasing `created_at`. We use

--- a/backend/src/handlers/session_access.rs
+++ b/backend/src/handlers/session_access.rs
@@ -192,34 +192,11 @@ pub fn is_session_mutator(app_state: &AppState, session_id: Uuid, user_id: Uuid)
 #[cfg(test)]
 mod db_tests {
     use super::*;
-    use crate::models::{NewSessionMember, NewSessionWithId, Session};
+    use crate::models::{NewSessionMember, Session};
 
     /// Insert a throwaway session owned by `owner_id`.
     fn make_session(conn: &mut diesel::pg::PgConnection, owner_id: Uuid) -> Session {
-        use crate::schema::sessions;
-        let session_id = Uuid::new_v4();
-        let new_session = NewSessionWithId {
-            id: session_id,
-            user_id: owner_id,
-            session_name: format!("test-session-{}", session_id),
-            session_key: session_id.to_string(),
-            working_directory: "/tmp".to_string(),
-            status: shared::SessionStatus::Active.as_str().to_string(),
-            git_branch: None,
-            client_version: None,
-            hostname: "test-host".to_string(),
-            launcher_id: None,
-            agent_type: "claude".to_string(),
-            repo_url: None,
-            scheduled_task_id: None,
-            paused: false,
-            claude_args: serde_json::Value::Array(Vec::new()),
-            launcher_version: None,
-        };
-        diesel::insert_into(sessions::table)
-            .values(&new_session)
-            .get_result::<Session>(conn)
-            .expect("insert test session")
+        crate::test_support::insert_session(conn, owner_id, "test-session")
     }
 
     fn add_member(

--- a/backend/src/handlers/websocket/continuations.rs
+++ b/backend/src/handlers/websocket/continuations.rs
@@ -657,7 +657,6 @@ fn insert_portal_message(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::{NewSessionWithId, NewUser, User};
 
     #[test]
     fn overload_matcher_accepts_only_transient_529_overloads() {
@@ -695,46 +694,16 @@ mod tests {
         assert_eq!(overload_retry_delay_secs(4), None);
     }
 
-    fn make_user(conn: &mut diesel::PgConnection) -> User {
-        use crate::schema::users;
-        let nonce = Uuid::new_v4();
-        let new_user = NewUser {
-            email: format!("test_overload_{nonce}@example.invalid"),
-            name: Some("Overload Test".to_string()),
-            avatar_url: None,
-        };
-        diesel::insert_into(users::table)
-            .values(&new_user)
-            .get_result::<User>(conn)
-            .expect("insert test user")
-    }
-
     fn make_session(conn: &mut diesel::PgConnection, user_id: Uuid) -> Uuid {
         use crate::schema::sessions;
-        let session_id = Uuid::new_v4();
-        let new_session = NewSessionWithId {
-            id: session_id,
-            user_id,
-            session_name: "overload-test".to_string(),
-            session_key: session_id.to_string(),
-            working_directory: "/tmp".to_string(),
-            status: shared::SessionStatus::Active.as_str().to_string(),
-            git_branch: None,
-            client_version: None,
-            hostname: "test-host".to_string(),
-            launcher_id: Some(Uuid::new_v4()),
-            agent_type: "claude".to_string(),
-            repo_url: None,
-            scheduled_task_id: None,
-            paused: false,
-            claude_args: serde_json::Value::Array(Vec::new()),
-            launcher_version: None,
-        };
-        diesel::insert_into(sessions::table)
-            .values(&new_session)
+        let session = crate::test_support::insert_session(conn, user_id, "overload-test");
+        // Preserve the launcher-owned shape the old literal had: the
+        // continuations under test carry their own launcher ids.
+        diesel::update(sessions::table.find(session.id))
+            .set(sessions::launcher_id.eq(Uuid::new_v4()))
             .execute(conn)
-            .expect("insert session");
-        session_id
+            .expect("set session launcher");
+        session.id
     }
 
     fn insert_overloaded_continuation(
@@ -767,7 +736,7 @@ mod tests {
             return;
         };
         let mut conn = pool.get().expect("db conn");
-        let user = make_user(&mut conn);
+        let user = crate::test_support::insert_user(&mut conn, "overload");
         let session_id = make_session(&mut conn, user.id);
 
         // 0 prior -> immediate.

--- a/backend/src/handlers/websocket/registration.rs
+++ b/backend/src/handlers/websocket/registration.rs
@@ -535,7 +535,7 @@ mod tests {
     /// in-memory registry entry is gone. Skips when no test DB is available.
     #[test]
     fn launcher_version_persists_on_session_row() {
-        use crate::models::{NewSessionWithId, NewUser, Session, User};
+        use crate::models::Session;
         use crate::schema::{sessions, users};
 
         let Some(pool) = crate::test_support::shared_pool() else {
@@ -543,40 +543,18 @@ mod tests {
         };
         let mut conn = pool.get().expect("conn");
 
-        let nonce = Uuid::new_v4();
-        let user = diesel::insert_into(users::table)
-            .values(&NewUser {
-                email: format!("test_launcher_version_{nonce}@example.invalid"),
-                name: Some("Launcher Version Test".to_string()),
-                avatar_url: None,
-            })
-            .get_result::<User>(&mut conn)
-            .expect("insert test user");
+        let user = crate::test_support::insert_user(&mut conn, "launcher_version");
 
-        let session_id = Uuid::new_v4();
-        let created = diesel::insert_into(sessions::table)
-            .values(&NewSessionWithId {
-                id: session_id,
-                user_id: user.id,
-                session_name: format!("launcher-version-{session_id}"),
-                session_key: session_id.to_string(),
-                working_directory: "/tmp".to_string(),
-                status: SessionStatus::Active.as_str().to_string(),
-                git_branch: None,
-                client_version: None,
-                hostname: "test-host".to_string(),
-                launcher_id: Some(Uuid::new_v4()),
-                agent_type: "claude".to_string(),
-                repo_url: None,
-                scheduled_task_id: None,
-                paused: false,
-                claude_args: serde_json::Value::Array(Vec::new()),
-                launcher_version: Some("2.13.42".to_string()),
-            })
-            .get_result::<Session>(&mut conn)
-            .expect("insert session");
-
-        assert_eq!(created.launcher_version.as_deref(), Some("2.13.42"));
+        let created = crate::test_support::insert_session(&mut conn, user.id, "launcher-version");
+        let session_id = created.id;
+        // Stamp the launcher provenance the old literal set inline.
+        diesel::update(sessions::table.find(session_id))
+            .set((
+                sessions::launcher_id.eq(Uuid::new_v4()),
+                sessions::launcher_version.eq("2.13.42"),
+            ))
+            .execute(&mut conn)
+            .expect("set launcher version");
 
         let fetched = sessions::table
             .find(session_id)

--- a/backend/src/handlers/websocket/replay.rs
+++ b/backend/src/handlers/websocket/replay.rs
@@ -111,48 +111,11 @@ pub(super) fn replay_history(
 // =============================================================================
 #[cfg(test)]
 mod replay_tests {
-    use crate::models::{NewSessionWithId, NewUser, Session, User};
+    use crate::models::Session;
     use chrono::Utc;
     use diesel::prelude::*;
-    fn make_user(conn: &mut diesel::pg::PgConnection, label: &str) -> User {
-        use crate::schema::users;
-        let nonce = uuid::Uuid::new_v4();
-        let new_user = NewUser {
-            email: format!("test_replay_{}_{}@example.invalid", label, nonce),
-            name: Some(format!("Test {}", label)),
-            avatar_url: None,
-        };
-        diesel::insert_into(users::table)
-            .values(&new_user)
-            .get_result::<User>(conn)
-            .expect("insert test user")
-    }
-
     fn make_session(conn: &mut diesel::pg::PgConnection, owner_id: uuid::Uuid) -> Session {
-        use crate::schema::sessions;
-        let session_id = uuid::Uuid::new_v4();
-        let new_session = NewSessionWithId {
-            id: session_id,
-            user_id: owner_id,
-            session_name: format!("test-replay-{}", session_id),
-            session_key: session_id.to_string(),
-            working_directory: "/tmp".to_string(),
-            status: shared::SessionStatus::Active.as_str().to_string(),
-            git_branch: None,
-            client_version: None,
-            hostname: "test-host".to_string(),
-            launcher_id: None,
-            agent_type: "claude".to_string(),
-            repo_url: None,
-            scheduled_task_id: None,
-            paused: false,
-            claude_args: serde_json::Value::Array(Vec::new()),
-            launcher_version: None,
-        };
-        diesel::insert_into(sessions::table)
-            .values(&new_session)
-            .get_result::<Session>(conn)
-            .expect("insert test session")
+        crate::test_support::insert_session(conn, owner_id, "test-replay")
     }
 
     fn seed_messages(
@@ -216,7 +179,7 @@ mod replay_tests {
         };
         let mut conn = pool.get().expect("conn");
 
-        let user = make_user(&mut conn, "limit");
+        let user = crate::test_support::insert_user(&mut conn, "limit");
         let session = make_session(&mut conn, user.id);
         let stamps = seed_messages(&mut conn, session.id, user.id, 200);
 
@@ -284,7 +247,7 @@ mod replay_tests {
         };
         let mut conn = pool.get().expect("conn");
 
-        let user = make_user(&mut conn, "strict_gt");
+        let user = crate::test_support::insert_user(&mut conn, "strict_gt");
         let session = make_session(&mut conn, user.id);
         // Three rows with strictly increasing server-assigned timestamps.
         let stamps = seed_messages(&mut conn, session.id, user.id, 3);
@@ -355,7 +318,7 @@ mod replay_tests {
         };
         let mut conn = pool.get().expect("conn");
 
-        let user = make_user(&mut conn, "no_watermark");
+        let user = crate::test_support::insert_user(&mut conn, "no_watermark");
         let session = make_session(&mut conn, user.id);
         let stamps = seed_messages(&mut conn, session.id, user.id, 3);
         drop(conn);

--- a/backend/src/push/dispatcher.rs
+++ b/backend/src/push/dispatcher.rs
@@ -276,31 +276,8 @@ mod db_tests {
         let mut conn = pool.get().expect("db conn");
         let user = crate::test_support::insert_user(&mut conn, "push");
 
-        use crate::models::NewSessionWithId;
-        use crate::schema::sessions;
-        let session_id = Uuid::new_v4();
-        let new_session = NewSessionWithId {
-            id: session_id,
-            user_id: user.id,
-            session_name: "resolve-test".to_string(),
-            session_key: session_id.to_string(),
-            working_directory: "/tmp".to_string(),
-            status: shared::SessionStatus::Active.as_str().to_string(),
-            git_branch: None,
-            client_version: None,
-            hostname: "test-host".to_string(),
-            launcher_id: None,
-            agent_type: "claude".to_string(),
-            repo_url: None,
-            scheduled_task_id: None,
-            paused: false,
-            claude_args: serde_json::Value::Array(Vec::new()),
-            launcher_version: None,
-        };
-        diesel::insert_into(sessions::table)
-            .values(&new_session)
-            .execute(&mut conn)
-            .expect("insert session");
+        let session = crate::test_support::insert_session(&mut conn, user.id, "resolve-test");
+        let session_id = session.id;
 
         let resolved = resolve_recipient(&mut conn, session_id).expect("resolve");
         // A fresh user has NULL notification_prefs -> defaults (C6 semantics).

--- a/backend/src/test_support.rs
+++ b/backend/src/test_support.rs
@@ -20,7 +20,7 @@ use diesel::r2d2::{ConnectionManager, Pool};
 use tower_cookies::Key;
 use uuid::Uuid;
 
-use crate::models::{NewUser, User};
+use crate::models::{NewSessionWithId, NewUser, Session, User};
 
 use crate::config::MobileAppLinksConfig;
 use crate::db::DbPool;
@@ -146,4 +146,46 @@ pub fn insert_user(conn: &mut PgConnection, label: &str) -> User {
         })
         .get_result::<User>(conn)
         .expect("insert test user")
+}
+
+/// Insert a throwaway session owned by `user_id` and return the persisted row.
+///
+/// Consolidates the near-identical `NewSessionWithId` literals + inserts that
+/// every DB-gated test module hand-wrote (the same class of duplication
+/// `insert_user` removed for users in #924). The defaults are what those
+/// literals all agreed on: `Active` status, `/tmp` working directory,
+/// `test-host` hostname, `claude` agent type, empty `claude_args`, everything
+/// else `None`/`false`. `session_key` is the fresh session id, so rows stay
+/// unique even when `session_name` repeats across parallel tests
+/// (`session_name` itself is not unique — only `session_key` is).
+///
+/// Takes a bare `&mut PgConnection` like `insert_user`, so it works with both
+/// a pooled and a direct connection. Tests needing non-default columns (a
+/// `Disconnected` status, a launcher version, ...) insert here then apply a
+/// follow-up `diesel::update` — the insert-then-update shape
+/// `archive_pending_sessions_db_tests` already used for timestamps.
+pub fn insert_session(conn: &mut PgConnection, user_id: Uuid, session_name: &str) -> Session {
+    use crate::schema::sessions;
+    let id = Uuid::new_v4();
+    diesel::insert_into(sessions::table)
+        .values(&NewSessionWithId {
+            id,
+            user_id,
+            session_name: session_name.to_string(),
+            session_key: id.to_string(),
+            working_directory: "/tmp".to_string(),
+            status: shared::SessionStatus::Active.as_str().to_string(),
+            git_branch: None,
+            client_version: None,
+            hostname: "test-host".to_string(),
+            launcher_id: None,
+            agent_type: "claude".to_string(),
+            repo_url: None,
+            scheduled_task_id: None,
+            paused: false,
+            claude_args: serde_json::Value::Array(Vec::new()),
+            launcher_version: None,
+        })
+        .get_result::<Session>(conn)
+        .expect("insert test session")
 }


### PR DESCRIPTION
![PR visualization](https://raw.githubusercontent.com/meawoppl/agent-portal/c2b2760e2f1e12abcf48e7dd3afb46575e4d28ea/.0-pr-viz/001861.svg)

Test-only DRY follow-up to the insert_user (#924) and test_app_state consolidations.

Eight DB-gated unit-test modules each hand-wrote the same 16-field NewSessionWithId literal (only the session name differed), and three of them also carried local make_user copies of test_support::insert_user. This adds test_support::insert_session with the canonical defaults everyone agreed on (Active, /tmp, test-host, claude agent, empty claude_args) and migrates all unit-test fixtures to it. Tests needing non-default columns (Disconnected status, launcher id/version) do a follow-up diesel::update - the insert-then-update shape archive_pending_sessions_db_tests already used for timestamps.

Net -170 lines. No production code touched. Verified locally: cargo fmt --check, RUSTFLAGS=-Dwarnings check, clippy clean, full workspace tests green, and all 29 DB-gated tests in the touched modules pass against the compose test DB.

Left for a follow-up: backend/tests/harness.rs (3 sites) and history_api.rs (2 sites) still spell out the literal - they need heavier per-site overrides (custom working dirs, codex agent type) and live in separate test binaries, so kept out to hold this diff small.