### PR TITLE
Adopt send_json in profile and push panels

### DIFF
--- a/.0-pr-viz/001896.svg
+++ b/.0-pr-viz/001896.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200" font-family="'Segoe UI','Noto Sans','DejaVu Sans',ui-sans-serif,system-ui,sans-serif">
+<rect width="2000" height="1200" fill="#16161e"/>
+<text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1896 · adopt send_json in profile and push panels</text>
+<text x="55" y="100" font-size="34" fill="#e6e9f5">Last two manual .json(&amp;body) sites repointed; behavior unchanged.</text>
+<line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666"/>
+<text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+<text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+<line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+<rect x="80" y="270" width="840" height="300" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="325" font-size="26" fill="#c0caf5">profile_panel.rs hand-rolls its PUT</text>
+<text x="108" y="380" font-size="23" fill="#a9b1d6">match Request::put(url).json(&amp;body)</text>
+<text x="108" y="430" font-size="23" fill="#f7768e">4-line match folds encode+send into false</text>
+<text x="108" y="480" font-size="23" fill="#f7768e">PUT /api/settings/profile, inline only here</text>
+<rect x="80" y="650" width="840" height="245" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="705" font-size="26" fill="#c0caf5">register_subscription builds POST by hand</text>
+<text x="108" y="760" font-size="23" fill="#a9b1d6">Request::post(&amp;url).json(req)?, then .send()?</text>
+<text x="108" y="810" font-size="23" fill="#f7768e">two-step build-then-send, POST /api/push/subscriptions</text>
+<rect x="1065" y="270" width="860" height="300" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="325" font-size="26" fill="#7aa2f7">both call utils::send_json</text>
+<text x="1093" y="380" font-size="23" fill="#a9b1d6">one helper: builder.json(body)?.send().await</text>
+<text x="1093" y="430" font-size="23" fill="#9ece6a">encode + send failures share a single Err arm</text>
+<text x="1093" y="480" font-size="23" fill="#9ece6a">joins 12 existing send_json call sites</text>
+<rect x="1065" y="650" width="860" height="245" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="705" font-size="26" fill="#7aa2f7">callers keep their own error mapping</text>
+<text x="1093" y="760" font-size="23" fill="#a9b1d6">profile still yields false; push still Err(e.to_string())</text>
+<text x="1093" y="810" font-size="23" fill="#9ece6a">685 frontend tests green, clippy and fmt clean</text>
+<text x="55" y="1172" font-size="22" fill="#565f89">Scope: settings panels only; binary upload, GET, and fork-dialog sites untouched.</text>
+</svg>

--- a/frontend/src/pages/settings/notifications_panel.rs
+++ b/frontend/src/pages/settings/notifications_panel.rs
@@ -515,8 +515,9 @@ fn key_b64url(
 /// POST the subscription and remember its server-side id for later deletion.
 async fn register_subscription(req: &RegisterPushSubscriptionRequest) -> Result<(), String> {
     let url = utils::api_url("/api/push/subscriptions");
-    let request = Request::post(&url).json(req).map_err(|e| e.to_string())?;
-    let resp = request.send().await.map_err(|e| e.to_string())?;
+    let resp = utils::send_json(Request::post(&url), req)
+        .await
+        .map_err(|e| e.to_string())?;
     if !resp.ok() {
         return Err(format!("server returned {}", resp.status()));
     }

--- a/frontend/src/pages/settings/profile_panel.rs
+++ b/frontend/src/pages/settings/profile_panel.rs
@@ -66,10 +66,13 @@ pub fn profile_panel() -> Html {
             let nickname = nickname.clone();
             saving.set(true);
             spawn_local(async move {
-                let ok = match Request::put(&utils::api_url("/api/settings/profile")).json(&body) {
-                    Ok(req) => req.send().await.map(|r| r.ok()).unwrap_or(false),
-                    Err(_) => false,
-                };
+                let ok = utils::send_json(
+                    Request::put(&utils::api_url("/api/settings/profile")),
+                    &body,
+                )
+                .await
+                .map(|r| r.ok())
+                .unwrap_or(false);
                 // Reflect the normalized value locally so the field matches
                 // what the server stored.
                 nickname.set(trimmed);


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/5f09ee9f6ee59a4977bf3fe8fec16e848a297972/.0-pr-viz/001896.svg)

Follow-up to #1892: the last two manual `Request::x(...).json(&body)` + match call sites now use the shared `utils::send_json` helper.

- `profile_panel.rs`: 4-line match collapses to `send_json(...).await.map(...).unwrap_or(false)`
- `notifications_panel.rs` (`register_subscription`): two-step build-then-send becomes one `send_json` call

No behavior change: error paths map to the same values as before (encode/send failures still surface as `false` / `Err(e.to_string())`). `cargo fmt --check`, `cargo clippy -p frontend`, and `cargo test -p frontend` (685 passed) all green.