### PR TITLE
Update claude-codes to 2.1.263

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1154,9 +1154,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-codes"
-version = "2.1.261"
+version = "2.1.263"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a946347834bddfd4999783b2275867dca286bcb93641ab1fe9b0cdc6cf0d02db"
+checksum = "f08040316a6e918e745cde39d3dc3cc49251660cd1603c65c64807436b80a1ab"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Claude Code integration
-claude-codes = { version = "2.1.261", default-features = false, features = ["types"] }
+claude-codes = { version = "2.1.263", default-features = false, features = ["types"] }
 
 # Muse CLI integration
 muse-codes = { version = "1.0.2", default-features = false, features = ["types"] }


### PR DESCRIPTION
Update `claude-codes` from `2.1.261` to `2.1.263` in the workspace manifest and lockfile. The [upstream changelog](https://github.com/meawoppl/rust-code-agent-sdks/blob/main/claude-codes/CHANGELOG.md) describes a tested-CLI version update. Published Rust source comparison confirms only version constants/documentation changed; no portal API or protocol adaptations are needed. Existing feature flags are preserved.

Validation: `cargo fmt --all`; `cargo test -p claude-session-lib --lib --locked`. Full workspace and frontend WASM validation run in CI.
