### PR TITLE
Update muse-codes to 1.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4530,9 +4530,9 @@ dependencies = [
 
 [[package]]
 name = "muse-codes"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e105eb7cfadf1140264299fb1d1fc78b5e027ef9c49cd016b7055a7757399050"
+checksum = "890f0e286ca5dda7256233fd8963f56d817aa6c1cc37a8811a301339a3c2d070"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 claude-codes = { version = "2.1.263", default-features = false, features = ["types"] }
 
 # Muse CLI integration
-muse-codes = { version = "1.0.2", default-features = false, features = ["types"] }
+muse-codes = { version = "1.0.3", default-features = false, features = ["types"] }
 codex-codes = { version = "0.153.4", default-features = false, features = ["types"] }
 
 # Web Push (VAPID + RFC8291 encryption). `default-features = false` drops the


### PR DESCRIPTION
Update `muse-codes` from `1.0.2` to `1.0.3` in the workspace manifest and lockfile. The [upstream changelog](https://github.com/meawoppl/rust-code-agent-sdks/blob/main/muse-codes/CHANGELOG.md) describes a tested-CLI version update. Published Rust source comparison confirms only version constants/documentation changed; no portal API or protocol adaptations are needed. Existing feature flags are preserved.

Validation: `cargo fmt --all`; `cargo test -p muse-session-lib --lib --locked`. Full workspace and frontend WASM validation run in CI.
