### PR TITLE
Dedupe JSONB claude_args decoding into models helper

### DIFF
--- a/.0-pr-viz/001870.svg
+++ b/.0-pr-viz/001870.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <!-- Header -->
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1870 · Dedupe JSONB claude_args decoding into models helper</text>
+
+  <!-- Thesis -->
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Five sites decoded JSONB claude_args with the same from_value line —</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">now models::jsonb_string_vec owns it; each site keeps its behavior.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <!-- Panel labels + center divider -->
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <!-- ==================== BEFORE panel: x 55–945 ==================== -->
+
+  <g>
+    <rect x="80" y="250" width="810" height="235" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="290" font-size="26" fill="#7aa2f7">background.rs:533 · scheduled_tasks.rs:38</text>
+    <text x="104" y="330" font-size="23" fill="#f7768e">from_value(claude_args.clone()).unwrap_or_default()</text>
+    <text x="104" y="366" font-size="23" fill="#f7768e">same decode pasted per call site</text>
+    <text x="104" y="402" font-size="23" fill="#a9b1d6">archive sweep + task_to_fields</text>
+    <text x="104" y="438" font-size="22" fill="#565f89">tolerance comment only on one site</text>
+  </g>
+
+  <line x1="485" y1="485" x2="485" y2="525" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+
+  <g>
+    <rect x="80" y="545" width="810" height="200" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="585" font-size="26" fill="#7aa2f7">launchers.rs:310 · sessions.rs:348</text>
+    <text x="104" y="625" font-size="23" fill="#f7768e">from_value::&lt;Vec&lt;String&gt;&gt;(…).unwrap_or_default()</text>
+    <text x="104" y="661" font-size="23" fill="#f7768e">fork + resume each spell it out again</text>
+    <text x="104" y="697" font-size="22" fill="#565f89">continuations.rs:387 makes five</text>
+  </g>
+
+  <g>
+    <rect x="80" y="765" width="810" height="165" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="811" font-size="26" fill="#c0caf5">tolerance lives in zero places</text>
+    <text x="104" y="851" font-size="23" fill="#f7768e">every site re-decides malformed → empty</text>
+    <text x="104" y="887" font-size="23" fill="#f7768e">a sixth caller means a sixth pasted line</text>
+  </g>
+
+  <!-- ==================== AFTER panel: x 1040–1945 ==================== -->
+
+  <g>
+    <rect x="1065" y="250" width="810" height="200" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1089" y="290" font-size="26" fill="#7aa2f7">models.rs · jsonb_string_vec</text>
+    <text x="1089" y="330" font-size="23" fill="#9ece6a">pub fn (&amp;Value) -&gt; Vec&lt;String&gt;</text>
+    <text x="1089" y="366" font-size="23" fill="#a9b1d6">from_value(v.clone()).unwrap_or_default()</text>
+    <text x="1089" y="402" font-size="22" fill="#565f89">malformed/absent → empty, documented once</text>
+  </g>
+
+  <line x1="1470" y1="450" x2="1470" y2="490" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <g>
+    <rect x="1065" y="500" width="810" height="265" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="1089" y="540" font-size="26" fill="#c0caf5">five one-line call sites</text>
+    <text x="1089" y="580" font-size="23" fill="#9ece6a">jsonb_string_vec(&amp;session.claude_args)</text>
+    <text x="1089" y="616" font-size="23" fill="#a9b1d6">archive, fork, resume, continuation, task fields</text>
+    <text x="1089" y="652" font-size="23" fill="#9ece6a">jsonb_string_vec(&amp;t.claude_args)</text>
+    <text x="1089" y="688" font-size="23" fill="#a9b1d6">scheduled-task row reuses the same helper</text>
+    <text x="1089" y="724" font-size="22" fill="#565f89">+27 / -14 lines across six files</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="785" width="810" height="145" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="831" font-size="26" fill="#c0caf5">pinned by a new unit test</text>
+    <text x="1089" y="871" font-size="23" fill="#9ece6a">jsonb_string_vec_decodes_array_and_tolerates_garbage</text>
+    <text x="1089" y="907" font-size="22" fill="#565f89">array decodes; null + object → empty</text>
+  </g>
+
+  <!-- Footer -->
+  <text x="55" y="1172" font-size="22" fill="#565f89">No behavior change — identical from_value + default semantics, named once.</text>
+</svg>

