### PR TITLE
Dedupe claude_args JSONB decode into helper

### DIFF
--- a/.0-pr-viz/001872.svg
+++ b/.0-pr-viz/001872.svg
@@ -1,0 +1,89 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <!-- Header -->
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1872 · Dedupe claude_args JSONB decode into helper</text>
+
+  <!-- Thesis -->
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Six call sites decoded claude_args with the same from_value chain —</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">now models::jsonb_or_default owns the decode; no behavior change.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <!-- Panel labels + center divider -->
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <!-- ==================== BEFORE panel: x 55–945 ==================== -->
+
+  <g>
+    <rect x="80" y="250" width="810" height="235" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="290" font-size="26" fill="#7aa2f7">the repeated expression, x6</text>
+    <text x="104" y="330" font-size="23" fill="#f7768e">from_value::&lt;Vec&lt;String&gt;&gt;(…claude_args…)</text>
+    <text x="104" y="366" font-size="23" fill="#f7768e">.unwrap_or_default()</text>
+    <text x="104" y="402" font-size="23" fill="#a9b1d6">owned Value in, Vec&lt;String&gt; out</text>
+    <text x="104" y="438" font-size="22" fill="#565f89">garbage decodes to empty, every time</text>
+  </g>
+
+  <line x1="485" y1="495" x2="485" y2="530" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+
+  <g>
+    <rect x="80" y="550" width="810" height="235" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="590" font-size="26" fill="#7aa2f7">four launch-path sites</text>
+    <text x="104" y="630" font-size="23" fill="#f7768e">launcher_socket.rs:1160 · reconcile</text>
+    <text x="104" y="666" font-size="23" fill="#f7768e">continuations.rs:388 · scheduled</text>
+    <text x="104" y="702" font-size="23" fill="#f7768e">sessions.rs:349 · resume</text>
+    <text x="104" y="738" font-size="23" fill="#f7768e">launchers.rs:311 · fork</text>
+  </g>
+
+  <g>
+    <rect x="80" y="805" width="810" height="200" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="845" font-size="26" fill="#c0caf5">two struct-literal sites</text>
+    <text x="104" y="885" font-size="23" fill="#f7768e">scheduled_tasks.rs:38 · task_to_fields</text>
+    <text x="104" y="921" font-size="23" fill="#f7768e">background.rs:533 · archive sweep</text>
+    <text x="104" y="957" font-size="22" fill="#565f89">a seventh shape means a seventh paste</text>
+  </g>
+
+  <!-- ==================== AFTER panel: x 1040–1945 ==================== -->
+
+  <g>
+    <rect x="1065" y="250" width="810" height="235" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1089" y="290" font-size="26" fill="#7aa2f7">models.rs · jsonb_or_default</text>
+    <text x="1089" y="330" font-size="23" fill="#9ece6a">pub fn jsonb_or_default&lt;T&gt;(v) -&gt; T</text>
+    <text x="1089" y="366" font-size="23" fill="#a9b1d6">serde_json::from_value(v).unwrap_or_default()</text>
+    <text x="1089" y="402" font-size="23" fill="#a9b1d6">owned Value in, T::default() on garbage</text>
+    <text x="1089" y="438" font-size="22" fill="#565f89">T: Default + DeserializeOwned</text>
+  </g>
+
+  <line x1="1470" y1="495" x2="1470" y2="530" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <g>
+    <rect x="1065" y="550" width="810" height="235" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="1089" y="590" font-size="26" fill="#c0caf5">six one-line call sites</text>
+    <text x="1089" y="630" font-size="23" fill="#9ece6a">models::jsonb_or_default(… .clone())</text>
+    <text x="1089" y="666" font-size="23" fill="#a9b1d6">let bindings keep their Vec&lt;String&gt; type</text>
+    <text x="1089" y="702" font-size="23" fill="#a9b1d6">struct fields infer from the schema types</text>
+    <text x="1089" y="738" font-size="22" fill="#565f89">+27 / -10 lines across seven files</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="805" width="810" height="200" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="845" font-size="26" fill="#c0caf5">pinned by a new unit test</text>
+    <text x="1089" y="885" font-size="23" fill="#9ece6a">jsonb_or_default_decodes_or_falls_back</text>
+    <text x="1089" y="921" font-size="23" fill="#a9b1d6">array decodes · null falls back · object falls back</text>
+    <text x="1089" y="957" font-size="22" fill="#565f89">backend lib tests green; clippy clean</text>
+  </g>
+
+  <!-- Footer -->
+  <text x="55" y="1172" font-size="22" fill="#565f89">No behavior change: null or garbage JSONB still becomes an empty Vec&lt;String&gt;.</text>
+</svg>

