### PR TITLE
Single-source Rust toolchain in rust-toolchain.toml

### DIFF
--- a/.0-pr-viz/001876.svg
+++ b/.0-pr-viz/001876.svg
@@ -1,0 +1,84 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <!-- Header -->
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1876 · Single-source Rust toolchain in rust-toolchain.toml</text>
+
+  <!-- Thesis -->
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Toolchain 1.96.0 was pinned in four places across CI YAML — one</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">forgotten bump drifts a lane; now one TOML owns it, all lanes read it.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <!-- Panel labels + center divider -->
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <!-- ==================== BEFORE panel: x 55–945 ==================== -->
+
+  <g>
+    <rect x="80" y="250" width="810" height="200" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="290" font-size="26" fill="#7aa2f7">ci.yml fmt · mobile-android.yml</text>
+    <text x="104" y="330" font-size="23" fill="#f7768e">uses: dtolnay/rust-toolchain@1.96.0</text>
+    <text x="104" y="366" font-size="23" fill="#f7768e">uses: dtolnay/rust-toolchain@1.96.0</text>
+    <text x="104" y="402" font-size="22" fill="#565f89">two copies of the same version pin</text>
+  </g>
+
+  <g>
+    <rect x="80" y="470" width="810" height="200" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="510" font-size="26" fill="#7aa2f7">setup-rust/action.yml</text>
+    <text x="104" y="550" font-size="23" fill="#f7768e">uses: dtolnay/rust-toolchain@1.96.0</text>
+    <text x="104" y="586" font-size="23" fill="#f7768e">sh -s -- -y --default-toolchain 1.96.0</text>
+    <text x="104" y="622" font-size="22" fill="#565f89">linux + macOS pins inside one file</text>
+  </g>
+
+  <line x1="485" y1="670" x2="485" y2="710" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+
+  <g>
+    <rect x="80" y="730" width="810" height="200" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="776" font-size="26" fill="#c0caf5">four pins of one version</text>
+    <text x="104" y="816" font-size="23" fill="#f7768e">bump the toolchain, touch four spots —</text>
+    <text x="104" y="852" font-size="23" fill="#f7768e">miss the macOS line, that lane builds old rustc</text>
+    <text x="104" y="888" font-size="22" fill="#565f89">+10 / -2 lines either way; drift is silent</text>
+  </g>
+
+  <!-- ==================== AFTER panel: x 1040–1945 ==================== -->
+
+  <g>
+    <rect x="1065" y="250" width="810" height="200" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1089" y="290" font-size="26" fill="#7aa2f7">rust-toolchain.toml (new)</text>
+    <text x="1089" y="330" font-size="23" fill="#9ece6a">[toolchain] channel = "1.96.0"</text>
+    <text x="1089" y="366" font-size="23" fill="#a9b1d6">the version lives here, exactly once</text>
+    <text x="1089" y="402" font-size="22" fill="#565f89">bump = edit this file only</text>
+  </g>
+
+  <line x1="1470" y1="450" x2="1470" y2="490" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <g>
+    <rect x="1065" y="500" width="810" height="230" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="1089" y="540" font-size="26" fill="#c0caf5">dtolnay steps · macOS rustup script</text>
+    <text x="1089" y="580" font-size="23" fill="#a9b1d6">no toolchain: input, no --default-toolchain</text>
+    <text x="1089" y="616" font-size="23" fill="#9ece6a">both resolve the toolchain from the TOML</text>
+    <text x="1089" y="656" font-size="22" fill="#565f89">same 1.96.0 everywhere — placement only</text>
+    <text x="1089" y="692" font-size="22" fill="#565f89">local dev shells get the pin for free</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="760" width="810" height="135" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="806" font-size="26" fill="#c0caf5">a single source of truth</text>
+    <text x="1089" y="846" font-size="23" fill="#9ece6a">next toolchain bump touches one file, not four</text>
+  </g>
+
+  <!-- Footer -->
+  <text x="55" y="1172" font-size="22" fill="#565f89">No behavior change: every lane still resolves 1.96.0; mobile lane untouched (reads the TOML too).</text>
+</svg>

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -52,9 +52,12 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
+        # No --default-toolchain: rustup resolves the toolchain from the
+        # repo-root rust-toolchain.toml (the single source of truth), so this
+        # lane can't drift from the dtolnay-based Linux lanes.
         rm -rf "$HOME/.cargo" "$HOME/.rustup"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-          | sh -s -- -y --default-toolchain 1.96.0 --profile minimal
+          | sh -s -- -y --profile minimal
         if [ -n "${{ inputs.components }}" ]; then
           "$HOME/.cargo/bin/rustup" component add $(echo "${{ inputs.components }}" | tr ',' ' ')
         fi

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,7 @@
+# Single source of truth for the repo's Rust toolchain (previously pinned as
+# `1.96.0` in four places across the CI YAML). Both `rustup` and
+# `dtolnay/rust-toolchain` honor this file when no explicit toolchain is given,
+# so local dev shells and every CI lane converge automatically. To bump the
+# toolchain, change `channel` here only.
+[toolchain]
+channel = "1.96.0"


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/2c45a24d9088748aa0e0d2715ff74e65e6123a48/.0-pr-viz/001876.svg)

Toolchain 1.96.0 was pinned in four places across CI YAML (fmt job, mobile lane, setup-rust dtolnay ref, setup-rust macOS rustup script). Adds rust-toolchain.toml as the single source of truth — rustup and dtolnay both honor it — and drops --default-toolchain from the macOS clean-install path so it cannot drift from the Linux lanes. No behavior change: all lanes still resolve 1.96.0.