### PR TITLE
Dedupe optional JSONB decode into helper

### DIFF
--- a/.0-pr-viz/001873.svg
+++ b/.0-pr-viz/001873.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <!-- Header -->
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1873 · Dedupe optional JSONB decode into helper</text>
+
+  <!-- Thesis -->
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Four tolerant Option-Value reads each pasted the same three-line decode —</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">now models::jsonb_opt_or_default owns it, so NULL and stale shapes fall back to default.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <!-- Panel labels + center divider -->
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <!-- ==================== BEFORE panel: x 55–945 ==================== -->
+
+  <g>
+    <rect x="80" y="250" width="810" height="200" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="290" font-size="26" fill="#7aa2f7">push/dispatcher.rs:171 · resolve_recipient</text>
+    <text x="104" y="330" font-size="23" fill="#f7768e">and_then(from_value).ok() then unwrap_or_default</text>
+    <text x="104" y="366" font-size="23" fill="#f7768e">notification_prefs lookup — pasted copy number one</text>
+    <text x="104" y="402" font-size="22" fill="#565f89">NULL or stale shape silently becomes default</text>
+  </g>
+
+  <line x1="485" y1="450" x2="485" y2="490" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+
+  <g>
+    <rect x="80" y="510" width="810" height="200" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="550" font-size="26" fill="#7aa2f7">handlers/push.rs · get_prefs + read_prefs</text>
+    <text x="104" y="590" font-size="23" fill="#f7768e">the same three lines in handler and test helper</text>
+    <text x="104" y="626" font-size="23" fill="#f7768e">notification_prefs lookup — copies two and three</text>
+    <text x="104" y="662" font-size="22" fill="#565f89">a doc comment re-explains the fallback twice</text>
+  </g>
+
+  <line x1="485" y1="710" x2="485" y2="750" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+
+  <g>
+    <rect x="80" y="770" width="810" height="200" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="810" font-size="26" fill="#7aa2f7">websocket/permissions.rs:208 · replay</text>
+    <text x="104" y="850" font-size="23" fill="#f7768e">permission_suggestions decode — copy number four</text>
+    <text x="104" y="886" font-size="23" fill="#f7768e">a fifth tolerant read means a fifth pasted triple</text>
+    <text x="104" y="922" font-size="22" fill="#565f89">fix the fallback once, miss three sites</text>
+  </g>
+
+  <!-- ==================== AFTER panel: x 1040–1945 ==================== -->
+
+  <g>
+    <rect x="1065" y="250" width="810" height="200" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1089" y="290" font-size="26" fill="#7aa2f7">models.rs:326 · jsonb_opt_or_default</text>
+    <text x="1089" y="330" font-size="23" fill="#9ece6a">one generic over Option-Value, NULL-tolerant</text>
+    <text x="1089" y="366" font-size="23" fill="#a9b1d6">and_then(from_value).ok() lives here exactly once</text>
+    <text x="1089" y="402" font-size="22" fill="#565f89">T: Default + DeserializeOwned bounds the deal</text>
+  </g>
+
+  <line x1="1470" y1="450" x2="1470" y2="490" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <g>
+    <rect x="1065" y="500" width="810" height="265" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="1089" y="540" font-size="26" fill="#c0caf5">four one-line call sites</text>
+    <text x="1089" y="580" font-size="23" fill="#9ece6a">jsonb_opt_or_default(stored) → NotificationPrefs</text>
+    <text x="1089" y="616" font-size="23" fill="#a9b1d6">dispatcher, get_prefs, read_prefs — type by inference</text>
+    <text x="1089" y="652" font-size="23" fill="#9ece6a">jsonb_opt_or_default(suggestions) → Vec-Suggestion</text>
+    <text x="1089" y="688" font-size="23" fill="#a9b1d6">permission replay keeps its Vec target type</text>
+    <text x="1089" y="724" font-size="22" fill="#565f89">+30 / -13 lines across the four files</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="785" width="810" height="145" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="831" font-size="26" fill="#c0caf5">pinned by a new unit test</text>
+    <text x="1089" y="871" font-size="23" fill="#9ece6a">jsonb_opt_or_default_tolerates_null_and_bad_shapes</text>
+    <text x="1089" y="907" font-size="22" fill="#565f89">NULL, valid array, stale object → default; 320 lib tests green</text>
+  </g>
+
+  <!-- Footer -->
+  <text x="55" y="1172" font-size="22" fill="#565f89">Leaves the sibling owned-Value decode from #1872 untouched — unifying the two helpers waits until that PR lands.</text>
+</svg>

