### PR TITLE
Dedupe backoff and version helpers into frontend utils

### DIFF
--- a/.0-pr-viz/001894.svg
+++ b/.0-pr-viz/001894.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200" font-family="'Segoe UI','Noto Sans','DejaVu Sans',ui-sans-serif,system-ui,sans-serif">
+<rect width="2000" height="1200" fill="#16161e"/>
+<text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1894 · dedupe backoff and version helpers into frontend utils</text>
+<text x="55" y="100" font-size="34" fill="#e6e9f5">One canonical copy in utils.rs; three call sites repointed, behavior unchanged.</text>
+<line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666"/>
+<text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+<text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+<line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+<rect x="80" y="270" width="840" height="300" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="325" font-size="26" fill="#c0caf5">calculate_backoff defined twice</text>
+<text x="108" y="380" font-size="23" fill="#a9b1d6">dashboard/types.rs (pub) and use_client_websocket.rs</text>
+<text x="108" y="430" font-size="23" fill="#f7768e">identical 1s-doubling, 30s-cap tiers in two homes</text>
+<text x="108" y="480" font-size="23" fill="#f7768e">hook imports a page module for a generic helper</text>
+<rect x="80" y="650" width="840" height="245" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="705" font-size="26" fill="#c0caf5">parse_version defined twice</text>
+<text x="108" y="760" font-size="23" fill="#a9b1d6">use_client_websocket.rs and launchers_panel.rs</text>
+<text x="108" y="810" font-size="23" fill="#f7768e">identical semver split, two private copies</text>
+<rect x="1065" y="270" width="860" height="300" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="325" font-size="26" fill="#7aa2f7">utils.rs owns both helpers</text>
+<text x="1093" y="380" font-size="23" fill="#a9b1d6">single pub calculate_backoff and parse_version</text>
+<text x="1093" y="430" font-size="23" fill="#9ece6a">bodies moved verbatim, zero behavior change</text>
+<text x="1093" y="480" font-size="23" fill="#9ece6a">hook, settings, and session view import from utils</text>
+<rect x="1065" y="650" width="860" height="245" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="705" font-size="26" fill="#7aa2f7">Shared copies pinned by unit tests</text>
+<text x="1093" y="760" font-size="23" fill="#a9b1d6">backoff tiers and semver splits covered in utils tests</text>
+<text x="1093" y="810" font-size="23" fill="#9ece6a">685 frontend tests green, clippy and fmt clean</text>
+<text x="55" y="1172" font-size="22" fill="#565f89">Scope: frontend only; hook-local is_newer_version and version_at_least logic untouched.</text>
+</svg>

--- a/frontend/src/hooks/use_client_websocket.rs
+++ b/frontend/src/hooks/use_client_websocket.rs
@@ -3,7 +3,7 @@
 #[path = "client_websocket_events.rs"]
 mod client_websocket_events;
 
-use crate::utils::{self, On401};
+use crate::utils::{self, calculate_backoff, parse_version, On401};
 use client_websocket_events::handle_server_message;
 use shared::api::TurnMetricsResponse;
 use shared::{AppConfig, ClientEndpoint, TurnMetrics, WsEndpoint};
@@ -45,24 +45,6 @@ pub struct UseClientWebSocket {
     /// launcher connected, disconnected, or was evicted. Consumers hang a
     /// `use_effect_with` on it to refetch `/api/launchers` (#710).
     pub launcher_event_counter: u32,
-}
-
-/// Calculate exponential backoff delay for reconnection attempts.
-fn calculate_backoff(attempt: u32) -> u32 {
-    const INITIAL_MS: u32 = 1000;
-    const MAX_MS: u32 = 30000;
-    INITIAL_MS
-        .saturating_mul(2u32.saturating_pow(attempt.min(5)))
-        .min(MAX_MS)
-}
-
-/// Parse a semver-ish "MAJOR.MINOR.PATCH" string into a comparable tuple.
-fn parse_version(s: &str) -> Option<(u64, u64, u64)> {
-    let mut parts = s.split('.');
-    let major = parts.next()?.parse().ok()?;
-    let minor = parts.next()?.parse().ok()?;
-    let patch = parts.next()?.parse().ok()?;
-    Some((major, minor, patch))
 }
 
 /// Decide whether `next` is strictly newer than `prev`. Falls back to string

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -44,7 +44,8 @@ use super::state::{
 use super::tasks_panel::{derive_task_events, TasksInbound, TasksPanel};
 use super::types::{PendingPermission, WsSender, MAX_MESSAGES_PER_SESSION};
 use super::websocket::{connect_websocket, send_message, WsEvent};
-use crate::pages::dashboard::types::{calculate_backoff, MessageData, MessagesResponse};
+use crate::pages::dashboard::types::{MessageData, MessagesResponse};
+use crate::utils::calculate_backoff;
 
 /// Props for the SessionView component
 #[derive(Properties, PartialEq)]

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -242,15 +242,6 @@ pub fn save_hidden_sessions(hidden: &HashSet<Uuid>) {
     }
 }
 
