### PR TITLE
Share worktree branch format between backend and launcher

### DIFF
--- a/.0-pr-viz/001864.svg
+++ b/.0-pr-viz/001864.svg
@@ -15,8 +15,8 @@
   <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1864 · Dedupe math placeholder token parsing</text>
 
   <!-- Thesis -->
-  <text x="55" y="100" font-size="34" fill="#e6e9f5">split and restore each hand-rolled the same MATH token scan — two helpers,</text>
-  <text x="55" y="140" font-size="34" fill="#e6e9f5">one call each, zero behavior change.</text>
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">extract, split, restore each hand-rolled the same scans — three helpers,</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">one helper each, zero behavior change.</text>
   <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
 
   <!-- Panel labels + center divider -->
@@ -74,7 +74,7 @@
   <g>
     <rect x="1065" y="710" width="810" height="180" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
     <text x="1089" y="756" font-size="26" fill="#c0caf5">same bytes, less code</text>
-    <text x="1089" y="792" font-size="23" fill="#a9b1d6">+25 / -26, malformed still dropped silently;</text>
+    <text x="1089" y="792" font-size="23" fill="#a9b1d6">+45 / -48, malformed still dropped silently;</text>
     <text x="1089" y="828" font-size="23" fill="#9ece6a">44 markdown tests pass, clippy clean</text>
   </g>
 

--- a/.0-pr-viz/001864.svg
+++ b/.0-pr-viz/001864.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <!-- Header -->
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1864 · Dedupe math placeholder token parsing</text>
+
+  <!-- Thesis -->
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">split and restore each hand-rolled the same MATH token scan — two helpers,</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">one call each, zero behavior change.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <!-- Panel labels + center divider -->
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <!-- ==================== BEFORE panel: x 55–945 ==================== -->
+
+  <g>
+    <rect x="80" y="250" width="810" height="190" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="290" font-size="26" fill="#7aa2f7">math.rs — two copies of the scan</text>
+    <text x="104" y="326" font-size="23" fill="#f7768e">for tc in chars.by_ref() { if tc == MATH_CLOSE ... }</text>
+    <text x="104" y="362" font-size="23" fill="#f7768e">in split_math_segments and restore_math</text>
+    <text x="104" y="398" font-size="22" fill="#565f89">collect-to-close loop, written out twice</text>
+  </g>
+
+  <g>
+    <rect x="80" y="460" width="810" height="190" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="500" font-size="26" fill="#c0caf5">two copies of the resolve</text>
+    <text x="104" y="536" font-size="23" fill="#f7768e">strip_prefix("MATH") + parse + index</text>
+    <text x="104" y="572" font-size="23" fill="#f7768e">a nested if-let pyramid in restore_math</text>
+    <text x="104" y="608" font-size="22" fill="#565f89">same token shape, two hand-rolled parsers</text>
+  </g>
+
+  <line x1="485" y1="650" x2="485" y2="690" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+
+  <g>
+    <rect x="80" y="710" width="810" height="180" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="756" font-size="26" fill="#c0caf5">fix one path, forget the other</text>
+    <text x="104" y="792" font-size="23" fill="#f7768e">a tweak to token handling lands twice —</text>
+    <text x="104" y="828" font-size="23" fill="#f7768e">or lands once and drifts</text>
+  </g>
+
+  <!-- ==================== AFTER panel: x 1040–1945 ==================== -->
+
+  <g>
+    <rect x="1065" y="250" width="810" height="190" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1089" y="290" font-size="26" fill="#7aa2f7">read_placeholder_token helper</text>
+    <text x="1089" y="326" font-size="23" fill="#9ece6a">one scan loop, called from both sites</text>
+    <text x="1089" y="362" font-size="23" fill="#a9b1d6">consumes through MATH_CLOSE or end of input</text>
+    <text x="1089" y="398" font-size="22" fill="#565f89">truncated tokens behave exactly as before</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="460" width="810" height="190" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="1089" y="500" font-size="26" fill="#c0caf5">lookup_placeholder helper</text>
+    <text x="1089" y="536" font-size="23" fill="#a9b1d6">strip_prefix + parse + index in one ?-chain</text>
+    <text x="1089" y="572" font-size="23" fill="#9ece6a">restore_math: nested if-lets become one if-let</text>
+    <text x="1089" y="608" font-size="22" fill="#565f89">split reuses it under strip_math_delimiters</text>
+  </g>
+
+  <line x1="1470" y1="650" x2="1470" y2="690" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <g>
+    <rect x="1065" y="710" width="810" height="180" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="756" font-size="26" fill="#c0caf5">same bytes, less code</text>
+    <text x="1089" y="792" font-size="23" fill="#a9b1d6">+25 / -26, malformed still dropped silently;</text>
+    <text x="1089" y="828" font-size="23" fill="#9ece6a">44 markdown tests pass, clippy clean</text>
+  </g>
+
+  <!-- Footer -->
+  <text x="55" y="1172" font-size="22" fill="#565f89">Scope is one file: the extract / split / restore trio in frontend markdown math.</text>
+</svg>

