### PR TITLE
Dedupe backoff and version-parse helpers in frontend

### DIFF
--- a/.0-pr-viz/001893.svg
+++ b/.0-pr-viz/001893.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect width="2000" height="1200" fill="#16161e"/>
+  <defs>
+    <marker id="dim-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#565f89"/></marker>
+    <marker id="red-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#f7768e"/></marker>
+    <marker id="green-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/></marker>
+  </defs>
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1893 · Dedupe backoff and version-parse helpers in frontend</text>
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Two byte-identical helpers lived in two files each; now each has one</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">canonical home plus imports — zero behavior change.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666"/>
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="255" width="840" height="240" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="108" y="302" font-size="26" fill="#7aa2f7">calculate_backoff × 2</text>
+    <text x="108" y="345" font-size="23" fill="#a9b1d6">dashboard/types.rs (pub) plus a private</text>
+    <text x="108" y="388" font-size="23" fill="#a9b1d6">copy in use_client_websocket.rs</text>
+    <text x="108" y="431" font-size="21" fill="#565f89">identical saturating backoff math</text>
+  </g>
+  <line x1="500" y1="495" x2="500" y2="575" stroke="#565f89" stroke-width="2" marker-end="url(#dim-arrow)"/>
+  <g>
+    <rect x="80" y="590" width="840" height="240" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="108" y="637" font-size="26" fill="#7aa2f7">parse_version × 2</text>
+    <text x="108" y="680" font-size="23" fill="#a9b1d6">private copies in the websocket hook</text>
+    <text x="108" y="723" font-size="23" fill="#a9b1d6">and in launchers_panel.rs</text>
+    <text x="108" y="766" font-size="21" fill="#565f89">identical split-and-parse bodies</text>
+  </g>
+  <line x1="500" y1="830" x2="500" y2="910" stroke="#f7768e" stroke-width="2" marker-end="url(#red-arrow)"/>
+  <g>
+    <rect x="80" y="925" width="840" height="155" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="108" y="972" font-size="26" fill="#c0caf5">Two helpers, four homes</text>
+    <text x="108" y="1016" font-size="23" fill="#f7768e">a fix in one copy silently misses the other</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="255" width="860" height="240" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1093" y="302" font-size="26" fill="#7aa2f7">backoff via dashboard re-export</text>
+    <text x="1093" y="345" font-size="23" fill="#a9b1d6">added to the existing pub use list;</text>
+    <text x="1093" y="388" font-size="23" fill="#a9b1d6">hook and session view import it</text>
+    <text x="1093" y="431" font-size="21" fill="#565f89">one canonical definition in types.rs</text>
+  </g>
+  <line x1="1495" y1="495" x2="1495" y2="575" stroke="#9ece6a" stroke-width="2" marker-end="url(#green-arrow)"/>
+  <g>
+    <rect x="1065" y="590" width="860" height="240" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1093" y="637" font-size="26" fill="#9ece6a">parse_version moves to utils.rs</text>
+    <text x="1093" y="680" font-size="23" fill="#a9b1d6">pub helper beside extract_folder;</text>
+    <text x="1093" y="723" font-size="23" fill="#a9b1d6">hook and panel import it</text>
+    <text x="1093" y="766" font-size="21" fill="#565f89">is_newer/version_at_least untouched</text>
+  </g>
+  <line x1="1495" y1="830" x2="1495" y2="910" stroke="#9ece6a" stroke-width="2" marker-end="url(#green-arrow)"/>
+  <g>
+    <rect x="1065" y="925" width="860" height="155" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1093" y="972" font-size="26" fill="#c0caf5">5 files, +16 / -32, 683 tests pass</text>
+    <text x="1093" y="1016" font-size="23" fill="#9ece6a">fmt, clippy, and frontend suite green</text>
+  </g>
+  <text x="55" y="1172" font-size="22" fill="#565f89">Scope: frontend only; comparators built on parse_version keep their own fallbacks by design.</text>
+</svg>

--- a/frontend/src/hooks/use_client_websocket.rs
+++ b/frontend/src/hooks/use_client_websocket.rs
@@ -3,7 +3,8 @@
 #[path = "client_websocket_events.rs"]
 mod client_websocket_events;
 
-use crate::utils::{self, On401};
+use crate::pages::dashboard::calculate_backoff;
+use crate::utils::{self, parse_version, On401};
 use client_websocket_events::handle_server_message;
 use shared::api::TurnMetricsResponse;
 use shared::{AppConfig, ClientEndpoint, TurnMetrics, WsEndpoint};
