### PR TITLE
Clippy conciseness cleanups across frontend and backend

### DIFF
--- a/.0-pr-viz/001885.svg
+++ b/.0-pr-viz/001885.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect width="2000" height="1200" fill="#16161e"/>
+  <defs>
+    <marker id="dim-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#565f89"/></marker>
+    <marker id="red-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#f7768e"/></marker>
+    <marker id="green-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/></marker>
+  </defs>
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1885 · Use map_or and is_ok_and for concise Option handling</text>
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Nine call sites spelled the same fold as .map(f).unwrap_or(d) across 4 files;</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">now map_or / is_ok_and say it in one call — same semantics, zero behavior change.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666"/>
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="255" width="840" height="175" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="108" y="302" font-size="26" fill="#7aa2f7">config.rs:392 — ServerConfig</text>
+    <text x="108" y="345" font-size="23" fill="#a9b1d6">allowed_emails.as_ref().map(|e| e.len())</text>
+    <text x="108" y="388" font-size="21" fill="#565f89">... .unwrap_or(0) for the log line</text>
+  </g>
+  <line x1="500" y1="430" x2="500" y2="510" stroke="#565f89" stroke-width="2" marker-end="url(#dim-arrow)"/>
+  <g>
+    <rect x="80" y="520" width="840" height="240" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="108" y="567" font-size="26" fill="#7aa2f7">turns.rs — render_turn_completed</text>
+    <text x="108" y="612" font-size="23" fill="#a9b1d6">usage.map(CodexUsage::input_tokens)</text>
+    <text x="108" y="655" font-size="23" fill="#a9b1d6">.unwrap_or(0), repeated for 5 token getters</text>
+    <text x="108" y="698" font-size="21" fill="#565f89">input, output, cached, reasoning, total</text>
+    <text x="108" y="735" font-size="21" fill="#565f89">connection.rs + service.rs: same shape with false</text>
+  </g>
+  <line x1="500" y1="760" x2="500" y2="840" stroke="#f7768e" stroke-width="2" marker-end="url(#red-arrow)"/>
+  <g>
+    <rect x="80" y="855" width="840" height="155" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="108" y="902" font-size="26" fill="#c0caf5">One fold, three spellings, nine sites</text>
+    <text x="108" y="946" font-size="23" fill="#f7768e">reviewer re-parses identical logic every time</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="255" width="860" height="175" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1093" y="302" font-size="26" fill="#7aa2f7">allowed_emails.as_ref().map_or(0, |e| e.len())</text>
+    <text x="1093" y="345" font-size="23" fill="#a9b1d6">one call: default plus closure</text>
+    <text x="1093" y="388" font-size="21" fill="#565f89">config.rs:392 — identical semantics</text>
+  </g>
+  <line x1="1495" y1="430" x2="1495" y2="510" stroke="#9ece6a" stroke-width="2" marker-end="url(#green-arrow)"/>
+  <g>
+    <rect x="1065" y="520" width="860" height="240" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1093" y="567" font-size="26" fill="#9ece6a">usage.map_or(0, CodexUsage::input_tokens)</text>
+    <text x="1093" y="612" font-size="23" fill="#a9b1d6">5 token getters collapse to 5 one-liners</text>
+    <text x="1093" y="655" font-size="23" fill="#a9b1d6">entry.file_type().is_ok_and(|ft| ft.is_dir())</text>
+    <text x="1093" y="698" font-size="21" fill="#565f89">Result plus predicate in one combinator</text>
+    <text x="1093" y="735" font-size="21" fill="#565f89">connection.rs; service.rs is_installed on linux + macos</text>
+  </g>
+  <line x1="1495" y1="760" x2="1495" y2="840" stroke="#9ece6a" stroke-width="2" marker-end="url(#green-arrow)"/>
+  <g>
+    <rect x="1065" y="855" width="860" height="155" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1093" y="902" font-size="26" fill="#c0caf5">9 sites, 2 combinators, 0 behavior change</text>
+    <text x="1093" y="946" font-size="23" fill="#9ece6a">fmt, clippy, and touched-crate tests stay green</text>
+  </g>
+  <text x="55" y="1172" font-size="22" fill="#565f89">Scope: 9 call sites in 4 files; similar .map().unwrap_or() sites elsewhere left for follow-ups.</text>
+</svg>