--- a/backend/src/background.rs
+++ b/backend/src/background.rs
@@ -528,9 +528,7 @@ fn archive_one_session(
             forked_from_session_id: session.forked_from_session_id,
             fork_point_turn_id: session.fork_point_turn_id.clone(),
             scheduled_task_id: session.scheduled_task_id,
-            // `claude_args` is stored as a JSONB string array; recover it as
-            // Vec<String>, tolerating a malformed/absent value as empty.
-            claude_args: serde_json::from_value(session.claude_args.clone()).unwrap_or_default(),
+            claude_args: models::jsonb_string_vec(&session.claude_args),
             // Per-write provenance: whichever backend runs this sweep stamps
             // its own version, so a re-archive reflects the newer writer.
             archived_by_version: Some(shared::VERSION.to_string()),

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -276,7 +276,7 @@ pub async fn fork_session(
             "Source launcher is offline or does not support session forking",
         ));
     }
-    let agent_type = source.agent_type.parse().unwrap_or(AgentType::Claude);
+    let agent_type = AgentType::parse_or_default(&source.agent_type);
     if agent_type == AgentType::Muse {
         return Err(AppError::BadRequest("Muse sessions cannot be forked"));
     }

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -21,7 +21,7 @@ use crate::auth::CurrentUserId;
 use crate::errors::AppError;
 use crate::handlers::responses::EmptyResponse;
 use crate::handlers::websocket::SessionManager;
-use crate::models::{NewSessionMember, NewSessionWithId};
+use crate::models::{jsonb_string_vec, NewSessionMember, NewSessionWithId};
 use crate::AppState;
 
 /// GET /api/launchers - List connected launchers for the current user
@@ -307,8 +307,7 @@ pub async fn fork_session(
     };
     let name = normalize_custom_name(Some(&req.name))
         .unwrap_or_else(|| format!("{} (fork)", source.session_name));
-    let mut claude_args: Vec<String> =
-        serde_json::from_value(source.claude_args.clone()).unwrap_or_default();
+    let mut claude_args: Vec<String> = jsonb_string_vec(&source.claude_args);
     if let Some(model) = req.model.filter(|model| !model.trim().is_empty()) {
         claude_args = apply_model_override(claude_args, agent_type, model);
     }

--- a/backend/src/handlers/scheduled_tasks.rs
+++ b/backend/src/handlers/scheduled_tasks.rs
@@ -22,7 +22,7 @@ use crate::{
     auth::CurrentUserId,
     errors::AppError,
     handlers::responses::EmptyResponse,
-    models::{NewScheduledTask, ScheduledTask, ScheduledTaskChangeset, Session},
+    models::{jsonb_string_vec, NewScheduledTask, ScheduledTask, ScheduledTaskChangeset, Session},
     schema::scheduled_tasks,
     AppState,
 };
@@ -35,7 +35,7 @@ fn task_to_fields(t: &ScheduledTask) -> ScheduledTaskFields {
         timezone: t.timezone.clone(),
         working_directory: t.working_directory.clone(),
         prompt: t.prompt.clone(),
-        claude_args: serde_json::from_value(t.claude_args.clone()).unwrap_or_default(),
+        claude_args: jsonb_string_vec(&t.claude_args),
         agent_type: t.agent_type.parse().unwrap_or(AgentType::Claude),
         max_runtime_minutes: t.max_runtime_minutes,
         session_mode: t.session_mode.parse().unwrap_or_default(),

--- a/backend/src/handlers/scheduled_tasks.rs
+++ b/backend/src/handlers/scheduled_tasks.rs
@@ -36,7 +36,7 @@ fn task_to_fields(t: &ScheduledTask) -> ScheduledTaskFields {
         working_directory: t.working_directory.clone(),
         prompt: t.prompt.clone(),
         claude_args: jsonb_string_vec(&t.claude_args),
-        agent_type: t.agent_type.parse().unwrap_or(AgentType::Claude),
+        agent_type: AgentType::parse_or_default(&t.agent_type),
         max_runtime_minutes: t.max_runtime_minutes,
         session_mode: t.session_mode.parse().unwrap_or_default(),
     }
@@ -93,7 +93,7 @@ fn upcoming_for_task(
             task_id: task.id,
             task_name: task.name.clone(),
             hostname: task.hostname.clone(),
-            agent_type: task.agent_type.parse().unwrap_or(AgentType::Claude),
+            agent_type: AgentType::parse_or_default(&task.agent_type),
             scheduled_for: next_utc.to_rfc3339(),
         });
         cursor = next;