@@ -45,24 +46,6 @@ pub struct UseClientWebSocket {
     /// launcher connected, disconnected, or was evicted. Consumers hang a
     /// `use_effect_with` on it to refetch `/api/launchers` (#710).
     pub launcher_event_counter: u32,
-}
-
-/// Calculate exponential backoff delay for reconnection attempts.
-fn calculate_backoff(attempt: u32) -> u32 {
-    const INITIAL_MS: u32 = 1000;
-    const MAX_MS: u32 = 30000;
-    INITIAL_MS
-        .saturating_mul(2u32.saturating_pow(attempt.min(5)))
-        .min(MAX_MS)
-}
-
-/// Parse a semver-ish "MAJOR.MINOR.PATCH" string into a comparable tuple.
-fn parse_version(s: &str) -> Option<(u64, u64, u64)> {
-    let mut parts = s.split('.');
-    let major = parts.next()?.parse().ok()?;
-    let minor = parts.next()?.parse().ok()?;
-    let patch = parts.next()?.parse().ok()?;
-    Some((major, minor, patch))
 }
 
 /// Decide whether `next` is strictly newer than `prev`. Falls back to string

--- a/frontend/src/pages/dashboard/mod.rs
+++ b/frontend/src/pages/dashboard/mod.rs
@@ -18,6 +18,6 @@ mod types;
 
 pub use page::DashboardPage;
 pub use types::{
-    load_group_by_host, load_rail_position, load_vim_mode, save_group_by_host, save_rail_position,
-    save_vim_mode, RailPosition,
+    calculate_backoff, load_group_by_host, load_rail_position, load_vim_mode, save_group_by_host,
+    save_rail_position, save_vim_mode, RailPosition,
 };

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -44,7 +44,8 @@ use super::state::{
 use super::tasks_panel::{derive_task_events, TasksInbound, TasksPanel};
 use super::types::{PendingPermission, WsSender, MAX_MESSAGES_PER_SESSION};
 use super::websocket::{connect_websocket, send_message, WsEvent};
-use crate::pages::dashboard::types::{calculate_backoff, MessageData, MessagesResponse};
+use crate::pages::dashboard::calculate_backoff;
+use crate::pages::dashboard::types::{MessageData, MessagesResponse};
 
 /// Props for the SessionView component
 #[derive(Properties, PartialEq)]

--- a/frontend/src/pages/settings/launchers_panel.rs
+++ b/frontend/src/pages/settings/launchers_panel.rs
@@ -3,7 +3,7 @@ use crate::pages::settings::agent_login::AgentLoginModal;
 use crate::pages::settings::agents_panel::{
     render_cell, InstallTarget, LoginTarget, ProbeState, AGENTS,
 };
-use crate::utils::{self, On401};
+use crate::utils::{self, parse_version, On401};
 use futures_util::stream::{FuturesUnordered, StreamExt};
 use gloo_net::http::Request;
 use shared::{AppConfig, LauncherInfo};
@@ -81,15 +81,6 @@ struct UpdateEntry {
     /// Whether this row is tracking an update-and-restart or a bare restart.
     mode: LifecycleMode,
     phase: UpdatePhase,
-}
-
-/// Parse a semver-ish "MAJOR.MINOR.PATCH" string into a comparable tuple.
-fn parse_version(s: &str) -> Option<(u64, u64, u64)> {
-    let mut parts = s.split('.');
-    let major = parts.next()?.parse().ok()?;
-    let minor = parts.next()?.parse().ok()?;
-    let patch = parts.next()?.parse().ok()?;
-    Some((major, minor, patch))
 }
 
 /// `current >= target` under semver ordering; `false` if either fails to parse.

--- a/frontend/src/utils.rs
+++ b/frontend/src/utils.rs
@@ -160,6 +160,15 @@ pub fn extract_folder(path: &str) -> &str {
         .unwrap_or(trimmed)
 }
 
+/// Parse a semver-ish "MAJOR.MINOR.PATCH" string into a comparable tuple.
+pub fn parse_version(s: &str) -> Option<(u64, u64, u64)> {
+    let mut parts = s.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    Some((major, minor, patch))
+}
+
 /// Read a value from browser localStorage, returning `None` when storage is
 /// unavailable (no window, storage disabled) or the key is absent.
 pub fn storage_get(key: &str) -> Option<String> {


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/214fdb814c506aad65e7514740ed048dd2caf168/.0-pr-viz/001893.svg)

Two byte-identical helpers had two homes each: calculate_backoff lived in both dashboard types and the client-websocket hook, and parse_version lived in both the hook and the launchers panel. The hook now imports calculate_backoff through the dashboard re-export (added to the existing pub use list) and both version parsers import a single pub parse_version from utils. Net -16 lines, zero behavior change.

Verification: cargo fmt, cargo clippy -p frontend clean, cargo test -p frontend (683 passed).