### PR TITLE
Dedupe location parsing in frontend URL helpers

### DIFF
--- a/.0-pr-viz/001895.svg
+++ b/.0-pr-viz/001895.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200" font-family="'Segoe UI','Noto Sans','DejaVu Sans',ui-sans-serif,system-ui,sans-serif">
+<rect width="2000" height="1200" fill="#16161e"/>
+<text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1895 · dedupe location parsing in frontend URL helpers</text>
+<text x="55" y="100" font-size="34" fill="#e6e9f5">One location_parts helper; get_base_url and get_ws_url share it.</text>
+<line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666"/>
+<text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+<text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+<line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+<rect x="80" y="270" width="840" height="300" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="325" font-size="26" fill="#c0caf5">window.location parsed twice</text>
+<text x="108" y="380" font-size="23" fill="#a9b1d6">get_base_url and get_ws_url in utils.rs</text>
+<text x="108" y="430" font-size="23" fill="#f7768e">identical protocol/host reads plus fallbacks</text>
+<text x="108" y="480" font-size="23" fill="#f7768e">https-to-wss mapping buried in the duplicate</text>
+<rect x="80" y="650" width="840" height="245" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="705" font-size="26" fill="#c0caf5">Two early-returns, two format sites</text>
+<text x="108" y="760" font-size="23" fill="#a9b1d6">each helper guards window and formats alone</text>
+<text x="108" y="810" font-size="23" fill="#f7768e">a fallback tweak must land in both places</text>
+<rect x="1065" y="270" width="860" height="300" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="325" font-size="26" fill="#7aa2f7">location_parts owns the parse</text>
+<text x="1093" y="380" font-size="23" fill="#a9b1d6">single fn returns Option of protocol, host</text>
+<text x="1093" y="430" font-size="23" fill="#9ece6a">per-field fallbacks preserved verbatim</text>
+<text x="1093" y="480" font-size="23" fill="#9ece6a">None only when there is no window</text>
+<rect x="1065" y="650" width="860" height="245" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="705" font-size="26" fill="#7aa2f7">Both helpers map over it</text>
+<text x="1093" y="760" font-size="23" fill="#a9b1d6">same defaults, same output strings</text>
+<text x="1093" y="810" font-size="23" fill="#9ece6a">utils tests green, clippy and fmt clean</text>
+<text x="55" y="1172" font-size="22" fill="#565f89">Scope: frontend/src/utils.rs only; api_url and ws_url callers untouched.</text>
+</svg>

--- a/frontend/src/utils.rs
+++ b/frontend/src/utils.rs
@@ -60,35 +60,37 @@ pub async fn fetch_json<T: DeserializeOwned>(path: &str, on_401: On401) -> Resul
         .map_err(|e| FetchError::Decode(e.to_string()))
 }
 
-/// Get the base HTTP URL (e.g., "http://localhost:3000" or "https://myapp.com")
-pub fn get_base_url() -> String {
-    let Some(window) = window() else {
-        return "http://localhost:3000".to_string();
-    };
+/// Read `(protocol, host)` from the browser location, with per-field fallbacks.
+///
+/// Returns `None` only when there is no window (e.g. SSR/tests); per-field
+/// failures still fall back to local-dev defaults so callers stay total.
+fn location_parts() -> Option<(String, String)> {
+    let window = window()?;
     let location = window.location();
-
     let protocol = location.protocol().unwrap_or_else(|_| "http:".to_string());
     let host = location
         .host()
         .unwrap_or_else(|_| "localhost:3000".to_string());
+    Some((protocol, host))
+}
 
-    format!("{}//{}", protocol, host)
+/// Get the base HTTP URL (e.g., "http://localhost:3000" or "https://myapp.com")
+pub fn get_base_url() -> String {
+    match location_parts() {
+        Some((protocol, host)) => format!("{}//{}", protocol, host),
+        None => "http://localhost:3000".to_string(),
+    }
 }
 
 /// Get the WebSocket URL (e.g., "ws://localhost:3000" or "wss://myapp.com")
 pub fn get_ws_url() -> String {
-    let Some(window) = window() else {
-        return "ws://localhost:3000".to_string();
-    };
-    let location = window.location();
-
-    let protocol = location.protocol().unwrap_or_else(|_| "http:".to_string());
-    let ws_protocol = if protocol == "https:" { "wss:" } else { "ws:" };
-    let host = location
-        .host()
-        .unwrap_or_else(|_| "localhost:3000".to_string());
-
-    format!("{}//{}", ws_protocol, host)
+    match location_parts() {
+        Some((protocol, host)) => {
+            let ws_protocol = if protocol == "https:" { "wss:" } else { "ws:" };
+            format!("{}//{}", ws_protocol, host)
+        }
+        None => "ws://localhost:3000".to_string(),
+    }
 }
 
 /// Build a full API URL from a path (e.g., "/api/sessions" -> "http://localhost:3000/api/sessions")


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/d37a60934bd4fff87248c39868d434b36497610b/.0-pr-viz/001895.svg)

Extracts shared location_parts helper behind get_base_url/get_ws_url. No behavior change.