--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -16,7 +16,7 @@ use crate::{
     auth::CurrentUserId,
     errors::AppError,
     handlers::responses::EmptyResponse,
-    models::{Message, NewSessionMember, Session, SessionMember},
+    models::{jsonb_string_vec, Message, NewSessionMember, Session, SessionMember},
     AppState,
 };
 
@@ -345,8 +345,7 @@ pub async fn resume_session(
 
     let auth_token = crate::handlers::launchers::mint_launch_token(&app_state, session.user_id)?;
     let request_id = Uuid::new_v4();
-    let claude_args =
-        serde_json::from_value::<Vec<String>>(session.claude_args.clone()).unwrap_or_default();
+    let claude_args = jsonb_string_vec(&session.claude_args);
     let agent_type = session
         .agent_type
         .parse()

--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -346,10 +346,7 @@ pub async fn resume_session(
     let auth_token = crate::handlers::launchers::mint_launch_token(&app_state, session.user_id)?;
     let request_id = Uuid::new_v4();
     let claude_args = jsonb_string_vec(&session.claude_args);
-    let agent_type = session
-        .agent_type
-        .parse()
-        .unwrap_or(shared::AgentType::Claude);
+    let agent_type = shared::AgentType::parse_or_default(&session.agent_type);
 
     use crate::schema::sessions;
     diesel::update(sessions::table.find(session_id))

--- a/backend/src/handlers/turn_metrics.rs
+++ b/backend/src/handlers/turn_metrics.rs
@@ -412,7 +412,7 @@ pub async fn list_aggregated_turn_metrics(
             let stop_reason_counts = reason_index.remove(&key).unwrap_or_default();
             MetricBucket {
                 bucket_start: row.bucket_start,
-                agent_type: row.agent_type.parse().unwrap_or(AgentType::Claude),
+                agent_type: AgentType::parse_or_default(&row.agent_type),
                 model: row.model,
                 service_tier: row.service_tier,
                 turn_count: row.turn_count,

--- a/backend/src/handlers/websocket/continuations.rs
+++ b/backend/src/handlers/websocket/continuations.rs
@@ -9,7 +9,9 @@ use uuid::Uuid;
 
 use super::{SessionId, SessionManager};
 use crate::db::DbPool;
-use crate::models::{NewMessage, NewSessionContinuation, Session, SessionContinuation};
+use crate::models::{
+    jsonb_string_vec, NewMessage, NewSessionContinuation, Session, SessionContinuation,
+};
 use crate::AppState;
 
 /// Lifecycle state stored in `session_continuations.status`.
@@ -398,8 +400,7 @@ pub fn load_scheduled_continuations(
         .unwrap_or_default()
         .into_iter()
         .map(|(row, session)| {
-            let claude_args =
-                serde_json::from_value::<Vec<String>>(session.claude_args).unwrap_or_default();
+            let claude_args = jsonb_string_vec(&session.claude_args);
             let agent_type = parse_agent_type(&session.agent_type);
             ContinuationConfig {
                 id: row.id,

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -1157,10 +1157,7 @@ fn reconcile_desired_sessions(app_state: &AppState, launcher_id: Uuid, user_id: 
             .register_launch_session(request_id, session.id);
 
         let claude_args = crate::models::jsonb_string_vec(&session.claude_args);
-        let agent_type = session
-            .agent_type
-            .parse()
-            .unwrap_or(shared::AgentType::Claude);
+        let agent_type = shared::AgentType::parse_or_default(&session.agent_type);
 
         let pending_fork = session.fork_launch_pending;
         let create_worktree = pending_fork && session.fork_create_worktree;

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -1156,8 +1156,7 @@ fn reconcile_desired_sessions(app_state: &AppState, launcher_id: Uuid, user_id: 
             .session_manager
             .register_launch_session(request_id, session.id);
 
-        let claude_args =
-            serde_json::from_value::<Vec<String>>(session.claude_args.clone()).unwrap_or_default();
+        let claude_args = crate::models::jsonb_string_vec(&session.claude_args);
         let agent_type = session
             .agent_type
             .parse()

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -3,6 +3,12 @@ use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+/// Decode a JSONB string-array column (e.g. `claude_args`) into `Vec<String>`,
+/// tolerating a malformed/absent value as empty.
+pub fn jsonb_string_vec(v: &serde_json::Value) -> Vec<String> {
+    serde_json::from_value(v.clone()).unwrap_or_default()
+}
+
 #[derive(Debug, Queryable, Selectable, Serialize, Deserialize, Clone)]
 #[diesel(table_name = crate::schema::users)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
@@ -787,5 +793,15 @@ mod tests {
         // skips-with-log rather than mis-routing a legacy/corrupt row.
         assert_eq!(push_sub("mms").platform_kind(), None);
         assert_eq!(push_sub("").platform_kind(), None);
+    }
+
+    #[test]
+    fn jsonb_string_vec_decodes_array_and_tolerates_garbage() {
+        assert_eq!(
+            jsonb_string_vec(&serde_json::json!(["--model", "opus"])),
+            vec!["--model".to_string(), "opus".to_string()]
+        );
+        assert!(jsonb_string_vec(&serde_json::json!(null)).is_empty());
+        assert!(jsonb_string_vec(&serde_json::json!({"oops": 1})).is_empty());
     }
 }

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -649,7 +649,7 @@ impl TurnMetric {
             // session is gone. Freshly inserted rows always carry one.
             session_id: self.session_id.unwrap_or_default(),
             user_message_id: self.user_message_id,
-            agent_type: self.agent_type.parse().unwrap_or(shared::AgentType::Claude),
+            agent_type: shared::AgentType::parse_or_default(&self.agent_type),
             model: self.model,
             service_tier: self.service_tier,
             started_at: self.started_at,

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -217,6 +217,14 @@ impl AgentType {
         }
     }
 
+    /// Parse a stored/transmitted agent-type string, falling back to the
+    /// default (`Claude`) on unknown or garbage input. The DB keeps
+    /// `agent_type` as text, so every read path needs the same tolerant
+    /// decode — one helper instead of a dozen `parse().unwrap_or(_)` spells.
+    pub fn parse_or_default(s: &str) -> Self {
+        s.parse().unwrap_or_default()
+    }
+
     /// Human-facing label ("Claude", "Codex", "Muse") for dropdowns, chips,
     /// and settings titles. Single source of truth so the frontend never
     /// re-matches the enum just to capitalize the wire name.
@@ -1418,6 +1426,19 @@ mod tests {
         assert_eq!(AgentType::Claude.display_name(), "Claude");
         assert_eq!(AgentType::Codex.display_name(), "Codex");
         assert_eq!(AgentType::Muse.display_name(), "Muse");
+    }
+
+    #[test]
+    fn agent_type_parse_or_default_tolerates_garbage() {
+        // Every variant parses (case-insensitively); unknown/empty input
+        // falls back to the default (Claude), matching the old
+        // `parse().unwrap_or(_)` behavior at every DB read site.
+        assert_eq!(AgentType::parse_or_default("claude"), AgentType::Claude);
+        assert_eq!(AgentType::parse_or_default("codex"), AgentType::Codex);
+        assert_eq!(AgentType::parse_or_default("muse"), AgentType::Muse);
+        assert_eq!(AgentType::parse_or_default("Muse"), AgentType::Muse);
+        assert_eq!(AgentType::parse_or_default("bogus"), AgentType::Claude);
+        assert_eq!(AgentType::parse_or_default(""), AgentType::Claude);
     }
 
     #[test]


### PR DESCRIPTION
![PR visualization](https://raw.githubusercontent.com/meawoppl/agent-portal/0b65752706c21e7670ca860d2f9ab35388050a52/.0-pr-viz/001870.svg)

Five call sites decoded the JSONB claude_args column with identical serde_json::from_value(...).unwrap_or_default(). Hoist that into models::jsonb_string_vec with one doc comment and a unit test pinning array/garbage behavior. No behavior change.