### PR TITLE
Hoist generic WebSocket routing into session-lib

### DIFF
--- a/.0-pr-viz/001889.svg
+++ b/.0-pr-viz/001889.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
+  <title id="title">Generic proxy routing moves into session-lib</title>
+  <desc id="desc">WebSocket routing and permission bridging move from the Claude-specific crate into the shared session crate without changing the wire.</desc>
+  <rect width="960" height="540" fill="#1a1b26"/>
+  <text x="480" y="62" text-anchor="middle" fill="#c0caf5" font-family="sans-serif" font-size="28" font-weight="700">Agent-neutral proxy routing</text>
+  <rect x="65" y="145" width="300" height="245" rx="20" fill="#24283b" stroke="#f7768e" stroke-width="3"/>
+  <text x="215" y="190" text-anchor="middle" fill="#f7768e" font-family="sans-serif" font-size="22" font-weight="700">claude-session-lib</text>
+  <text x="215" y="235" text-anchor="middle" fill="#9aa5ce" font-family="sans-serif" font-size="18">agent implementation</text>
+  <text x="215" y="270" text-anchor="middle" fill="#9aa5ce" font-family="sans-serif" font-size="18">Claude output + Wiggum</text>
+  <text x="215" y="305" text-anchor="middle" fill="#9aa5ce" font-family="sans-serif" font-size="18">connection orchestration</text>
+  <path d="M390 267 H555" stroke="#7dcfff" stroke-width="5" marker-end="url(#arrow)"/>
+  <text x="472" y="245" text-anchor="middle" fill="#7dcfff" font-family="sans-serif" font-size="17">hoist</text>
+  <rect x="595" y="120" width="300" height="295" rx="20" fill="#24283b" stroke="#9ece6a" stroke-width="3"/>
+  <text x="745" y="165" text-anchor="middle" fill="#9ece6a" font-family="sans-serif" font-size="22" font-weight="700">session-lib</text>
+  <text x="745" y="215" text-anchor="middle" fill="#c0caf5" font-family="monospace" font-size="17">ws_reader</text>
+  <text x="745" y="250" text-anchor="middle" fill="#c0caf5" font-family="monospace" font-size="17">permission_bridge</text>
+  <text x="745" y="285" text-anchor="middle" fill="#c0caf5" font-family="monospace" font-size="17">PortalInput + Ack</text>
+  <text x="745" y="320" text-anchor="middle" fill="#c0caf5" font-family="monospace" font-size="17">file routing</text>
+  <text x="745" y="355" text-anchor="middle" fill="#c0caf5" font-family="monospace" font-size="17">heartbeat dispatch</text>
+  <text x="480" y="480" text-anchor="middle" fill="#bb9af7" font-family="sans-serif" font-size="20">One typed transport path for Claude, Codex, and Muse</text>
+  <defs><marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto"><path d="M0,0 L0,6 L9,3 z" fill="#7dcfff"/></marker></defs>
+</svg>

--- a/.0-pr-viz/001889.svg
+++ b/.0-pr-viz/001889.svg
@@ -1,22 +1,28 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
-  <title id="title">Generic proxy routing moves into session-lib</title>
-  <desc id="desc">WebSocket routing and permission bridging move from the Claude-specific crate into the shared session crate without changing the wire.</desc>
-  <rect width="960" height="540" fill="#1a1b26"/>
-  <text x="480" y="62" text-anchor="middle" fill="#c0caf5" font-family="sans-serif" font-size="28" font-weight="700">Agent-neutral proxy routing</text>
-  <rect x="65" y="145" width="300" height="245" rx="20" fill="#24283b" stroke="#f7768e" stroke-width="3"/>
-  <text x="215" y="190" text-anchor="middle" fill="#f7768e" font-family="sans-serif" font-size="22" font-weight="700">claude-session-lib</text>
-  <text x="215" y="235" text-anchor="middle" fill="#9aa5ce" font-family="sans-serif" font-size="18">agent implementation</text>
-  <text x="215" y="270" text-anchor="middle" fill="#9aa5ce" font-family="sans-serif" font-size="18">Claude output + Wiggum</text>
-  <text x="215" y="305" text-anchor="middle" fill="#9aa5ce" font-family="sans-serif" font-size="18">connection orchestration</text>
-  <path d="M390 267 H555" stroke="#7dcfff" stroke-width="5" marker-end="url(#arrow)"/>
-  <text x="472" y="245" text-anchor="middle" fill="#7dcfff" font-family="sans-serif" font-size="17">hoist</text>
-  <rect x="595" y="120" width="300" height="295" rx="20" fill="#24283b" stroke="#9ece6a" stroke-width="3"/>
-  <text x="745" y="165" text-anchor="middle" fill="#9ece6a" font-family="sans-serif" font-size="22" font-weight="700">session-lib</text>
-  <text x="745" y="215" text-anchor="middle" fill="#c0caf5" font-family="monospace" font-size="17">ws_reader</text>
-  <text x="745" y="250" text-anchor="middle" fill="#c0caf5" font-family="monospace" font-size="17">permission_bridge</text>
-  <text x="745" y="285" text-anchor="middle" fill="#c0caf5" font-family="monospace" font-size="17">PortalInput + Ack</text>
-  <text x="745" y="320" text-anchor="middle" fill="#c0caf5" font-family="monospace" font-size="17">file routing</text>
-  <text x="745" y="355" text-anchor="middle" fill="#c0caf5" font-family="monospace" font-size="17">heartbeat dispatch</text>
-  <text x="480" y="480" text-anchor="middle" fill="#bb9af7" font-family="sans-serif" font-size="20">One typed transport path for Claude, Codex, and Muse</text>
-  <defs><marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto"><path d="M0,0 L0,6 L9,3 z" fill="#7dcfff"/></marker></defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200" font-family="'Segoe UI','Noto Sans','DejaVu Sans',ui-sans-serif,system-ui,sans-serif">
+<rect width="2000" height="1200" fill="#16161e"/>
+<text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1889 · finish the agent-neutral session boundary</text>
+<text x="55" y="100" font-size="34" fill="#e6e9f5">WebSocket routing belongs to session-lib; each agent keeps its own behavior.</text>
+<line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666"/>
+<text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+<text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+<line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+<rect x="80" y="270" width="840" height="300" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="325" font-size="26" fill="#c0caf5">claude-session-lib owns transport</text>
+<text x="108" y="380" font-size="23" fill="#a9b1d6">ws_reader and permission_bridge live here</text>
+<text x="108" y="430" font-size="23" fill="#f7768e">generic file and input routing is agent-specific</text>
+<text x="108" y="480" font-size="23" fill="#f7768e">new agents would need to duplicate the same path</text>
+<rect x="80" y="650" width="840" height="245" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="705" font-size="26" fill="#c0caf5">ConnectionResult names Claude</text>
+<text x="108" y="760" font-size="23" fill="#a9b1d6">a shared transport result leaks one implementation</text>
+<text x="108" y="810" font-size="23" fill="#f7768e">the abstraction boundary remains incomplete</text>
+<rect x="1065" y="270" width="860" height="300" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="325" font-size="26" fill="#7aa2f7">session-lib owns the typed route</text>
+<text x="1093" y="380" font-size="23" fill="#a9b1d6">PortalInput, Ack, files, and permissions move together</text>
+<text x="1093" y="430" font-size="23" fill="#9ece6a">input_delivery accepts agent behavior as closures</text>
+<text x="1093" y="480" font-size="23" fill="#9ece6a">session_event reports handled, unhandled, or disconnect</text>
+<rect x="1065" y="650" width="860" height="245" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="705" font-size="26" fill="#7aa2f7">AgentExited is implementation-neutral</text>
+<text x="1093" y="760" font-size="23" fill="#a9b1d6">Claude keeps output classification and Wiggum</text>
+<text x="1093" y="810" font-size="23" fill="#9ece6a">the WebSocket wire and visible behavior stay unchanged</text>
+<text x="55" y="1172" font-size="22" fill="#565f89">Scope: proxy-session ownership only; agent output parsing remains in each agent crate.</text>
 </svg>

