### PR TITLE
Dedupe AgentType::Claude fallbacks to unwrap_or_default

### DIFF
--- a/.0-pr-viz/001869.svg
+++ b/.0-pr-viz/001869.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <!-- Header -->
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1869 · Dedupe AgentType::Claude fallbacks to unwrap_or_default</text>
+
+  <!-- Thesis -->
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Four parse fallbacks hardcoded AgentType::Claude though Default already is Claude —</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">now unwrap_or_default() follows the single source of truth; unknown strings stay on Claude.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <!-- Panel labels + center divider -->
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <!-- ==================== BEFORE panel: x 55–945 ==================== -->
+
+  <g>
+    <rect x="80" y="250" width="810" height="235" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="290" font-size="26" fill="#7aa2f7">scheduled_tasks.rs:39,96 · two fallbacks</text>
+    <text x="104" y="330" font-size="23" fill="#f7768e">t.agent_type.parse().unwrap_or(AgentType::Claude)</text>
+    <text x="104" y="366" font-size="23" fill="#f7768e">task.agent_type.parse().unwrap_or(AgentType::Claude)</text>
+    <text x="104" y="402" font-size="23" fill="#a9b1d6">next line down: session_mode uses unwrap_or_default()</text>
+    <text x="104" y="438" font-size="22" fill="#565f89">same function, two idioms side by side</text>
+  </g>
+
+  <line x1="485" y1="485" x2="485" y2="525" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+
+  <g>
+    <rect x="80" y="545" width="810" height="200" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="585" font-size="26" fill="#7aa2f7">launchers.rs:279 · turn_metrics.rs:415</text>
+    <text x="104" y="625" font-size="23" fill="#f7768e">source.agent_type.parse().unwrap_or(AgentType::Claude)</text>
+    <text x="104" y="661" font-size="23" fill="#f7768e">row.agent_type.parse().unwrap_or(AgentType::Claude)</text>
+    <text x="104" y="697" font-size="22" fill="#565f89">transcript.rs + agent_comms.rs already unwrap_or_default()</text>
+  </g>
+
+  <g>
+    <rect x="80" y="765" width="810" height="165" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="811" font-size="26" fill="#c0caf5">the defect: the default is stated five times</text>
+    <text x="104" y="851" font-size="23" fill="#f7768e">AgentType::default() is Claude — each fallback repeats it</text>
+    <text x="104" y="887" font-size="23" fill="#f7768e">a future Default change leaves four stale fallbacks</text>
+  </g>
+
+  <!-- ==================== AFTER panel: x 1040–1945 ==================== -->
+
+  <g>
+    <rect x="1065" y="250" width="810" height="200" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1089" y="290" font-size="26" fill="#7aa2f7">shared/src/lib.rs · AgentType owns the default</text>
+    <text x="1089" y="330" font-size="23" fill="#9ece6a">#[default] Claude — the single source of truth</text>
+    <text x="1089" y="366" font-size="23" fill="#a9b1d6">new test agent_type_default_is_claude pins it</text>
+    <text x="1089" y="402" font-size="22" fill="#565f89">unknown strings must land on Claude, provably</text>
+  </g>
+
+  <line x1="1470" y1="450" x2="1470" y2="490" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <g>
+    <rect x="1065" y="500" width="810" height="265" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="1089" y="540" font-size="26" fill="#c0caf5">four call sites, one line each</text>
+    <text x="1089" y="580" font-size="23" fill="#9ece6a">…parse().unwrap_or_default() — 4 sites</text>
+    <text x="1089" y="616" font-size="23" fill="#a9b1d6">task_to_fields · upcoming_for_task</text>
+    <text x="1089" y="652" font-size="23" fill="#a9b1d6">fork-agent guard · turn-metrics buckets</text>
+    <text x="1089" y="688" font-size="23" fill="#9ece6a">matches the transcript.rs + agent_comms.rs idiom</text>
+    <text x="1089" y="724" font-size="22" fill="#565f89">fallback now tracks Default through any future change</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="785" width="810" height="145" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="831" font-size="26" fill="#c0caf5">imports follow the code</text>
+    <text x="1089" y="871" font-size="23" fill="#9ece6a">scheduled_tasks.rs drops its AgentType import</text>
+    <text x="1089" y="907" font-size="22" fill="#565f89">turn_metrics.rs scopes it to mod tests · 319 lib tests green</text>
+  </g>
+
+  <!-- Footer -->
+  <text x="55" y="1172" font-size="22" fill="#565f89">Scope: the four DB/wire parse fallbacks only — sibling fallbacks (RailPosition::Top, BucketKind::Day) keep their spellings.</text>
+</svg>

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -276,7 +276,7 @@ pub async fn fork_session(
             "Source launcher is offline or does not support session forking",
         ));
     }