--- a/.0-pr-viz/001865.svg
+++ b/.0-pr-viz/001865.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-red" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#f7768e"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <!-- Header -->
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1865 · Share worktree branch format between backend and launcher</text>
+
+  <!-- Thesis -->
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">The unnamed-worktree name lived as two literals that had to match by convention;</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">now one shared shape mints both, so rail name and branch can never drift.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <!-- Panel labels + center divider -->
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <!-- ==================== BEFORE panel: x 55–945 ==================== -->
+
+  <g>
+    <rect x="80" y="250" width="810" height="190" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="290" font-size="26" fill="#7aa2f7">launchers.rs — default_worktree_branch()</text>
+    <text x="104" y="326" font-size="23" fill="#f7768e">"session-{}" + "%Y%m%d-%H%M%S", inline</text>
+    <text x="104" y="362" font-size="23" fill="#a9b1d6">mints the rail display name before launch</text>
+    <text x="104" y="398" font-size="22" fill="#565f89">must equal the branch the launcher will make</text>
+  </g>
+
+  <g>
+    <rect x="80" y="460" width="810" height="190" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="500" font-size="26" fill="#7aa2f7">worktree.rs — default_branch_name()</text>
+    <text x="104" y="536" font-size="23" fill="#f7768e">"session-{}" + "%Y%m%d-%H%M%S", inline again</text>
+    <text x="104" y="572" font-size="23" fill="#a9b1d6">fallback branch when no name is supplied</text>
+    <text x="104" y="608" font-size="22" fill="#565f89">kept in sync with the backend by a comment</text>
+  </g>
+
+  <line x1="485" y1="650" x2="485" y2="690" stroke="#f7768e" stroke-width="1.5" marker-end="url(#arr-red)"/>
+
+  <g>
+    <rect x="80" y="710" width="810" height="180" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="756" font-size="26" fill="#c0caf5">edit one, forget the other</text>
+    <text x="104" y="792" font-size="23" fill="#f7768e">a format tweak lands once and drifts —</text>
+    <text x="104" y="828" font-size="23" fill="#f7768e">the rail shows a name that matches no branch</text>
+  </g>
+
+  <!-- ==================== AFTER panel: x 1040–1945 ==================== -->
+
+  <g>
+    <rect x="1065" y="250" width="810" height="190" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1089" y="290" font-size="26" fill="#7aa2f7">shared/lib.rs — one canonical shape</text>
+    <text x="1089" y="326" font-size="23" fill="#9ece6a">WORKTREE_BRANCH_PREFIX = "session-"</text>
+    <text x="1089" y="362" font-size="23" fill="#9ece6a">WORKTREE_BRANCH_TIME_FORMAT = "%Y%m%d-%H%M%S"</text>
+    <text x="1089" y="398" font-size="22" fill="#565f89">WASM-safe consts, no new dependency</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="460" width="810" height="190" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="1089" y="500" font-size="26" fill="#c0caf5">both defaults build from the consts</text>
+    <text x="1089" y="536" font-size="23" fill="#a9b1d6">launchers.rs + worktree.rs format the same pair</text>
+    <text x="1089" y="572" font-size="23" fill="#a9b1d6">same strings, same call sites as before</text>
+    <text x="1089" y="608" font-size="22" fill="#565f89">mirroring comments replaced by shared truth</text>
+  </g>
+
+  <line x1="1470" y1="650" x2="1470" y2="690" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <g>
+    <rect x="1065" y="710" width="810" height="180" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="756" font-size="26" fill="#c0caf5">one shape, zero drift</text>
+    <text x="1089" y="792" font-size="23" fill="#9ece6a">one edit updates backend display + launcher branch</text>
+    <text x="1089" y="828" font-size="23" fill="#a9b1d6">both sides' tests pass, clippy + WASM build clean</text>
+  </g>
+
+  <!-- Footer -->
+  <text x="55" y="1172" font-size="22" fill="#565f89">Unnamed launches only: caller-supplied names still sanitize launcher-side in sanitize_branch_name.</text>
+</svg>

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -156,12 +156,17 @@ fn normalize_custom_name(name: Option<&str>) -> Option<String> {
         .map(str::to_string)
 }
 