--- a/claude-session-lib/src/lib.rs
+++ b/claude-session-lib/src/lib.rs
@@ -6,10 +6,9 @@
 //!
 //! Claude-specific backend for [`session_lib`]: defines [`ClaudeAgent`] (the
 //! per-agent dispatch type) and the `claude_io_task` that owns the `claude`
-//! CLI process. Also re-houses the `proxy_session` connection loop used by
-//! the `claude-portal` proxy binary — that loop is claude-specific (wiggum
-//! mode, portal-reminder injection, image upload, stream-json output
-//! forwarding) and isn't getting split until a future PR.
+//! CLI process. Its `proxy_session` module retains the Claude-specific
+//! connection orchestration (Wiggum, image handling, and typed Claude output);
+//! protocol-neutral routing and delivery live in `session_lib::proxy_session`.
 
 pub mod agent;
 pub mod auth;

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -168,7 +168,7 @@ impl Default for Backoff {
 
 /// Result from the connection loop
 pub enum LoopResult {
-    /// Normal exit (Claude process ended)
+    /// Normal exit (agent process ended)
     NormalExit,
     /// Session not found - caller should restart with fresh session
     SessionNotFound,
@@ -373,7 +373,7 @@ pub async fn run_connection_loop<A: Agent>(
 
         match result {
             ConnectionResult::AgentExited => {
-                info!("Claude process exited, shutting down");
+                info!("Agent process exited, shutting down");
                 session.persist_buffer().await;
                 return Ok(LoopResult::NormalExit);
             }

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -1,7 +1,6 @@
 //! Proxy session management and WebSocket connection handling.
 
 mod git_metadata;
-mod input_delivery;
 mod media_display;
 mod output_forwarder;
 mod session_event;
@@ -12,6 +11,7 @@ mod wiggum;
 use session_lib::proxy_session::heartbeat_watchdog;
 pub(crate) use session_lib::proxy_session::portal_reminder;
 pub(crate) use session_lib::proxy_session::portal_reminder::inject_portal_reminder;
+pub use session_lib::proxy_session::{ack_portal_input, emit_input_progress};
 
 pub use session_lib::proxy_session::ws_reader::{classify_portal_input, RoutedPortalInput};
 pub use wiggum::wiggum_prompt;
@@ -372,7 +372,7 @@ pub async fn run_connection_loop<A: Agent>(
         session.first_connection = false;
 
         match result {
-            ConnectionResult::ClaudeExited => {
+            ConnectionResult::AgentExited => {
                 info!("Claude process exited, shutting down");
                 session.persist_buffer().await;
                 return Ok(LoopResult::NormalExit);
@@ -938,43 +938,6 @@ async fn recv_option(rx: &mut tokio::sync::oneshot::Receiver<()>) -> Option<()> 
     rx.await.ok()
 }
 
-/// Emit an `InputProgressAck` delivery-stage signal for a tracked input, if it
-/// carried a `client_msg_id` (#939). The backend relays it to web clients.
-pub(super) async fn emit_input_progress(
-    ws_write: &SharedWsWrite,
-    session_id: Uuid,
-    client_msg_id: Option<Uuid>,
-    stage: shared::InputDeliveryStage,
-) {
-    let Some(client_msg_id) = client_msg_id else {
-        return;
-    };
-    let msg = ProxyToServer::InputProgressAck {
-        session_id,
-        client_msg_id,
-        stage,
-    };
-    let mut ws = ws_write.lock().await;
-    if let Err(e) = ws.send(msg).await {
-        error!("Failed to send InputProgressAck: {}", e);
-    }
-}
-
-/// Send an `InputAck` for a portal input, if it carried ack metadata.
-pub async fn ack_portal_input(ws_write: &SharedWsWrite, ack: Option<PortalInputAck>) {
-    let Some(ack) = ack else {
-        return;
-    };
-    let msg = ProxyToServer::InputAck {
-        session_id: ack.session_id,
-        ack_seq: ack.seq,
-    };
-    let mut ws = ws_write.lock().await;
-    if let Err(e) = ws.send(msg).await {
-        error!("Failed to send InputAck: {}", e);
-    }
-}
-
 /// Run the main select loop
 ///
 /// The Claude session internally uses a dedicated drain task to continuously
@@ -1022,14 +985,22 @@ async fn run_main_loop<A: Agent>(
             }
 
             Some(input) = input_rx.recv() => {
-                if let Some(result) = input_delivery::handle_input(
+                if let Some(result) = session_lib::proxy_session::input_delivery::handle_input(
                     &state.ws_write,
                     state.session_id,
-                    &state.working_directory,
-                    &state.git_metadata,
                     &state.reminder_pending,
                     claude_session,
                     input,
+                    || git_metadata::check_and_send_branch_update_if_branch_changed(
+                        &state.ws_write,
+                        state.session_id,
+                        &state.working_directory,
+                        &state.git_metadata,
+                    ),
+                    |text| crate::io_task::claude_user_echo_value(
+                        text.to_string(),
+                        state.session_id,
+                    ),
                 )
                 .await
                 {

--- a/claude-session-lib/src/proxy_session/mod.rs
+++ b/claude-session-lib/src/proxy_session/mod.rs
@@ -4,10 +4,8 @@ mod git_metadata;
 mod input_delivery;
 mod media_display;
 mod output_forwarder;
-mod permission_bridge;
 mod session_event;
 mod wiggum;
-mod ws_reader;
 
 // Hoisted to session-lib (#1657): these serve every agent under the proxy.
 // Re-exported here so internal call sites keep their `super::` paths.
@@ -15,8 +13,8 @@ use session_lib::proxy_session::heartbeat_watchdog;
 pub(crate) use session_lib::proxy_session::portal_reminder;
 pub(crate) use session_lib::proxy_session::portal_reminder::inject_portal_reminder;
 
+pub use session_lib::proxy_session::ws_reader::{classify_portal_input, RoutedPortalInput};
 pub use wiggum::wiggum_prompt;
-pub use ws_reader::{classify_portal_input, RoutedPortalInput};
 
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -37,12 +35,15 @@ pub use media_display::MediaDisplaySink;
 
 use git_metadata::{get_open_prs, get_pr_url, GitMetadataState, GitRefreshTrigger};
 use output_forwarder::spawn_output_forwarder;
-use wiggum::WiggumState;
-use ws_reader::{
+use session_lib::proxy_session::ws_reader::{
     spawn_ws_reader, FileDownloadEvent, FileReceiveState, FileUploadEvent, WsReaderChannels,
 };
+use wiggum::WiggumState;
 
-pub use session_lib::proxy_session::{ConnectionResult, NativeConnection, SharedWsWrite, WsRead};
+pub use session_lib::proxy_session::{
+    ConnectionResult, GracefulShutdown, NativeConnection, PermissionResponseData, PortalInput,
+    PortalInputAck, SharedWsWrite, WsRead,
+};
 
 /// Sink for codex thread-id persistence. The proxy crate owns the
 /// `ProxyConfig` JSON file; this callback lets the session loop hand the
@@ -187,39 +188,6 @@ pub enum RegisterError {
     /// A transient failure (connection dropped, send failed). The caller
     /// should reconnect after backing off for the given duration.
     Transient(Duration),
-}
-
-/// Permission response data (from frontend to Claude)
-#[derive(Debug)]
-pub struct PermissionResponseData {
-    pub request_id: String,
-    pub allow: bool,
-    pub input: Option<serde_json::Value>,
-    pub permissions: Vec<claude_codes::io::PermissionSuggestion>,
-    pub reason: Option<String>,
-}
-
-/// Portal-originated user input plus optional backend ack metadata.
-pub struct PortalInput {
-    pub text: String,
-    /// Optional typed portal event that the agent I/O task should synthesize
-    /// into the transcript instead of a plain user-text echo.
-    pub display_event: Option<serde_json::Value>,
-    pub ack: Option<PortalInputAck>,
-    /// Browser-assigned delivery-tracking id (#939). When present, the main
-    /// loop emits `InputProgressAck` at `ProxyReceived` (dequeue) and
-    /// `AgentAccepted` (after the agent accepts the input).
-    pub client_msg_id: Option<Uuid>,
-}
-
-pub struct PortalInputAck {
-    pub session_id: Uuid,
-    pub seq: i64,
-}
-
-/// Signal for graceful server shutdown with recommended reconnect delay
-pub struct GracefulShutdown {
-    pub reconnect_delay_ms: u64,
 }
 
 /// State that persists across WebSocket reconnections for a session.
@@ -1098,7 +1066,11 @@ async fn run_main_loop<A: Agent>(
             }
 
             Some(perm_response) = state.perm_rx.recv() => {
-                permission_bridge::handle_permission_response(claude_session, perm_response).await;
+                session_lib::proxy_session::permission_bridge::handle_permission_response(
+                    claude_session,
+                    perm_response,
+                )
+                .await;
             }
 
             Some(()) = state.interrupt_rx.recv() => {

--- a/claude-session-lib/src/proxy_session/session_event.rs
+++ b/claude-session-lib/src/proxy_session/session_event.rs
@@ -1,8 +1,8 @@
 //! Session-event arm of the proxy connection loop (#1165 item 3).
 //!
-//! Extracted from the `run_main_loop` `select!` so the god-loop reads as thin
-//! dispatch (parallels [`input_delivery::handle_input`](super::input_delivery)
-//! and [`wiggum::handle_wiggum_activation`](super::wiggum)). Dispatches one
+//! Claude-specific tail of event dispatch. Agent-neutral side channels are
+//! handled first by [`session_lib::proxy_session::session_event`]; this module
+//! retains raw-output behavior and Wiggum. Dispatches one
 //! [`SessionEvent`] from `claude_session.next_event()`:
 //!
 //! - Non-Claude `RawOutput`: the simple codex path (git refresh, buffer, send,

--- a/claude-session-lib/src/proxy_session/session_event.rs
+++ b/claude-session-lib/src/proxy_session/session_event.rs
@@ -107,107 +107,21 @@ pub(super) async fn handle_next_event<A: Agent>(
         }
     }
 
-    // Per-turn metrics: forward as a typed `TurnMetricsReport` envelope. Doesn't
-    // go through the output buffer because it's not part of the message-replay
-    // path — a missed metrics row is acceptable (next turn replaces it on the
-    // dashboard) but we still want low-latency delivery.
-    if let Some(SessionEvent::TurnMetricsReady(metrics)) = event {
-        let msg = ProxyToServer::TurnMetricsReport(metrics);
-        let mut ws = state.ws_write.lock().await;
-        if ws.send(msg).await.is_err() {
-            error!("Failed to send turn metrics report");
-            return Some(ConnectionResult::Disconnected(
-                state.connection_start.elapsed(),
-            ));
-        }
-        return None;
-    }
-
-    // Ephemeral tool-progress heartbeat: forward as a typed side-channel,
-    // mirroring `TurnMetricsReport` above. Deliberately bypasses the output
-    // buffer — heartbeats are live-status only and must never be persisted or
-    // replayed. The backend fans it out to web clients (never to the DB).
-    if let Some(SessionEvent::ToolProgress {
-        tool_use_id,
-        parent_tool_use_id,
-        tool_name,
-        elapsed_time_seconds,
-        subagent_type,
-        subagent_retry,
-    }) = event
+    let event = match session_lib::proxy_session::session_event::dispatch(
+        event,
+        &state.ws_write,
+        state.session_id,
+        state.connection_start,
+        state.codex_thread_id_sink.as_deref(),
+    )
+    .await
     {
-        let msg = ProxyToServer::ToolProgress {
-            session_id: state.session_id,
-            tool_use_id,
-            parent_tool_use_id,
-            tool_name,
-            elapsed_time_seconds,
-            subagent_type,
-            subagent_retry,
-        };
-        let mut ws = state.ws_write.lock().await;
-        if ws.send(msg).await.is_err() {
-            error!("Failed to send tool-progress heartbeat");
-            return Some(ConnectionResult::Disconnected(
-                state.connection_start.elapsed(),
-            ));
+        session_lib::proxy_session::session_event::DispatchResult::Handled => return None,
+        session_lib::proxy_session::session_event::DispatchResult::Disconnect(result) => {
+            return Some(result);
         }
-        return None;
-    }
-
-    // Neutral ephemeral live-status (muse's streamed deltas / task status):
-    // forward as a typed side-channel exactly like `ToolProgress` above.
-    // Deliberately bypasses the output buffer — live-status only, never
-    // persisted or replayed. The backend fans it out to web clients (never to
-    // the DB); if nobody is listening it evaporates.
-    if let Some(SessionEvent::Ephemeral(payload)) = event {
-        let msg = ProxyToServer::Ephemeral {
-            session_id: state.session_id,
-            payload,
-        };
-        let mut ws = state.ws_write.lock().await;
-        if ws.send(msg).await.is_err() {
-            error!("Failed to send ephemeral live-status frame");
-            return Some(ConnectionResult::Disconnected(
-                state.connection_start.elapsed(),
-            ));
-        }
-        return None;
-    }
-
-    // Codex app-server thread id: hand it to the persistence sink (the proxy's
-    // ProxyConfig writer) so the next resume of this session can call
-    // `thread/resume` with it. Emitted once per spawn by codex-session-lib.
-    // No-op for claude sessions (claude doesn't emit it).
-    if let Some(SessionEvent::CodexThreadId(thread_id)) = event {
-        if let Some(sink) = state.codex_thread_id_sink.as_ref() {
-            sink(thread_id);
-        }
-        return None;
-    }
-
-    if let Some(SessionEvent::SessionLimitReached {
-        session_id,
-        reset_at,
-        source_message,
-        prompt,
-    }) = event
-    {
-        let msg = ProxyToServer::SessionLimitReached(shared::SessionLimitContinuationFields {
-            session_id,
-            reset_at,
-            source_message,
-            prompt,
-        });
-        let mut ws = state.ws_write.lock().await;
-        if ws.send(msg).await.is_err() {
-            error!("Failed to send session-limit continuation candidate");
-            return Some(ConnectionResult::Disconnected(
-                state.connection_start.elapsed(),
-            ));
-        }
-        return None;
-    }
+        session_lib::proxy_session::session_event::DispatchResult::Unhandled(event) => event,
+    };
 
     handle_session_event_with_wiggum(
         event,

--- a/claude-session-lib/src/proxy_session/wiggum.rs
+++ b/claude-session-lib/src/proxy_session/wiggum.rs
@@ -173,7 +173,7 @@ pub(super) async fn handle_wiggum_activation<A: Agent>(
             shared::InputDeliveryStage::Failed,
         )
         .await;
-        return Some(ConnectionResult::ClaudeExited);
+        return Some(ConnectionResult::AgentExited);
     }
     emit_input_progress(
         ws_write,
@@ -304,7 +304,7 @@ pub(super) async fn handle_session_event_with_wiggum<A: Agent>(
                         {
                             error!("Failed to resend wiggum prompt: {}", e);
                             *wiggum_state = None;
-                            return Some(ConnectionResult::ClaudeExited);
+                            return Some(ConnectionResult::AgentExited);
                         }
                     }
                 }
@@ -375,7 +375,7 @@ pub(super) async fn handle_session_event_with_wiggum<A: Agent>(
         }
         Some(SessionEvent::Exited { code }) => {
             info!("Claude session exited with code {}", code);
-            Some(ConnectionResult::ClaudeExited)
+            Some(ConnectionResult::AgentExited)
         }
         Some(SessionEvent::TurnMetricsReady(_)) => {
             // Handled in run_main_loop before calling this function
@@ -425,12 +425,12 @@ pub(super) async fn handle_session_event_with_wiggum<A: Agent>(
                 }
                 eprintln!();
             }
-            Some(ConnectionResult::ClaudeExited)
+            Some(ConnectionResult::AgentExited)
         }
         None => {
             // Session has ended
             info!("Claude session ended");
-            Some(ConnectionResult::ClaudeExited)
+            Some(ConnectionResult::AgentExited)
         }
     }
 }

--- a/claude-session-lib/src/proxy_session/wiggum.rs
+++ b/claude-session-lib/src/proxy_session/wiggum.rs
@@ -77,7 +77,7 @@ pub struct WiggumState {
 /// Wiggum-activation arm of the proxy connection loop (#1165 item 3).
 ///
 /// Extracted from the `run_main_loop` `select!` so the god-loop reads as thin
-/// dispatch (parallels [`input_delivery::handle_input`](super::input_delivery)).
+/// dispatch (parallels [`session_lib::proxy_session::input_delivery::handle_input`]).
 /// Sets [`WiggumState`] atomically with sending the first iteration's prompt,
 /// emitting the [`InputDeliveryStage`](shared::InputDeliveryStage) progress
 /// events (#939) along the way. Returns `Some(ConnectionResult)` to end the

--- a/session-lib/src/proxy_session/input_delivery.rs
+++ b/session-lib/src/proxy_session/input_delivery.rs
@@ -19,16 +19,7 @@ use super::{
 };
 use crate::agent::Agent;
 use crate::session::Session;
-
-fn truncate(s: &str, max_chars: usize) -> String {
-    let mut chars = s.chars();
-    let prefix: String = chars.by_ref().take(max_chars).collect();
-    if chars.next().is_some() {
-        format!("{prefix}...")
-    } else {
-        prefix
-    }
-}
+use shared::fmt::truncate_str as truncate;
 
 /// Deliver one user input to the agent. Returns `Some(ConnectionResult)` to end
 /// the connection (delivery failure), or `None` to continue the loop.

--- a/session-lib/src/proxy_session/input_delivery.rs
+++ b/session-lib/src/proxy_session/input_delivery.rs
@@ -13,33 +13,41 @@ use tokio::sync::oneshot;
 use tracing::{debug, error};
 use uuid::Uuid;
 
-use session_lib::agent::Agent;
-use session_lib::session::Session;
-
-use super::git_metadata::{check_and_send_branch_update_if_branch_changed, GitMetadataState};
 use super::{
-    ack_portal_input, emit_input_progress, truncate, ConnectionResult, PortalInput, PortalInputAck,
-    SharedWsWrite,
+    ack_portal_input, emit_input_progress, portal_reminder, ConnectionResult, PortalInput,
+    PortalInputAck, SharedWsWrite,
 };
+use crate::agent::Agent;
+use crate::session::Session;
+
+fn truncate(s: &str, max_chars: usize) -> String {
+    let mut chars = s.chars();
+    let prefix: String = chars.by_ref().take(max_chars).collect();
+    if chars.next().is_some() {
+        format!("{prefix}...")
+    } else {
+        prefix
+    }
+}
 
 /// Deliver one user input to the agent. Returns `Some(ConnectionResult)` to end
 /// the connection (delivery failure), or `None` to continue the loop.
-pub(super) async fn handle_input<A: Agent>(
+pub async fn handle_input<A, Refresh, RefreshFuture, Display>(
     ws_write: &SharedWsWrite,
     session_id: Uuid,
-    working_directory: &str,
-    git_metadata: &GitMetadataState,
     reminder_pending: &AtomicBool,
     claude_session: &mut Session<A>,
     input: PortalInput,
-) -> Option<ConnectionResult> {
-    check_and_send_branch_update_if_branch_changed(
-        ws_write,
-        session_id,
-        working_directory,
-        git_metadata,
-    )
-    .await;
+    refresh_git: Refresh,
+    default_display: Display,
+) -> Option<ConnectionResult>
+where
+    A: Agent,
+    Refresh: FnOnce() -> RefreshFuture,
+    RefreshFuture: std::future::Future<Output = ()>,
+    Display: FnOnce(&str) -> serde_json::Value,
+{
+    refresh_git().await;
 
     debug!("sending to agent process: {}", truncate(&input.text, 100));
 
@@ -47,10 +55,10 @@ pub(super) async fn handle_input<A: Agent>(
     // `swap` makes the claim atomic, so a burst of queued inputs prefixes
     // exactly one of them.
     let (text, display_event) = if reminder_pending.swap(false, Ordering::SeqCst) {
-        super::portal_reminder::fold_session_start_reminder(
+        portal_reminder::fold_session_start_reminder(
             input.text,
             input.display_event,
-            |text| crate::io_task::claude_user_echo_value(text.to_string(), session_id),
+            default_display,
         )
     } else {
         (input.text, input.display_event)
@@ -79,7 +87,7 @@ pub(super) async fn handle_input<A: Agent>(
                 shared::InputDeliveryStage::Failed,
             )
             .await;
-            return Some(ConnectionResult::ClaudeExited);
+            return Some(ConnectionResult::AgentExited);
         }
     };
     spawn_delivery_completion(

--- a/session-lib/src/proxy_session/mod.rs
+++ b/session-lib/src/proxy_session/mod.rs
@@ -8,8 +8,10 @@
 //! moved item so its internal call sites are unchanged.
 
 pub mod heartbeat_watchdog;
+pub mod input_delivery;
 pub mod permission_bridge;
 pub mod portal_reminder;
+pub mod session_event;
 pub mod ws_reader;
 
 use std::sync::Arc;
@@ -56,7 +58,7 @@ pub type WsRead = ws_bridge::WsReceiver<ServerToProxy>;
 /// Result from a single WebSocket connection attempt.
 pub enum ConnectionResult {
     /// The agent process exited normally.
-    ClaudeExited,
+    AgentExited,
     /// WebSocket disconnected, includes how long the connection was up.
     Disconnected(Duration),
     /// Session not found error - need to restart with fresh session.
@@ -69,4 +71,40 @@ pub enum ConnectionResult {
     /// Reconnecting with the same token can never succeed, so the proxy must
     /// stop rather than hammer the backend forever (#1045).
     RegistrationRejected,
+}
+
+/// Emit an input-delivery stage for a browser-tracked message.
+pub async fn emit_input_progress(
+    ws_write: &SharedWsWrite,
+    session_id: uuid::Uuid,
+    client_msg_id: Option<uuid::Uuid>,
+    stage: shared::InputDeliveryStage,
+) {
+    let Some(client_msg_id) = client_msg_id else {
+        return;
+    };
+    let msg = ProxyToServer::InputProgressAck {
+        session_id,
+        client_msg_id,
+        stage,
+    };
+    let mut ws = ws_write.lock().await;
+    if let Err(error) = ws.send(msg).await {
+        tracing::error!("Failed to send InputProgressAck: {error}");
+    }
+}
+
+/// Acknowledge a persisted portal input after the agent accepts it.
+pub async fn ack_portal_input(ws_write: &SharedWsWrite, ack: Option<PortalInputAck>) {
+    let Some(ack) = ack else {
+        return;
+    };
+    let msg = ProxyToServer::InputAck {
+        session_id: ack.session_id,
+        ack_seq: ack.seq,
+    };
+    let mut ws = ws_write.lock().await;
+    if let Err(error) = ws.send(msg).await {
+        tracing::error!("Failed to send InputAck: {error}");
+    }
 }

--- a/session-lib/src/proxy_session/mod.rs
+++ b/session-lib/src/proxy_session/mod.rs
@@ -8,12 +8,41 @@
 //! moved item so its internal call sites are unchanged.
 
 pub mod heartbeat_watchdog;
+pub mod permission_bridge;
 pub mod portal_reminder;
+pub mod ws_reader;
 
 use std::sync::Arc;
 use std::time::Duration;
 
 use shared::{ProxyToServer, ServerToProxy, SessionEndpoint};
+
+/// Permission response data routed from the portal to an agent session.
+#[derive(Debug)]
+pub struct PermissionResponseData {
+    pub request_id: String,
+    pub allow: bool,
+    pub input: Option<serde_json::Value>,
+    pub permissions: Vec<claude_codes::io::PermissionSuggestion>,
+    pub reason: Option<String>,
+}
+
+/// Portal-originated user input plus optional backend acknowledgement metadata.
+pub struct PortalInput {
+    pub text: String,
+    pub display_event: Option<serde_json::Value>,
+    pub ack: Option<PortalInputAck>,
+    pub client_msg_id: Option<uuid::Uuid>,
+}
+
+pub struct PortalInputAck {
+    pub session_id: uuid::Uuid,
+    pub seq: i64,
+}
+
+pub struct GracefulShutdown {
+    pub reconnect_delay_ms: u64,
+}
 
 /// The native WebSocket connection to the backend session endpoint.
 pub type NativeConnection = ws_bridge::native_client::Connection<SessionEndpoint>;

--- a/session-lib/src/proxy_session/permission_bridge.rs
+++ b/session-lib/src/proxy_session/permission_bridge.rs
@@ -7,20 +7,19 @@
 
 use tracing::{debug, warn};
 
-use session_lib::agent::Agent;
-use session_lib::io::PermissionResponse as LibPermissionResponse;
-use session_lib::session::Session;
-
-use crate::Permission;
+use crate::agent::Agent;
+use crate::io::PermissionResponse as LibPermissionResponse;
+use crate::session::Session;
+use claude_codes::Permission;
 
 use super::PermissionResponseData;
 
 /// Forward a frontend permission response to the agent.
-pub(super) async fn handle_permission_response<A: Agent>(
+pub async fn handle_permission_response<A: Agent>(
     claude_session: &mut Session<A>,
     perm_response: PermissionResponseData,
 ) {
-    debug!("sending permission response to claude: {:?}", perm_response);
+    debug!("sending permission response to agent: {:?}", perm_response);
 
     // Build the library's neutral PermissionResponse.
     let lib_response = if perm_response.allow {

--- a/session-lib/src/proxy_session/session_event.rs
+++ b/session-lib/src/proxy_session/session_event.rs
@@ -1,0 +1,74 @@
+//! Agent-neutral session-event forwarding.
+
+use std::time::Instant;
+
+use crate::io::SessionEvent;
+use shared::ProxyToServer;
+
+use super::{ConnectionResult, SharedWsWrite};
+
+pub enum DispatchResult {
+    Handled,
+    Unhandled(Option<SessionEvent>),
+    Disconnect(ConnectionResult),
+}
+
+/// Forward event variants whose meaning is independent of the producing agent.
+/// Visible output remains unhandled so the caller can apply its agent-specific
+/// rendering, git-signal, and compatibility behavior.
+pub async fn dispatch(
+    event: Option<SessionEvent>,
+    ws_write: &SharedWsWrite,
+    session_id: uuid::Uuid,
+    connection_start: Instant,
+    thread_id_sink: Option<&(dyn Fn(String) + Send + Sync)>,
+) -> DispatchResult {
+    let message = match event {
+        Some(SessionEvent::TurnMetricsReady(metrics)) => ProxyToServer::TurnMetricsReport(metrics),
+        Some(SessionEvent::ToolProgress {
+            tool_use_id,
+            parent_tool_use_id,
+            tool_name,
+            elapsed_time_seconds,
+            subagent_type,
+            subagent_retry,
+        }) => ProxyToServer::ToolProgress {
+            session_id,
+            tool_use_id,
+            parent_tool_use_id,
+            tool_name,
+            elapsed_time_seconds,
+            subagent_type,
+            subagent_retry,
+        },
+        Some(SessionEvent::Ephemeral(payload)) => ProxyToServer::Ephemeral {
+            session_id,
+            payload,
+        },
+        Some(SessionEvent::CodexThreadId(thread_id)) => {
+            if let Some(sink) = thread_id_sink {
+                sink(thread_id);
+            }
+            return DispatchResult::Handled;
+        }
+        Some(SessionEvent::SessionLimitReached {
+            session_id,
+            reset_at,
+            source_message,
+            prompt,
+        }) => ProxyToServer::SessionLimitReached(shared::SessionLimitContinuationFields {
+            session_id,
+            reset_at,
+            source_message,
+            prompt,
+        }),
+        other => return DispatchResult::Unhandled(other),
+    };
+
+    if ws_write.lock().await.send(message).await.is_err() {
+        tracing::error!("Failed to forward agent-neutral session event");
+        DispatchResult::Disconnect(ConnectionResult::Disconnected(connection_start.elapsed()))
+    } else {
+        DispatchResult::Handled
+    }
+}

--- a/session-lib/src/proxy_session/ws_reader.rs
+++ b/session-lib/src/proxy_session/ws_reader.rs
@@ -4,7 +4,17 @@ use shared::{SendMode, ServerToProxy};
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, trace, warn};
 
-use super::{truncate, GracefulShutdown, PermissionResponseData, WsRead};
+use super::{GracefulShutdown, PermissionResponseData, PortalInput, PortalInputAck, WsRead};
+
+fn truncate(s: &str, max_chars: usize) -> String {
+    let mut chars = s.chars();
+    let prefix: String = chars.by_ref().take(max_chars).collect();
+    if chars.next().is_some() {
+        format!("{prefix}...")
+    } else {
+        prefix
+    }
+}
 
 /// Events sent through the file upload channel from the WS reader to the main loop
 pub enum FileUploadEvent {
@@ -25,27 +35,27 @@ pub enum FileDownloadEvent {
 }
 
 /// Tracks state for a file being received in chunks
-pub(crate) struct FileReceiveState {
-    pub(crate) filename: String,
-    pub(crate) total_chunks: u32,
-    pub(crate) total_size: u64,
-    pub(crate) received_chunks: u32,
-    pub(crate) received_bytes: u64,
-    pub(crate) file_handle: Option<tokio::fs::File>,
-    pub(crate) start_time: std::time::Instant,
-    pub(crate) last_log_percent: u32,
+pub struct FileReceiveState {
+    pub filename: String,
+    pub total_chunks: u32,
+    pub total_size: u64,
+    pub received_chunks: u32,
+    pub received_bytes: u64,
+    pub file_handle: Option<tokio::fs::File>,
+    pub start_time: std::time::Instant,
+    pub last_log_percent: u32,
     /// Bytes are written here and renamed to `filename` only on completion,
     /// so a consumer (the agent) can never read a truncated file (#939).
-    pub(crate) temp_path: std::path::PathBuf,
-    pub(crate) final_path: std::path::PathBuf,
-    pub(crate) disposition: shared::FileUploadDisposition,
+    pub temp_path: std::path::PathBuf,
+    pub final_path: std::path::PathBuf,
+    pub disposition: shared::FileUploadDisposition,
 }
 
 /// A portal input classified by send mode: a plain user input or a
 /// wiggum-mode activation carrying the original prompt.
 pub enum RoutedPortalInput {
-    Input(super::PortalInput),
-    Wiggum(super::PortalInput),
+    Input(PortalInput),
+    Wiggum(PortalInput),
 }
 
 /// Convert a `ClaudeInput`/`SequencedInput` payload into a routed portal
@@ -53,7 +63,7 @@ pub enum RoutedPortalInput {
 pub fn classify_portal_input(
     content: serde_json::Value,
     send_mode: Option<SendMode>,
-    ack: Option<super::PortalInputAck>,
+    ack: Option<PortalInputAck>,
     client_msg_id: Option<uuid::Uuid>,
 ) -> RoutedPortalInput {
     let (text, display_event) = match content {
@@ -66,7 +76,7 @@ pub fn classify_portal_input(
             None => (other.to_string(), None),
         },
     };
-    let input = super::PortalInput {
+    let input = PortalInput {
         text,
         display_event,
         ack,
@@ -83,10 +93,10 @@ pub fn classify_portal_input(
 fn route_portal_input(
     content: serde_json::Value,
     send_mode: Option<SendMode>,
-    ack: Option<super::PortalInputAck>,
+    ack: Option<PortalInputAck>,
     client_msg_id: Option<uuid::Uuid>,
-    input_tx: &mpsc::UnboundedSender<super::PortalInput>,
-    wiggum_tx: &mpsc::UnboundedSender<super::PortalInput>,
+    input_tx: &mpsc::UnboundedSender<PortalInput>,
+    wiggum_tx: &mpsc::UnboundedSender<PortalInput>,
 ) -> WsMessageResult {
     let label = if ack.is_some() { "seq_input" } else { "input" };
     let seq_part = ack
@@ -119,7 +129,7 @@ fn route_portal_input(
 }
 
 /// Result from handling a WebSocket text message
-pub(super) enum WsMessageResult {
+pub enum WsMessageResult {
     /// Continue processing messages
     Continue,
     /// Disconnect (error or other reason)
@@ -134,12 +144,12 @@ pub(super) enum WsMessageResult {
 ///
 /// Bundles every `mpsc`/`oneshot` sender used by [`spawn_ws_reader`] so the
 /// spawn signature stays small. Field names mirror the call-site locals.
-pub(super) struct WsReaderChannels {
-    pub input_tx: mpsc::UnboundedSender<super::PortalInput>,
+pub struct WsReaderChannels {
+    pub input_tx: mpsc::UnboundedSender<PortalInput>,
     pub perm_tx: mpsc::UnboundedSender<PermissionResponseData>,
     pub ack_tx: mpsc::UnboundedSender<u64>,
     pub disconnect_tx: tokio::sync::oneshot::Sender<()>,
-    pub wiggum_tx: mpsc::UnboundedSender<super::PortalInput>,
+    pub wiggum_tx: mpsc::UnboundedSender<PortalInput>,
     pub graceful_shutdown_tx: mpsc::UnboundedSender<GracefulShutdown>,
     pub session_terminated_tx: tokio::sync::oneshot::Sender<()>,
     pub file_upload_tx: mpsc::UnboundedSender<FileUploadEvent>,
@@ -148,11 +158,11 @@ pub(super) struct WsReaderChannels {
 }
 
 /// Spawn the WebSocket reader task
-pub(super) fn spawn_ws_reader(
+pub fn spawn_ws_reader(
     mut ws_read: WsRead,
     channels: WsReaderChannels,
-    heartbeat: session_lib::heartbeat::HeartbeatTracker,
-    tunnel: std::sync::Arc<session_lib::tunnel::TunnelManager>,
+    heartbeat: crate::heartbeat::HeartbeatTracker,
+    tunnel: std::sync::Arc<crate::tunnel::TunnelManager>,
 ) -> tokio::task::JoinHandle<()> {
     let WsReaderChannels {
         input_tx,
@@ -218,11 +228,11 @@ pub(super) fn spawn_ws_reader(
 #[allow(clippy::too_many_arguments)]
 async fn handle_ws_message(
     proxy_msg: ServerToProxy,
-    input_tx: &mpsc::UnboundedSender<super::PortalInput>,
+    input_tx: &mpsc::UnboundedSender<PortalInput>,
     perm_tx: &mpsc::UnboundedSender<PermissionResponseData>,
     ack_tx: &mpsc::UnboundedSender<u64>,
-    wiggum_tx: &mpsc::UnboundedSender<super::PortalInput>,
-    heartbeat: &session_lib::heartbeat::HeartbeatTracker,
+    wiggum_tx: &mpsc::UnboundedSender<PortalInput>,
+    heartbeat: &crate::heartbeat::HeartbeatTracker,
     file_upload_tx: &mpsc::UnboundedSender<FileUploadEvent>,
     file_download_tx: &mpsc::UnboundedSender<FileDownloadEvent>,
     interrupt_tx: &mpsc::UnboundedSender<()>,
@@ -248,7 +258,7 @@ async fn handle_ws_message(
             return route_portal_input(
                 content,
                 send_mode,
-                Some(super::PortalInputAck { session_id, seq }),
+                Some(PortalInputAck { session_id, seq }),
                 client_msg_id,
                 input_tx,
                 wiggum_tx,
@@ -457,7 +467,7 @@ mod tests {
         // optimistic-row advance / pending-input replay.
         let session_id = uuid::Uuid::nil();
         let client_msg_id = uuid::Uuid::from_u128(7);
-        let ack = super::super::PortalInputAck {
+        let ack = PortalInputAck {
             session_id,
             seq: 42,
         };
@@ -480,7 +490,7 @@ mod tests {
     #[test]
     fn classify_wiggum_preserves_ack_and_client_msg_id() {
         let client_msg_id = uuid::Uuid::from_u128(9);
-        let ack = super::super::PortalInputAck {
+        let ack = PortalInputAck {
             session_id: uuid::Uuid::nil(),
             seq: 5,
         };

--- a/session-lib/src/proxy_session/ws_reader.rs
+++ b/session-lib/src/proxy_session/ws_reader.rs
@@ -5,16 +5,7 @@ use tokio::sync::mpsc;
 use tracing::{debug, error, info, trace, warn};
 
 use super::{GracefulShutdown, PermissionResponseData, PortalInput, PortalInputAck, WsRead};
-
-fn truncate(s: &str, max_chars: usize) -> String {
-    let mut chars = s.chars();
-    let prefix: String = chars.by_ref().take(max_chars).collect();
-    if chars.next().is_some() {
-        format!("{prefix}...")
-    } else {
-        prefix
-    }
-}
+use shared::fmt::truncate_str as truncate;
 
 /// Events sent through the file upload channel from the WS reader to the main loop
 pub enum FileUploadEvent {


### PR DESCRIPTION
![PR visualization](https://raw.githubusercontent.com/meawoppl/agent-portal/86d85d1e3d32fd464310e077eb6f4a6496d312a5/.0-pr-viz/001889.svg)

Completes #1657 by moving the remaining genuinely agent-neutral proxy machinery into session-lib:

- WebSocket reader and typed routing channels
- portal input/ack and permission-response transport types
- permission bridging
- input delivery, with agent-specific display synthesis and git refresh inverted into caller seams
- neutral SessionEvent side-channel dispatch
- ConnectionResult::AgentExited naming

The Claude-side tail now contains only behavior that is actually agent-specific: raw-output git/media handling and Wiggum. Wire shapes and runtime behavior are unchanged.

Closes #1657.