### PR TITLE
Add AgentType parse_or_default, dedupe 12 sites

### DIFF
--- a/.0-pr-viz/001874.svg
+++ b/.0-pr-viz/001874.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <!-- Header -->
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1874 · Add AgentType parse_or_default, dedupe 12 sites</text>
+
+  <!-- Thesis -->
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Twelve agent-type reads each spelled the same stale-means-Claude fallback three ways —</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">now AgentType::parse_or_default owns it in shared, so every DB and wire reader agrees.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <!-- Panel labels + center divider -->
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <!-- ==================== BEFORE panel: x 55–945 ==================== -->
+
+  <g>
+    <rect x="80" y="250" width="810" height="200" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="290" font-size="26" fill="#7aa2f7">six files · three spellings, one meaning</text>
+    <text x="104" y="330" font-size="23" fill="#f7768e">.parse().unwrap_or(AgentType::Claude)</text>
+    <text x="104" y="366" font-size="23" fill="#f7768e">.parse().unwrap_or_default() — the same thing</text>
+    <text x="104" y="402" font-size="22" fill="#565f89">Default for AgentType is Claude either way</text>
+  </g>
+
+  <line x1="485" y1="450" x2="485" y2="490" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+
+  <g>
+    <rect x="80" y="510" width="810" height="200" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="550" font-size="26" fill="#7aa2f7">continuations.rs · five copies alone</text>
+    <text x="104" y="590" font-size="23" fill="#f7768e">AgentOutput fan-out pasted per handler</text>
+    <text x="104" y="626" font-size="23" fill="#f7768e">session.agent_type.parse().unwrap_or_default()</text>
+    <text x="104" y="662" font-size="22" fill="#565f89">five of the twelve sites in a single file</text>
+  </g>
+
+  <line x1="485" y1="710" x2="485" y2="750" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+
+  <g>
+    <rect x="80" y="770" width="810" height="200" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="810" font-size="26" fill="#7aa2f7">agent_comms.rs:434 · the third spelling</text>
+    <text x="104" y="850" font-size="23" fill="#f7768e">AgentType::from_str(..).unwrap_or_default()</text>
+    <text x="104" y="886" font-size="23" fill="#f7768e">a thirteenth reader means a thirteenth paste</text>
+    <text x="104" y="922" font-size="22" fill="#565f89">its FromStr import dies with the call</text>
+  </g>
+
+  <!-- ==================== AFTER panel: x 1040–1945 ==================== -->
+
+  <g>
+    <rect x="1065" y="250" width="810" height="200" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1089" y="290" font-size="26" fill="#7aa2f7">shared/lib.rs · parse_or_default</text>
+    <text x="1089" y="330" font-size="23" fill="#9ece6a">pub fn parse_or_default(s: &amp;str) -&gt; Self</text>
+    <text x="1089" y="366" font-size="23" fill="#a9b1d6">s.parse().unwrap_or_default() lives here once</text>
+    <text x="1089" y="402" font-size="22" fill="#565f89">WASM-safe: the history page uses it too</text>
+  </g>
+
+  <line x1="1470" y1="450" x2="1470" y2="490" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <g>
+    <rect x="1065" y="500" width="810" height="265" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="1089" y="540" font-size="26" fill="#c0caf5">twelve one-line call sites</text>
+    <text x="1089" y="580" font-size="23" fill="#9ece6a">parse_or_default(&amp;stored) → Claude on stale</text>
+    <text x="1089" y="616" font-size="23" fill="#a9b1d6">models, metrics, launchers, tasks, sockets</text>
+    <text x="1089" y="652" font-size="23" fill="#9ece6a">shared::parse_or_default(&amp;m) → history page</text>
+    <text x="1089" y="688" font-size="23" fill="#a9b1d6">type flows from the struct field by inference</text>
+    <text x="1089" y="724" font-size="22" fill="#565f89">+34 / -13 lines across eight files</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="785" width="810" height="145" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="831" font-size="26" fill="#c0caf5">pinned by a new unit test</text>
+    <text x="1089" y="871" font-size="23" fill="#9ece6a">agent_type_parse_or_default_tolerates_stale_strings</text>
+    <text x="1089" y="907" font-size="22" fill="#565f89">known, cased, stale, empty; 197 shared + 319 backend green</text>
+  </g>
+
+  <!-- Footer -->
+  <text x="55" y="1172" font-size="22" fill="#565f89">Leaves the matches! gate and the Option-chain fallback untouched — different shapes, different helpers.</text>
+</svg>