--- a/backend/src/background.rs
+++ b/backend/src/background.rs
@@ -530,7 +530,7 @@ fn archive_one_session(
             scheduled_task_id: session.scheduled_task_id,
             // `claude_args` is stored as a JSONB string array; recover it as
             // Vec<String>, tolerating a malformed/absent value as empty.
-            claude_args: serde_json::from_value(session.claude_args.clone()).unwrap_or_default(),
+            claude_args: crate::models::jsonb_or_default(session.claude_args.clone()),
             // Per-write provenance: whichever backend runs this sweep stamps
             // its own version, so a re-archive reflects the newer writer.
             archived_by_version: Some(shared::VERSION.to_string()),

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -307,8 +307,7 @@ pub async fn fork_session(
     };
     let name = normalize_custom_name(Some(&req.name))
         .unwrap_or_else(|| format!("{} (fork)", source.session_name));
-    let mut claude_args: Vec<String> =
-        serde_json::from_value(source.claude_args.clone()).unwrap_or_default();
+    let mut claude_args: Vec<String> = crate::models::jsonb_or_default(source.claude_args.clone());
     if let Some(model) = req.model.filter(|model| !model.trim().is_empty()) {
         claude_args = apply_model_override(claude_args, agent_type, model);
     }

--- a/backend/src/handlers/scheduled_tasks.rs
+++ b/backend/src/handlers/scheduled_tasks.rs
@@ -35,7 +35,7 @@ fn task_to_fields(t: &ScheduledTask) -> ScheduledTaskFields {
         timezone: t.timezone.clone(),
         working_directory: t.working_directory.clone(),
         prompt: t.prompt.clone(),
-        claude_args: serde_json::from_value(t.claude_args.clone()).unwrap_or_default(),
+        claude_args: crate::models::jsonb_or_default(t.claude_args.clone()),
         agent_type: t.agent_type.parse().unwrap_or(AgentType::Claude),
         max_runtime_minutes: t.max_runtime_minutes,
         session_mode: t.session_mode.parse().unwrap_or_default(),

--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -345,8 +345,7 @@ pub async fn resume_session(
 
     let auth_token = crate::handlers::launchers::mint_launch_token(&app_state, session.user_id)?;
     let request_id = Uuid::new_v4();
-    let claude_args =
-        serde_json::from_value::<Vec<String>>(session.claude_args.clone()).unwrap_or_default();
+    let claude_args: Vec<String> = crate::models::jsonb_or_default(session.claude_args.clone());
     let agent_type = session
         .agent_type
         .parse()

--- a/backend/src/handlers/websocket/continuations.rs
+++ b/backend/src/handlers/websocket/continuations.rs
@@ -384,8 +384,7 @@ pub fn load_scheduled_continuations(
         .unwrap_or_default()
         .into_iter()
         .map(|(row, session)| {
-            let claude_args =
-                serde_json::from_value::<Vec<String>>(session.claude_args).unwrap_or_default();
+            let claude_args: Vec<String> = crate::models::jsonb_or_default(session.claude_args);
             let agent_type = session.agent_type.parse().unwrap_or_default();
             ContinuationConfig {
                 id: row.id,

--- a/backend/src/handlers/websocket/launcher_socket.rs
+++ b/backend/src/handlers/websocket/launcher_socket.rs
@@ -1156,8 +1156,7 @@ fn reconcile_desired_sessions(app_state: &AppState, launcher_id: Uuid, user_id: 
             .session_manager
             .register_launch_session(request_id, session.id);
 
-        let claude_args =
-            serde_json::from_value::<Vec<String>>(session.claude_args.clone()).unwrap_or_default();
+        let claude_args: Vec<String> = crate::models::jsonb_or_default(session.claude_args.clone());
         let agent_type = session
             .agent_type
             .parse()

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -319,6 +319,17 @@ pub struct NewPushSubscription {
     pub device_label: Option<String>,
 }
 
+/// Decode an owned JSONB column into `T`, falling back to `T::default()`
+/// when the stored value no longer parses (e.g. an older payload shape).
+/// Keeps tolerant reads of `sessions.claude_args`,
+/// `scheduled_tasks.claude_args`, etc. in one place.
+pub fn jsonb_or_default<T>(v: serde_json::Value) -> T
+where
+    T: Default + serde::de::DeserializeOwned,
+{
+    serde_json::from_value(v).unwrap_or_default()
+}
+
 // ============================================================================
 // Pending Permission Request Models
 // ============================================================================
@@ -787,5 +798,15 @@ mod tests {
         // skips-with-log rather than mis-routing a legacy/corrupt row.
         assert_eq!(push_sub("mms").platform_kind(), None);
         assert_eq!(push_sub("").platform_kind(), None);
+    }
+
+    #[test]
+    fn jsonb_or_default_decodes_or_falls_back() {
+        assert_eq!(
+            jsonb_or_default::<Vec<String>>(serde_json::json!(["--model", "opus"])),
+            vec!["--model".to_string(), "opus".to_string()]
+        );
+        assert!(jsonb_or_default::<Vec<String>>(serde_json::json!(null)).is_empty());
+        assert!(jsonb_or_default::<Vec<String>>(serde_json::json!({"oops": 1})).is_empty());
     }
 }


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/5efdf36359b2d72d6838d7c48b2620963b27bfbd/.0-pr-viz/001872.svg)

Six call sites repeated `serde_json::from_value::<Vec<String>>(...claude_args...).unwrap_or_default()` to tolerantly read the `claude_args` JSONB column (launcher reconcile, continuations, resume, scheduled tasks, fork, archive sweep). This adds `models::jsonb_or_default<T>` for owned JSONB values and uses it at all six, with a unit test pinning the decode/garbage behavior. No behavior change.