-/// Calculate exponential backoff delay for reconnection attempts
-pub fn calculate_backoff(attempt: u32) -> u32 {
-    const INITIAL_MS: u32 = 1000;
-    const MAX_MS: u32 = 30000;
-    INITIAL_MS
-        .saturating_mul(2u32.saturating_pow(attempt.min(5)))
-        .min(MAX_MS)
-}
-
 /// Format permission input for display.
 ///
 /// `input` is a `serde_json::Value` because the cross-agent

--- a/frontend/src/pages/settings/launchers_panel.rs
+++ b/frontend/src/pages/settings/launchers_panel.rs
@@ -3,7 +3,7 @@ use crate::pages::settings::agent_login::AgentLoginModal;
 use crate::pages::settings::agents_panel::{
     render_cell, InstallTarget, LoginTarget, ProbeState, AGENTS,
 };
-use crate::utils::{self, On401};
+use crate::utils::{self, parse_version, On401};
 use futures_util::stream::{FuturesUnordered, StreamExt};
 use gloo_net::http::Request;
 use shared::{AppConfig, LauncherInfo};
@@ -81,15 +81,6 @@ struct UpdateEntry {
     /// Whether this row is tracking an update-and-restart or a bare restart.
     mode: LifecycleMode,
     phase: UpdatePhase,
-}
-
-/// Parse a semver-ish "MAJOR.MINOR.PATCH" string into a comparable tuple.
-fn parse_version(s: &str) -> Option<(u64, u64, u64)> {
-    let mut parts = s.split('.');
-    let major = parts.next()?.parse().ok()?;
-    let minor = parts.next()?.parse().ok()?;
-    let patch = parts.next()?.parse().ok()?;
-    Some((major, minor, patch))
 }
 
 /// `current >= target` under semver ordering; `false` if either fails to parse.

--- a/frontend/src/utils.rs
+++ b/frontend/src/utils.rs
@@ -160,6 +160,24 @@ pub fn extract_folder(path: &str) -> &str {
         .unwrap_or(trimmed)
 }
 
+/// Parse a semver-ish "MAJOR.MINOR.PATCH" string into a comparable tuple.
+pub fn parse_version(s: &str) -> Option<(u64, u64, u64)> {
+    let mut parts = s.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    Some((major, minor, patch))
+}
+
+/// Calculate exponential backoff delay for reconnection attempts.
+pub fn calculate_backoff(attempt: u32) -> u32 {
+    const INITIAL_MS: u32 = 1000;
+    const MAX_MS: u32 = 30000;
+    INITIAL_MS
+        .saturating_mul(2u32.saturating_pow(attempt.min(5)))
+        .min(MAX_MS)
+}
+
 /// Read a value from browser localStorage, returning `None` when storage is
 /// unavailable (no window, storage disabled) or the key is absent.
 pub fn storage_get(key: &str) -> Option<String> {
@@ -205,5 +223,21 @@ mod tests {
     #[test]
     fn format_dollars_handles_negative_amounts() {
         assert_eq!(format_dollars(-1_234.5), "$-1,234.50");
+    }
+
+    #[test]
+    fn backoff_doubles_then_caps_at_30s() {
+        assert_eq!(calculate_backoff(0), 1000);
+        assert_eq!(calculate_backoff(1), 2000);
+        assert_eq!(calculate_backoff(2), 4000);
+        assert_eq!(calculate_backoff(5), 30000);
+        assert_eq!(calculate_backoff(99), 30000);
+    }
+
+    #[test]
+    fn parse_version_splits_semver() {
+        assert_eq!(parse_version("2.5.92"), Some((2, 5, 92)));
+        assert_eq!(parse_version("dev"), None);
+        assert_eq!(parse_version("2.5"), None);
     }
 }


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/8bda0ef063737193770a371bc70626f0cd5efd9a/.0-pr-viz/001894.svg)

Moves the two identical copies of `calculate_backoff` (dashboard/types.rs, hooks/use_client_websocket.rs) and the two identical copies of `parse_version` (hooks/use_client_websocket.rs, pages/settings/launchers_panel.rs) into `frontend/src/utils.rs` as the single canonical definitions, and repoints all three call sites at them.

No behavior change: bodies moved verbatim. Adds two small unit tests in utils.rs pinning the backoff tiers (1s doubling, 30s cap) and semver-split semantics so the shared copies stay honest.

Supersedes #1893.