### PR TITLE
Adopt send_json helper in agent-login requests

### DIFF
--- a/.0-pr-viz/001892.svg
+++ b/.0-pr-viz/001892.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect width="2000" height="1200" fill="#1a1b26"/>
+  <defs>
+    <marker id="dim-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#565f89"/></marker>
+    <marker id="red-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#f7768e"/></marker>
+    <marker id="green-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/></marker>
+  </defs>
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1892 · Adopt send_json helper in agent-login requests</text>
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">start_login and submit_code hand-chained .json().send() behind map_err;</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">now one shared utils::send_json call each — zero behavior change.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666"/>
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="255" width="840" height="240" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="108" y="302" font-size="26" fill="#7aa2f7">agent_login.rs — start_login, submit_code</text>
+    <text x="108" y="345" font-size="23" fill="#a9b1d6">Request::post(&amp;url)</text>
+    <text x="108" y="388" font-size="23" fill="#a9b1d6">.json(&amp;body).map_err(...)?</text>
+    <text x="108" y="431" font-size="23" fill="#a9b1d6">.send().await.map_err(...)?</text>
+    <text x="108" y="474" font-size="21" fill="#565f89">two-step chain spelled out twice</text>
+  </g>
+  <line x1="500" y1="495" x2="500" y2="575" stroke="#565f89" stroke-width="2" marker-end="url(#dim-arrow)"/>
+  <g>
+    <rect x="80" y="590" width="840" height="240" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="108" y="637" font-size="26" fill="#7aa2f7">same shape, two call sites</text>
+    <text x="108" y="680" font-size="23" fill="#a9b1d6">serialize-then-send logic duplicated</text>
+    <text x="108" y="723" font-size="23" fill="#a9b1d6">while utils::send_json already exists</text>
+    <text x="108" y="766" font-size="21" fill="#565f89">adopted by admin, dialogs, panels</text>
+  </g>
+  <line x1="500" y1="830" x2="500" y2="910" stroke="#f7768e" stroke-width="2" marker-end="url(#red-arrow)"/>
+  <g>
+    <rect x="80" y="925" width="840" height="155" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="108" y="972" font-size="26" fill="#c0caf5">One helper, two holdouts</text>
+    <text x="108" y="1016" font-size="23" fill="#f7768e">reader re-derives the same chain twice</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="255" width="860" height="240" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1093" y="302" font-size="26" fill="#7aa2f7">utils::send_json(Request::post(&amp;url), &amp;body)</text>
+    <text x="1093" y="345" font-size="23" fill="#a9b1d6">.await.map_err(|e| e.to_string())?</text>
+    <text x="1093" y="388" font-size="23" fill="#a9b1d6">serialize plus send in one fallible step</text>
+    <text x="1093" y="431" font-size="21" fill="#565f89">agent_login.rs:354, 374 — identical Err arms</text>
+  </g>
+  <line x1="1495" y1="495" x2="1495" y2="575" stroke="#9ece6a" stroke-width="2" marker-end="url(#green-arrow)"/>
+  <g>
+    <rect x="1065" y="590" width="860" height="240" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1093" y="637" font-size="26" fill="#9ece6a">2 sites, 1 helper, -6 lines</text>
+    <text x="1093" y="680" font-size="23" fill="#a9b1d6">same String errors, same control flow</text>
+    <text x="1093" y="723" font-size="23" fill="#a9b1d6">clippy clean, 3 agent_login tests pass</text>
+    <text x="1093" y="766" font-size="21" fill="#565f89">cargo fmt, clippy, test verified locally</text>
+  </g>
+  <line x1="1495" y1="830" x2="1495" y2="910" stroke="#9ece6a" stroke-width="2" marker-end="url(#green-arrow)"/>
+  <g>
+    <rect x="1065" y="925" width="860" height="155" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1093" y="972" font-size="26" fill="#c0caf5">Adoption complete for ?-propagating callers</text>
+    <text x="1093" y="1016" font-size="23" fill="#9ece6a">fork, forwarding, profile keep bespoke arms</text>
+  </g>
+  <text x="55" y="1172" font-size="22" fill="#565f89">Scope: 1 file; raw .json() chains with custom error arms (fork_dialog, forwarding/profile panels) left as-is.</text>
+</svg>

--- a/.0-pr-viz/001892.svg
+++ b/.0-pr-viz/001892.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
      font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
-  <rect width="2000" height="1200" fill="#1a1b26"/>
+  <rect width="2000" height="1200" fill="#16161e"/>
   <defs>
     <marker id="dim-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#565f89"/></marker>
     <marker id="red-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#f7768e"/></marker>

--- a/frontend/src/pages/settings/agent_login.rs
+++ b/frontend/src/pages/settings/agent_login.rs
@@ -351,10 +351,7 @@ async fn start_login(
 ) -> Result<StartAgentLoginResponse, String> {
     let url = utils::api_url(&format!("/api/launchers/{launcher_id}/agent-login/start"));
     let body = StartAgentLoginRequest { agent_type };
-    let resp = Request::post(&url)
-        .json(&body)
-        .map_err(|e| e.to_string())?
-        .send()
+    let resp = utils::send_json(Request::post(&url), &body)
         .await
         .map_err(|e| e.to_string())?;
     if !resp.ok() {
@@ -374,10 +371,7 @@ async fn submit_code(
         "/api/launchers/{launcher_id}/agent-login/{flow_id}/code"
     ));
     let body = SubmitAgentLoginCodeRequest { code };
-    let resp = Request::post(&url)
-        .json(&body)
-        .map_err(|e| e.to_string())?
-        .send()
+    let resp = utils::send_json(Request::post(&url), &body)
         .await
         .map_err(|e| e.to_string())?;
     if !resp.ok() {


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/1d8b0915c8f7ee46be04dfca58cf24941d4a43b9/.0-pr-viz/001892.svg)

Finishes the utils::send_json adoption in the Settings agent-login modal: start_login and submit_code chained Request::post().json().send() by hand; both now go through the shared one-step helper introduced for the admin path. Identical error mapping (serialization and send failures still surface as Err(String)), so zero behavior change: -6 lines.

Verification: cargo fmt, cargo clippy -p frontend, cargo test -p frontend agent_login (3 passed).