--- a/backend/src/handlers/agent_comms.rs
+++ b/backend/src/handlers/agent_comms.rs
@@ -5,7 +5,6 @@
 //! proxy token (programmatic/agent callers), and is scoped to a single user —
 //! you can only see and message your own sessions.
 
-use std::str::FromStr;
 use std::sync::Arc;
 
 use axum::{
@@ -431,7 +430,7 @@ pub async fn show_media(
     }
 
     let content_json = portal.to_json();
-    let agent_type = AgentType::from_str(&session.agent_type).unwrap_or_default();
+    let agent_type = AgentType::parse_or_default(&session.agent_type);
 
     // Persist the transcript row (durability + reconnect replay). Broadcast is
     // best-effort; persistence is the guarantee.

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -276,7 +276,7 @@ pub async fn fork_session(
             "Source launcher is offline or does not support session forking",
         ));
     }
-    let agent_type = source.agent_type.parse().unwrap_or(AgentType::Claude);
+    let agent_type = AgentType::parse_or_default(&source.agent_type);
     if agent_type == AgentType::Muse {
         return Err(AppError::BadRequest("Muse sessions cannot be forked"));
     }

--- a/backend/src/handlers/scheduled_tasks.rs
+++ b/backend/src/handlers/scheduled_tasks.rs
@@ -36,7 +36,7 @@ fn task_to_fields(t: &ScheduledTask) -> ScheduledTaskFields {
         working_directory: t.working_directory.clone(),
         prompt: t.prompt.clone(),
         claude_args: serde_json::from_value(t.claude_args.clone()).unwrap_or_default(),
-        agent_type: t.agent_type.parse().unwrap_or(AgentType::Claude),
+        agent_type: AgentType::parse_or_default(&t.agent_type),
         max_runtime_minutes: t.max_runtime_minutes,
         session_mode: t.session_mode.parse().unwrap_or_default(),
     }
@@ -93,7 +93,7 @@ fn upcoming_for_task(
             task_id: task.id,
             task_name: task.name.clone(),
             hostname: task.hostname.clone(),
-            agent_type: task.agent_type.parse().unwrap_or(AgentType::Claude),
+            agent_type: AgentType::parse_or_default(&task.agent_type),
             scheduled_for: next_utc.to_rfc3339(),
         });
         cursor = next;

