### PR TITLE
Use shallow checkouts in history-free CI jobs

### DIFF
--- a/.0-pr-viz/001875.svg
+++ b/.0-pr-viz/001875.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <!-- Header -->
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1875 · Shallow checkouts in history-free CI jobs</text>
+
+  <!-- Thesis -->
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Three CI jobs cloned the full git history for a version stamp</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">they never compute — now they check out shallow, builds untouched.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <!-- Panel labels + center divider -->
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <!-- ==================== BEFORE panel: x 55–945 ==================== -->
+
+  <g>
+    <rect x="80" y="250" width="810" height="200" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="290" font-size="26" fill="#7aa2f7">lint · lint-css · fmt</text>
+    <text x="104" y="330" font-size="23" fill="#f7768e">- uses: actions/checkout@v4</text>
+    <text x="104" y="366" font-size="23" fill="#f7768e">  with: fetch-depth: 0</text>
+    <text x="104" y="402" font-size="23" fill="#f7768e"># full history so build.rs version is real (#1096)</text>
+  </g>
+
+  <g>
+    <rect x="80" y="470" width="810" height="200" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="510" font-size="26" fill="#c0caf5">the comment is wrong in all three</text>
+    <text x="104" y="550" font-size="23" fill="#f7768e">none of them builds: no rustc, no build.rs,</text>
+    <text x="104" y="586" font-size="23" fill="#f7768e">no commit-count version — the scripts scan</text>
+    <text x="104" y="622" font-size="23" fill="#f7768e">the working tree, rustfmt parses, stylelint reads</text>
+  </g>
+
+  <line x1="485" y1="670" x2="485" y2="710" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+
+  <g>
+    <rect x="80" y="730" width="810" height="165" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="776" font-size="26" fill="#c0caf5">full clone on every push, three times over</text>
+    <text x="104" y="816" font-size="23" fill="#f7768e">history carries multi-MB wasm + webp blobs,</text>
+    <text x="104" y="852" font-size="23" fill="#f7768e">fetched deep and then never read</text>
+  </g>
+
+  <!-- ==================== AFTER panel: x 1040–1945 ==================== -->
+
+  <g>
+    <rect x="1065" y="250" width="810" height="200" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1089" y="290" font-size="26" fill="#7aa2f7">lint · lint-css · fmt</text>
+    <text x="1089" y="330" font-size="23" fill="#9ece6a">- uses: actions/checkout@v4  (bare)</text>
+    <text x="1089" y="366" font-size="23" fill="#a9b1d6">one short comment each: why shallow is safe</text>
+    <text x="1089" y="402" font-size="22" fill="#565f89">default depth 1 — nothing to keep in sync</text>
+  </g>
+
+  <line x1="1470" y1="450" x2="1470" y2="490" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <g>
+    <rect x="1065" y="500" width="810" height="230" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="1089" y="540" font-size="26" fill="#c0caf5">six build lanes keep fetch-depth: 0</text>
+    <text x="1089" y="580" font-size="23" fill="#a9b1d6">build-frontend · clippy · build-backend</text>
+    <text x="1089" y="616" font-size="23" fill="#a9b1d6">test · e2e-tests · build-binaries</text>
+    <text x="1089" y="656" font-size="22" fill="#565f89">they compile: build.rs commit-count version</text>
+    <text x="1089" y="692" font-size="22" fill="#565f89">stays real exactly where it is consumed</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="760" width="810" height="135" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="806" font-size="26" fill="#c0caf5">smaller clones, same guarantees</text>
+    <text x="1089" y="846" font-size="23" fill="#9ece6a">shallower fetch on every push, zero behavior change</text>
+  </g>
+
+  <!-- Footer -->
+  <text x="55" y="1172" font-size="22" fill="#565f89">No behavior change: job steps are identical apart from checkout depth; substance verified locally.</text>
+</svg>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
     name: Lint Checks
     runs-on: ubuntu-latest
     steps:
+      # Shallow checkout: these scripts scan the working tree only and never
+      # build, so the build.rs commit-count version (#1096) doesn't apply.
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
 
       - name: Check migration naming convention
         run: ./scripts/check-migration-names.sh
@@ -36,9 +36,8 @@ jobs:
       run:
         working-directory: frontend/lint
     steps:
+      # Shallow checkout: stylelint reads the working tree only, no builds.
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -57,9 +56,8 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
+      # Shallow checkout: rustfmt never runs build.rs, so no history needed.
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.96.0


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/d3cdd554e1f3a584baa123db721ae849740cf070/.0-pr-viz/001875.svg)

The `lint`, `lint-css`, and `fmt` CI jobs cloned the full git history (`fetch-depth: 0`) solely because of a copy-pasted comment about the build.rs commit-count version (#1096) — but none of them builds anything, so build.rs never runs there. They now use the default shallow checkout with a short comment saying why that's safe. The six build/test lanes keep `fetch-depth: 0`.

No behavior change; the job steps are otherwise identical. Verified locally: migration-name + json-macro scripts pass, `cargo fmt --check` clean, stylelint clean.