--- a/backend/src/handlers/push.rs
+++ b/backend/src/handlers/push.rs
@@ -170,9 +170,7 @@ pub async fn get_prefs(
         .select(users::notification_prefs)
         .first(&mut conn)?;
 
-    let prefs = stored
-        .and_then(|v| serde_json::from_value(v).ok())
-        .unwrap_or_default();
+    let prefs = crate::models::jsonb_opt_or_default(stored);
 
     Ok(Json(prefs))
 }
@@ -223,9 +221,7 @@ mod db_tests {
             .select(users::notification_prefs)
             .first(conn)
             .expect("select notification_prefs");
-        stored
-            .and_then(|v| serde_json::from_value(v).ok())
-            .unwrap_or_default()
+        crate::models::jsonb_opt_or_default(stored)
     }
 
     #[test]

--- a/backend/src/handlers/websocket/permissions.rs
+++ b/backend/src/handlers/websocket/permissions.rs
@@ -204,10 +204,8 @@ pub fn replay_pending_permission(db_pool: &DbPool, session_id: Uuid, tx: &WebCli
             session_id, pending.tool_name, pending.request_id
         );
 
-        let suggestions: Vec<shared::PermissionSuggestion> = pending
-            .permission_suggestions
-            .and_then(|v| serde_json::from_value(v).ok())
-            .unwrap_or_default();
+        let suggestions: Vec<shared::PermissionSuggestion> =
+            crate::models::jsonb_opt_or_default(pending.permission_suggestions);
 
         let _ = tx.send(ServerToClient::PermissionRequest {
             request_id: pending.request_id,

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -319,6 +319,18 @@ pub struct NewPushSubscription {
     pub device_label: Option<String>,
 }
 
+/// Decode an optional JSONB column into `T`, falling back to `T::default()`
+/// when the column is NULL or the stored value no longer parses (e.g. an
+/// older payload shape). Keeps tolerant reads of `users.notification_prefs`,
+/// `pending_permission_requests.permission_suggestions`, etc. in one place.
+pub fn jsonb_opt_or_default<T>(v: Option<serde_json::Value>) -> T
+where
+    T: Default + serde::de::DeserializeOwned,
+{
+    v.and_then(|v| serde_json::from_value(v).ok())
+        .unwrap_or_default()
+}
+
 // ============================================================================
 // Pending Permission Request Models
 // ============================================================================
@@ -787,5 +799,18 @@ mod tests {
         // skips-with-log rather than mis-routing a legacy/corrupt row.
         assert_eq!(push_sub("mms").platform_kind(), None);
         assert_eq!(push_sub("").platform_kind(), None);
+    }
+
+    #[test]
+    fn jsonb_opt_or_default_tolerates_null_and_bad_shapes() {
+        // NULL column → default.
+        let none: Vec<String> = jsonb_opt_or_default(None);
+        assert!(none.is_empty());
+        // Well-formed value decodes.
+        let some: Vec<String> = jsonb_opt_or_default(Some(serde_json::json!(["a", "b"])));
+        assert_eq!(some, vec!["a".to_string(), "b".to_string()]);
+        // Stale shape (object where a list is expected) → default, not panic.
+        let stale: Vec<String> = jsonb_opt_or_default(Some(serde_json::json!({"old": true})));
+        assert!(stale.is_empty());
     }
 }

--- a/backend/src/push/dispatcher.rs
+++ b/backend/src/push/dispatcher.rs
@@ -168,9 +168,7 @@ fn resolve_recipient(
         .first::<(Uuid, String, Option<serde_json::Value>)>(conn)
         .optional()?;
     Ok(row.map(|(user_id, name, stored)| {
-        let prefs = stored
-            .and_then(|v| serde_json::from_value(v).ok())
-            .unwrap_or_default();
+        let prefs = crate::models::jsonb_opt_or_default(stored);
         (user_id, name, prefs)
     }))
 }


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/a5eaa13a3f9423aa61b9b72b5fc2d6d3b1aaadf2/.0-pr-viz/001873.svg)

Four call sites decoded an optional JSONB column with the same three-line idiom (notification prefs x3, permission suggestions x1). This adds a small generic helper next to the same pattern and routes all four through it, plus a unit test pinning the NULL / valid / stale-shape cases. No behavior change: identical fallback semantics.