--- a/backend/src/handlers/turn_metrics.rs
+++ b/backend/src/handlers/turn_metrics.rs
@@ -412,7 +412,7 @@ pub async fn list_aggregated_turn_metrics(
             let stop_reason_counts = reason_index.remove(&key).unwrap_or_default();
             MetricBucket {
                 bucket_start: row.bucket_start,
-                agent_type: row.agent_type.parse().unwrap_or(AgentType::Claude),
+                agent_type: AgentType::parse_or_default(&row.agent_type),
                 model: row.model,
                 service_tier: row.service_tier,
                 turn_count: row.turn_count,

--- a/backend/src/handlers/websocket/continuations.rs
+++ b/backend/src/handlers/websocket/continuations.rs
@@ -149,7 +149,7 @@ pub fn handle_session_limit_reached(
             key,
             ServerToClient::AgentOutput {
                 content: portal.to_json(),
-                agent_type: session.agent_type.parse().unwrap_or_default(),
+                agent_type: AgentType::parse_or_default(&session.agent_type),
                 meta,
             },
         );
@@ -326,7 +326,7 @@ fn update_terminal_status(
                         &session_id.to_string(),
                         ServerToClient::AgentOutput {
                             content: portal.to_json(),
-                            agent_type: session.agent_type.parse().unwrap_or_default(),
+                            agent_type: AgentType::parse_or_default(&session.agent_type),
                             meta,
                         },
                     );
@@ -386,7 +386,7 @@ pub fn load_scheduled_continuations(
         .map(|(row, session)| {
             let claude_args =
                 serde_json::from_value::<Vec<String>>(session.claude_args).unwrap_or_default();
-            let agent_type = session.agent_type.parse().unwrap_or_default();
+            let agent_type = AgentType::parse_or_default(&session.agent_type);
             ContinuationConfig {
                 id: row.id,
                 session_id: row.session_id,
@@ -537,7 +537,7 @@ pub fn schedule_overloaded_retry(
                 key,
                 ServerToClient::AgentOutput {
                     content: portal.to_json(),
-                    agent_type: session.agent_type.parse().unwrap_or_default(),
+                    agent_type: AgentType::parse_or_default(&session.agent_type),
                     meta,
                 },
             );
@@ -595,7 +595,7 @@ pub fn schedule_overloaded_retry(
             key,
             ServerToClient::AgentOutput {
                 content: portal.to_json(),
-                agent_type: session.agent_type.parse().unwrap_or_default(),
+                agent_type: AgentType::parse_or_default(&session.agent_type),
                 meta,
             },
         );

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -643,7 +643,7 @@ impl TurnMetric {
             // session is gone. Freshly inserted rows always carry one.
             session_id: self.session_id.unwrap_or_default(),
             user_message_id: self.user_message_id,
-            agent_type: self.agent_type.parse().unwrap_or(shared::AgentType::Claude),
+            agent_type: shared::AgentType::parse_or_default(&self.agent_type),
             model: self.model,
             service_tier: self.service_tier,
             started_at: self.started_at,

--- a/frontend/src/pages/history/transcript.rs
+++ b/frontend/src/pages/history/transcript.rs
@@ -57,7 +57,7 @@ pub fn history_transcript_page(props: &HistoryTranscriptProps) -> Html {
     // first archived line's own agent_type (so a Codex transcript renders
     // correctly even while the manifest is in flight or failed).
     let agent_type = match &*manifest {
-        Some(Ok(m)) => shared::AgentType::from_str(&m.agent_type).unwrap_or_default(),
+        Some(Ok(m)) => shared::AgentType::parse_or_default(&m.agent_type),
         _ => match &*messages {
             Some(Ok(lines)) => lines
                 .first()

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -228,6 +228,15 @@ impl AgentType {
         }
     }
 
+    /// Parse a stored agent-type string, falling back to the default
+    /// ([`AgentType::Claude`]) on unknown values. Single place where the
+    /// dozen DB/wire read sites agree that a stale string means Claude
+    /// rather than an error — previously each spelled out
+    /// `.parse().unwrap_or(AgentType::Claude)` (or the equivalent default).
+    pub fn parse_or_default(s: &str) -> Self {
+        s.parse().unwrap_or_default()
+    }
+
     /// The command that installs this agent's CLI, as structured data so the
     /// launcher (which runs it) and the frontend (which displays it for the
     /// user to confirm) agree on exactly one thing.
@@ -1339,6 +1348,19 @@ mod tests {
         // Default is Fresh so omitted/older payloads keep today's behavior.
         assert_eq!(SessionMode::default(), SessionMode::Fresh);
         assert_eq!("fresh".parse::<SessionMode>().unwrap(), SessionMode::Fresh);
+    }
+
+    #[test]
+    fn agent_type_parse_or_default_tolerates_stale_strings() {
+        // Every known wire value parses, case-insensitively like FromStr.
+        assert_eq!(AgentType::parse_or_default("claude"), AgentType::Claude);
+        assert_eq!(AgentType::parse_or_default("codex"), AgentType::Codex);
+        assert_eq!(AgentType::parse_or_default("Muse"), AgentType::Muse);
+        // A stale/unknown stored string means Claude, never an error —
+        // this is the fallback the DB read sites previously spelled out.
+        assert_eq!(AgentType::parse_or_default("gpt-5"), AgentType::Claude);
+        assert_eq!(AgentType::parse_or_default(""), AgentType::Claude);
+        assert_eq!(AgentType::default(), AgentType::Claude);
     }
 
     #[test]


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/fcbd62a29e372bc5efd9b4918407a1da9adc0943/.0-pr-viz/001874.svg)

Twelve read sites parsed a stored agent-type string with the same fallback spelled three ways (.parse().unwrap_or(AgentType::Claude), .parse().unwrap_or_default(), AgentType::from_str(..).unwrap_or_default()). Since Default for AgentType is Claude, all three meant the same thing. This adds a shared AgentType::parse_or_default helper (WASM-compatible, exercised by the frontend history page too) and routes all twelve through it, plus a unit test for known/stale/empty inputs. No behavior change.