--- a/.0-pr-viz/001890.svg
+++ b/.0-pr-viz/001890.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect width="2000" height="1200" fill="#16161e"/>
+  <defs>
+    <marker id="dim-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#565f89"/></marker>
+    <marker id="red-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#f7768e"/></marker>
+    <marker id="green-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/></marker>
+  </defs>
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1890 · Clippy conciseness cleanups across frontend and backend</text>
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Eighteen call sites spelled one fold three ways as .map(f).unwrap_or(d);</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">now map_or / is_some_and / is_ok_and say it in one call — zero behavior change.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666"/>
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="255" width="840" height="175" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="108" y="302" font-size="26" fill="#7aa2f7">config.rs:392 — ServerConfig</text>
+    <text x="108" y="345" font-size="23" fill="#a9b1d6">allowed_emails.as_ref().map(|e| e.len())</text>
+    <text x="108" y="388" font-size="21" fill="#565f89">... .unwrap_or(0) for the log line</text>
+  </g>
+  <line x1="500" y1="430" x2="500" y2="510" stroke="#565f89" stroke-width="2" marker-end="url(#dim-arrow)"/>
+  <g>
+    <rect x="80" y="520" width="840" height="240" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="108" y="567" font-size="26" fill="#7aa2f7">turns.rs — render_turn_completed</text>
+    <text x="108" y="612" font-size="23" fill="#a9b1d6">usage.map(CodexUsage::input_tokens)</text>
+    <text x="108" y="655" font-size="23" fill="#a9b1d6">.unwrap_or(0), repeated for 5 token getters</text>
+    <text x="108" y="698" font-size="21" fill="#565f89">tokens_panel, admin, service: same shape, false</text>
+    <text x="108" y="735" font-size="21" fill="#565f89">connection.rs, paths.rs, probe.rs: same shape</text>
+  </g>
+  <line x1="500" y1="760" x2="500" y2="840" stroke="#f7768e" stroke-width="2" marker-end="url(#red-arrow)"/>
+  <g>
+    <rect x="80" y="855" width="840" height="155" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="108" y="902" font-size="26" fill="#c0caf5">One fold, three spellings, eighteen sites</text>
+    <text x="108" y="946" font-size="23" fill="#f7768e">reviewer re-parses identical logic every time</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="255" width="860" height="175" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1093" y="302" font-size="26" fill="#7aa2f7">allowed_emails.as_ref().map_or(0, |e| e.len())</text>
+    <text x="1093" y="345" font-size="23" fill="#a9b1d6">one call: default plus closure</text>
+    <text x="1093" y="388" font-size="21" fill="#565f89">config.rs:392 — identical semantics</text>
+  </g>
+  <line x1="1495" y1="430" x2="1495" y2="510" stroke="#9ece6a" stroke-width="2" marker-end="url(#green-arrow)"/>
+  <g>
+    <rect x="1065" y="520" width="860" height="240" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1093" y="567" font-size="26" fill="#9ece6a">usage.map_or(0, CodexUsage::input_tokens)</text>
+    <text x="1093" y="612" font-size="23" fill="#a9b1d6">8 map_or sites: config, turns, system bar</text>
+    <text x="1093" y="655" font-size="23" fill="#a9b1d6">6 is_some_and: tokens, admin, paths</text>
+    <text x="1093" y="698" font-size="23" fill="#a9b1d6">4 is_ok_and: connection, service, probe</text>
+    <text x="1093" y="735" font-size="21" fill="#565f89">Result plus predicate in one combinator</text>
+  </g>
+  <line x1="1495" y1="760" x2="1495" y2="840" stroke="#9ece6a" stroke-width="2" marker-end="url(#green-arrow)"/>
+  <g>
+    <rect x="1065" y="855" width="860" height="155" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1093" y="902" font-size="26" fill="#c0caf5">18 sites, 3 combinators, 0 behavior change</text>
+    <text x="1093" y="946" font-size="23" fill="#9ece6a">fmt, clippy, and frontend tests stay green</text>
+  </g>
+  <text x="55" y="1172" font-size="22" fill="#565f89">Scope: 9 code files; other .map().unwrap_or() sites (e.g. dashboard types) left for follow-ups.</text>
+</svg>

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -389,7 +389,7 @@ impl ServerConfig {
             tracing::info!(
                 "Email access control enabled: domain={:?}, specific_emails={}",
                 allowed_email_domain,
-                allowed_emails.as_ref().map(|e| e.len()).unwrap_or(0)
+                allowed_emails.as_ref().map_or(0, |e| e.len())
             );
         }
 