-/// Timestamped default branch/name for an unnamed worktree launch. Mirrors the
-/// launcher's own fallback format (`session-<YYYYMMDD-HHMMSS>`) so the two paths
-/// stay visually consistent; generating it here lets the display name match the
-/// worktree branch even when the caller supplies no name.
+/// Timestamped default branch/name for an unnamed worktree launch. Built from
+/// the shared [`shared::WORKTREE_BRANCH_PREFIX`] shape (the launcher's fallback
+/// uses the same consts) so the display name always matches the worktree branch
+/// even when the caller supplies no name; generating it here lets the two agree
+/// before the launcher runs.
 fn default_worktree_branch() -> String {
-    format!("session-{}", chrono::Local::now().format("%Y%m%d-%H%M%S"))
+    format!(
+        "{}{}",
+        shared::WORKTREE_BRANCH_PREFIX,
+        chrono::Local::now().format(shared::WORKTREE_BRANCH_TIME_FORMAT)
+    )
 }
 
 fn default_session_name(working_directory: &str) -> String {

--- a/frontend/src/components/markdown/math.rs
+++ b/frontend/src/components/markdown/math.rs
@@ -44,32 +44,19 @@ pub(super) fn extract_math_placeholders(text: &str) -> (String, Vec<String>) {
             i += c.len_utf8();
             continue;
         }
-        // Display math: $$...$$
-        if bytes[i] == b'$' && bytes.get(i + 1) == Some(&b'$') {
-            if let Some(rel) = text[i + 2..].find("$$") {
-                let end = i + 2 + rel + 2;
+        // Fixed-delimiter math: `$$...$$`, `\[...\]`, `\(...\)`. The three
+        // shapes differ only in their delimiters, so one table covers them.
+        let mut matched = false;
+        for (open, close) in [("$$", "$$"), ("\\[", "\\]"), ("\\(", "\\)")] {
+            if let Some(end) = match_fixed_span(text, i, open, close) {
                 emit_placeholder(&mut output, &mut math_blocks, &text[i..end]);
                 i = end;
-                continue;
+                matched = true;
+                break;
             }
         }
-        // LaTeX-style display: \[...\]
-        if bytes[i] == b'\\' && bytes.get(i + 1) == Some(&b'[') {
-            if let Some(rel) = text[i + 2..].find("\\]") {
-                let end = i + 2 + rel + 2;
-                emit_placeholder(&mut output, &mut math_blocks, &text[i..end]);
-                i = end;
-                continue;
-            }
-        }
-        // LaTeX-style inline: \(...\)
-        if bytes[i] == b'\\' && bytes.get(i + 1) == Some(&b'(') {
-            if let Some(rel) = text[i + 2..].find("\\)") {
-                let end = i + 2 + rel + 2;
-                emit_placeholder(&mut output, &mut math_blocks, &text[i..end]);
-                i = end;
-                continue;
-            }
+        if matched {
+            continue;
         }
         // Inline math: $...$ on a single line.
         //
@@ -119,6 +106,17 @@ pub(super) fn extract_math_placeholders(text: &str) -> (String, Vec<String>) {
     }
 
     (output, math_blocks)
+}
+
+/// Match one fixed-delimiter math span (`$$…$$`, `\[…\]`, `\(…\)`) at byte
+/// offset `i`, returning the end offset (exclusive) on success. `i` must be a
+/// char boundary, as the scan maintains throughout.
+fn match_fixed_span(text: &str, i: usize, open: &str, close: &str) -> Option<usize> {
+    if !text[i..].starts_with(open) {
+        return None;
+    }
+    let rel = text[i + open.len()..].find(close)?;
+    Some(i + open.len() + rel + close.len())
 }
 
 fn emit_placeholder(output: &mut String, math_blocks: &mut Vec<String>, math: &str) {

--- a/frontend/src/components/markdown/math.rs
+++ b/frontend/src/components/markdown/math.rs
@@ -137,6 +137,25 @@ pub(super) enum MathSegment {
     Math { latex: String, display: bool },
 }
 
+/// Read one placeholder token following a `MATH_OPEN`, consuming through the
+/// closing `MATH_CLOSE` (or end of input for a truncated token).
+fn read_placeholder_token(chars: &mut std::str::Chars<'_>) -> String {
+    let mut token = String::new();
+    for tc in chars.by_ref() {
+        if tc == MATH_CLOSE {
+            break;
+        }
+        token.push(tc);
+    }
+    token
+}
+
+/// Resolve a `MATH<idx>` placeholder token to its captured literal.
+fn lookup_placeholder<'a>(token: &str, math_blocks: &'a [String]) -> Option<&'a str> {
+    let idx = token.strip_prefix("MATH")?.parse::<usize>().ok()?;
+    math_blocks.get(idx).map(String::as_str)
+}
+
 /// Split a text run on math placeholders, resolving each back to its captured
 /// literal and classifying it as inline or display math.
 ///
@@ -154,18 +173,8 @@ pub(super) fn split_math_segments(text: &str, math_blocks: &[String]) -> Vec<Mat
             buf.push(c);
             continue;
         }
-        let mut token = String::new();
-        for tc in chars.by_ref() {
-            if tc == MATH_CLOSE {
-                break;
-            }
-            token.push(tc);
-        }
-        let resolved = token
-            .strip_prefix("MATH")
-            .and_then(|idx| idx.parse::<usize>().ok())
-            .and_then(|idx| math_blocks.get(idx))
-            .and_then(|literal| strip_math_delimiters(literal));
+        let token = read_placeholder_token(&mut chars);
+        let resolved = lookup_placeholder(&token, math_blocks).and_then(strip_math_delimiters);
         // A malformed placeholder is dropped, matching `restore_math`.
         if let Some((latex, display)) = resolved {
             if !buf.is_empty() {
@@ -205,20 +214,10 @@ pub(super) fn restore_math(text: &str, math_blocks: &[String]) -> String {
     let mut chars = text.chars();
     while let Some(c) = chars.next() {
         if c == MATH_OPEN {
-            let mut token = String::new();
-            for tc in chars.by_ref() {
-                if tc == MATH_CLOSE {
-                    break;
-                }
-                token.push(tc);
-            }
-            if let Some(n_str) = token.strip_prefix("MATH") {
-                if let Ok(idx) = n_str.parse::<usize>() {
-                    if let Some(math) = math_blocks.get(idx) {
-                        out.push_str(math);
-                        continue;
-                    }
-                }
+            let token = read_placeholder_token(&mut chars);
+            if let Some(math) = lookup_placeholder(&token, math_blocks) {
+                out.push_str(math);
+                continue;
             }
             // Malformed: drop silently
         } else {

--- a/launcher/src/worktree.rs
+++ b/launcher/src/worktree.rs
@@ -178,7 +178,14 @@ fn sanitize_branch_name(input: &str) -> String {
 }
 
 fn default_branch_name() -> String {
-    format!("session-{}", chrono::Local::now().format("%Y%m%d-%H%M%S"))
+    // Shared shape with the backend's pre-launch display-name default
+    // ([`shared::WORKTREE_BRANCH_PREFIX`]) so an unnamed worktree launch shows
+    // the same name in the rail as on the branch.
+    format!(
+        "{}{}",
+        shared::WORKTREE_BRANCH_PREFIX,
+        chrono::Local::now().format(shared::WORKTREE_BRANCH_TIME_FORMAT)
+    )
 }
 
 #[cfg(test)]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -39,6 +39,15 @@ pub const LAUNCHER_CAPABILITY_RESTART: &str = "launcher.restart";
 /// undecodable frame (#1366).
 pub const LAUNCHER_CAPABILITY_HEARTBEAT_ACK: &str = "launcher.heartbeat_ack";
 
+/// Default git-worktree branch shape for unnamed worktree launches:
+/// `session-<YYYYMMDD-HHMMSS>`. Single source of truth shared by the backend
+/// (which mints the display name before the launcher runs) and the launcher
+/// (which falls back to it when no branch is supplied), so the two can never
+/// drift apart and leave the rail showing a name that matches no branch.
+pub const WORKTREE_BRANCH_PREFIX: &str = "session-";
+/// `chrono` format string for [`WORKTREE_BRANCH_PREFIX`] timestamps.
+pub const WORKTREE_BRANCH_TIME_FORMAT: &str = "%Y%m%d-%H%M%S";
+
 /// Tokyo-Night data-visualization palette shared by charts, sparklines, and
 /// terminal colors. CSS theme tokens remain in the stylesheets where the
 /// browser can resolve them directly.


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/b35fb43d30003c3fe784f1a0b37b3ef5116f6e97/.0-pr-viz/001865.svg)

The backend's pre-launch display-name default and the launcher's branch fallback both minted `session-<YYYYMMDD-HHMMSS>` from inline literals, with comments noting they must mirror each other. This moves the prefix and timestamp format into `shared` (`WORKTREE_BRANCH_PREFIX` / `WORKTREE_BRANCH_TIME_FORMAT`) and builds both defaults from them. No behavior change: same strings, same call sites, existing tests cover both.