-    let agent_type = source.agent_type.parse().unwrap_or(AgentType::Claude);
+    let agent_type = source.agent_type.parse().unwrap_or_default();
     if agent_type == AgentType::Muse {
         return Err(AppError::BadRequest("Muse sessions cannot be forked"));
     }

--- a/backend/src/handlers/scheduled_tasks.rs
+++ b/backend/src/handlers/scheduled_tasks.rs
@@ -13,7 +13,7 @@ use shared::api::{
     CreateScheduledTaskRequest, ScheduledTaskInfo, ScheduledTaskListResponse,
     ScheduledTaskOccurrence, UpcomingScheduledTasksResponse, UpdateScheduledTaskRequest,
 };
-use shared::{AgentType, ScheduledTaskConfig, ScheduledTaskFields, ServerToLauncher};
+use shared::{ScheduledTaskConfig, ScheduledTaskFields, ServerToLauncher};
 use std::{str::FromStr, sync::Arc};
 use tracing::{error, info, warn};
 use uuid::Uuid;
@@ -36,7 +36,7 @@ fn task_to_fields(t: &ScheduledTask) -> ScheduledTaskFields {
         working_directory: t.working_directory.clone(),
         prompt: t.prompt.clone(),
         claude_args: serde_json::from_value(t.claude_args.clone()).unwrap_or_default(),
-        agent_type: t.agent_type.parse().unwrap_or(AgentType::Claude),
+        agent_type: t.agent_type.parse().unwrap_or_default(),
         max_runtime_minutes: t.max_runtime_minutes,
         session_mode: t.session_mode.parse().unwrap_or_default(),
     }
@@ -93,7 +93,7 @@ fn upcoming_for_task(
             task_id: task.id,
             task_name: task.name.clone(),
             hostname: task.hostname.clone(),
-            agent_type: task.agent_type.parse().unwrap_or(AgentType::Claude),
+            agent_type: task.agent_type.parse().unwrap_or_default(),
             scheduled_for: next_utc.to_rfc3339(),
         });
         cursor = next;

--- a/backend/src/handlers/turn_metrics.rs
+++ b/backend/src/handlers/turn_metrics.rs
@@ -28,7 +28,6 @@ use diesel::prelude::*;
 use diesel::sql_types::{BigInt, Double, Nullable, Text, Timestamptz};
 use serde::Deserialize;
 use shared::api::{MetricBucket, MetricBucketsResponse, TurnMetricsResponse};
-use shared::AgentType;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -412,7 +411,7 @@ pub async fn list_aggregated_turn_metrics(
             let stop_reason_counts = reason_index.remove(&key).unwrap_or_default();
             MetricBucket {
                 bucket_start: row.bucket_start,
-                agent_type: row.agent_type.parse().unwrap_or(AgentType::Claude),
+                agent_type: row.agent_type.parse().unwrap_or_default(),
                 model: row.model,
                 service_tier: row.service_tier,
                 turn_count: row.turn_count,
@@ -439,6 +438,7 @@ pub async fn list_aggregated_turn_metrics(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use shared::AgentType;
 
     #[test]
     fn parse_bucket_defaults_to_day() {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1421,6 +1421,14 @@ mod tests {
     }
 
     #[test]
+    fn agent_type_default_is_claude() {
+        // DB/wire parse fallbacks use `unwrap_or_default()` — pin that the
+        // default is Claude so an unknown agent string can never silently
+        // route a session to a different agent.
+        assert_eq!(AgentType::default(), AgentType::Claude);
+    }
+
+    #[test]
     fn session_role_wire_and_capabilities() {
         assert_eq!(SessionRole::Owner.as_str(), "owner");
         assert_eq!(SessionRole::Editor.as_str(), "editor");


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/6e10dbc32e9ced40f1ffebf2cadc9afcb5407ea8/.0-pr-viz/001869.svg)

Four backend parse fallbacks hardcoded `unwrap_or(AgentType::Claude)` while `AgentType::default()` is already `Claude` — and the rest of the codebase (transcript.rs, agent_comms.rs, session_mode next door in scheduled_tasks.rs) already uses `unwrap_or_default()`. This switches the four laggards over so the fallback follows the single source of truth, drops the now-unused import in scheduled_tasks.rs, moves the test-only import in turn_metrics.rs into the test module, and pins `AgentType::default() == Claude` with a unit test.