--- a/frontend/src/components/codex_renderer/turns.rs
+++ b/frontend/src/components/codex_renderer/turns.rs
@@ -24,11 +24,11 @@ pub(super) fn render_turn_completed(
     status: Option<&str>,
     turn_metrics: Option<&shared::TurnMetrics>,
 ) -> Html {
-    let input = usage.map(CodexUsage::input_tokens).unwrap_or(0);
-    let output = usage.map(CodexUsage::output_tokens).unwrap_or(0);
-    let cached = usage.map(CodexUsage::cached_input_tokens).unwrap_or(0);
-    let reasoning = usage.map(CodexUsage::reasoning_output_tokens).unwrap_or(0);
-    let total = usage.map(CodexUsage::total_tokens).unwrap_or(0);
+    let input = usage.map_or(0, CodexUsage::input_tokens);
+    let output = usage.map_or(0, CodexUsage::output_tokens);
+    let cached = usage.map_or(0, CodexUsage::cached_input_tokens);
+    let reasoning = usage.map_or(0, CodexUsage::reasoning_output_tokens);
+    let total = usage.map_or(0, CodexUsage::total_tokens);
     let thread_total = usage.and_then(CodexUsage::thread_total_tokens);
     let context_window = usage.and_then(|u| u.model_context_window);
     let context_snapshot = context_snapshot(input, cached, context_window);

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -682,18 +682,13 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         .and_then(|lid| launchers.iter().find(|l| l.launcher_id == lid).cloned());
 
     // Per-agent install hints for the dropdown labels and the inline warning.
-    let claude_label = match agent_installed(&agent_installs, AgentType::Claude) {
-        Some(false) => "Claude (not installed)".to_string(),
-        _ => "Claude".to_string(),
+    let install_label = |agent: AgentType| match agent_installed(&agent_installs, agent) {
+        Some(false) => format!("{} (not installed)", agent.display_name()),
+        _ => agent.display_name().to_string(),
     };
-    let codex_label = match agent_installed(&agent_installs, AgentType::Codex) {
-        Some(false) => "Codex (not installed)".to_string(),
-        _ => "Codex".to_string(),
-    };
-    let muse_label = match agent_installed(&agent_installs, AgentType::Muse) {
-        Some(false) => "Muse (not installed)".to_string(),
-        _ => "Muse".to_string(),
-    };
+    let claude_label = install_label(AgentType::Claude);
+    let codex_label = install_label(AgentType::Codex);
+    let muse_label = install_label(AgentType::Muse);
     let selected_agent_missing = agent_installed(&agent_installs, *agent_type) == Some(false);
     let still_probing = *probing_agents && agent_installs.is_empty();
     let selected_agent_label = agent_type.display_name();

--- a/frontend/src/components/message_renderer/renderers/system.rs
+++ b/frontend/src/components/message_renderer/renderers/system.rs
@@ -70,8 +70,8 @@ fn render_init_bar(msg: &shared::SystemMessage, timestamp: Option<&str>) -> Html
         .as_ref()
         .and_then(|m| m.claude_code_version.as_deref())
         .unwrap_or("");
-    let tool_count = init.as_ref().map(|m| m.tools.len()).unwrap_or(0);
-    let mcp_count = init.as_ref().map(|m| m.mcp_servers.len()).unwrap_or(0);
+    let tool_count = init.as_ref().map_or(0, |m| m.tools.len());
+    let mcp_count = init.as_ref().map_or(0, |m| m.mcp_servers.len());
     let fast_mode = init
         .as_ref()
         .and_then(|m| m.fast_mode_state.as_deref())

--- a/frontend/src/pages/admin/mod.rs
+++ b/frontend/src/pages/admin/mod.rs
@@ -257,7 +257,7 @@ pub fn admin_page(props: &AdminPageProps) -> Html {
             let confirm_inner = confirm_action.clone();
 
             let target_user = users_inner.iter().find(|u| u.id == user_id).cloned();
-            let is_currently_admin = target_user.as_ref().map(|u| u.is_admin).unwrap_or(false);
+            let is_currently_admin = target_user.as_ref().is_some_and(|u| u.is_admin);
             let action_text = if is_currently_admin {
                 "Remove admin privileges from this user?"
             } else {
@@ -297,7 +297,7 @@ pub fn admin_page(props: &AdminPageProps) -> Html {
             let ban_reason_input = ban_reason_input.clone();
 
             let target_user = users_inner.iter().find(|u| u.id == user_id).cloned();
-            let is_currently_disabled = target_user.as_ref().map(|u| u.disabled).unwrap_or(false);
+            let is_currently_disabled = target_user.as_ref().is_some_and(|u| u.disabled);
 
             if is_currently_disabled {
                 // Unbanning - use simple confirmation

--- a/frontend/src/pages/settings/tokens_panel.rs
+++ b/frontend/src/pages/settings/tokens_panel.rs
@@ -33,8 +33,7 @@ pub fn count_expiring_tokens(tokens: &[ProxyTokenInfo]) -> usize {
             t.expires_at
                 .as_deref()
                 .and_then(days_until_expiration)
-                .map(|d| (0..=7).contains(&d))
-                .unwrap_or(false)
+                .is_some_and(|d| (0..=7).contains(&d))
         })
         .count()
 }

--- a/frontend/src/pages/settings/tokens_panel.rs
+++ b/frontend/src/pages/settings/tokens_panel.rs
@@ -65,8 +65,8 @@ fn token_row(props: &TokenRowProps) -> Html {
     let token_id = token.id;
 
     let days_left = token.expires_at.as_deref().and_then(days_until_expiration);
-    let is_expired = days_left.map(|d| d < 0).unwrap_or(false);
-    let is_expiring_soon = days_left.map(|d| (0..=7).contains(&d)).unwrap_or(false);
+    let is_expired = days_left.is_some_and(|d| d < 0);
+    let is_expiring_soon = days_left.is_some_and(|d| (0..=7).contains(&d));
 
     let status_class = if token.revoked {
         "token-status revoked"

--- a/launcher/src/connection.rs
+++ b/launcher/src/connection.rs
@@ -582,7 +582,7 @@ fn list_directory(path: &str, request_id: Uuid) -> LauncherToServer {
         if !filter_lower.is_empty() && !name.to_lowercase().starts_with(&filter_lower) {
             continue;
         }
-        let is_dir = entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false);
+        let is_dir = entry.file_type().is_ok_and(|ft| ft.is_dir());
         if is_dir {
             let under_home = entry
                 .path()

--- a/launcher/src/service.rs
+++ b/launcher/src/service.rs
@@ -267,7 +267,7 @@ pub fn logs(lines: u32, follow: bool) -> Result<()> {
 
 #[cfg(target_os = "linux")]
 pub fn is_installed() -> bool {
-    service_file_path().map(|p| p.exists()).unwrap_or(false)
+    service_file_path().is_ok_and(|p| p.exists())
 }
 
 // --- macOS (launchd) ---
@@ -542,7 +542,7 @@ pub fn logs(lines: u32, follow: bool) -> Result<()> {
 
 #[cfg(target_os = "macos")]
 pub fn is_installed() -> bool {
-    plist_path().map(|p| p.exists()).unwrap_or(false)
+    plist_path().is_ok_and(|p| p.exists())
 }
 
 // --- Unsupported platforms ---

--- a/session-lib/src/paths.rs
+++ b/session-lib/src/paths.rs
@@ -77,8 +77,7 @@ fn migrate_between(legacy: &Path, new: &Path) {
     let same = std::fs::canonicalize(legacy)
         .ok()
         .zip(std::fs::canonicalize(new).ok())
-        .map(|(a, b)| a == b)
-        .unwrap_or(false);
+        .is_some_and(|(a, b)| a == b);
     if same {
         return;
     }

--- a/session-lib/src/probe.rs
+++ b/session-lib/src/probe.rs
@@ -126,9 +126,7 @@ pub fn probe_muse_sandbox() -> Option<bool> {
 /// label instead of a name, annotated when the credential comes from the
 /// environment rather than the saved file.
 pub fn probe_muse_login() -> shared::AgentLoginStatus {
-    let via_env = std::env::var("META_API_KEY")
-        .map(|v| !v.trim().is_empty())
-        .unwrap_or(false);
+    let via_env = std::env::var("META_API_KEY").is_ok_and(|v| !v.trim().is_empty());
     if via_env {
         return shared::AgentLoginStatus::LoggedIn {
             label: Some("meta".to_string()),


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/3d20e879cc7ce434b9adb1ab57de3079894c8492/.0-pr-viz/001890.svg)

Small no-behavior-change cleanups in the map_or/is_some_and/is_ok_and family:

- Use map_or and is_ok_and for concise Option handling
- Use is_some_and for token expiry checks
- Use is_some_and and is_ok_and for remaining sites
- Use map_or for tool counts in init bar
- Use is_some_and for admin toggle checks

Verified locally with cargo fmt, cargo clippy, and the frontend unit tests.