### PR TITLE
Update codex-codes to 0.153.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.151.5"
+version = "0.153.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8beaa298da6a6ed6bf10b8ebe5db335257cf484de5a429a11754f8f4d32202"
+checksum = "53a298430bf650d7ea520f03d47337d1cbf8a6af19d20988e01ba349205fe503"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ claude-codes = { version = "2.1.261", default-features = false, features = ["typ
 
 # Muse CLI integration
 muse-codes = { version = "1.0.2", default-features = false, features = ["types"] }
-codex-codes = { version = "0.151.5", default-features = false, features = ["types"] }
+codex-codes = { version = "0.153.4", default-features = false, features = ["types"] }
 
 # Web Push (VAPID + RFC8291 encryption). `default-features = false` drops the
 # bundled HTTP clients (isahc/libcurl and hyper) — we build the message here and


### PR DESCRIPTION
Update `codex-codes` from `0.151.5` to `0.153.4` in the workspace manifest and lockfile. The [upstream changelog](https://github.com/meawoppl/rust-code-agent-sdks/blob/main/codex-codes/CHANGELOG.md) describes a tested-CLI version update. Published Rust source comparison confirms only version constants/documentation changed; no portal API or protocol adaptations are needed. Existing feature flags are preserved.

Validation: `cargo fmt --all`; `cargo test -p codex-session-lib --lib --locked`. Full workspace and frontend WASM validation run in CI.
