### PR TITLE
Collapse Ok/Err matches into combinators

### DIFF
--- a/.0-pr-viz/001897.svg
+++ b/.0-pr-viz/001897.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200" font-family="'Segoe UI','Noto Sans','DejaVu Sans',ui-sans-serif,system-ui,sans-serif">
+<rect width="2000" height="1200" fill="#16161e"/>
+<text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1897 · collapse Ok/Err matches into combinators</text>
+<text x="55" y="100" font-size="34" fill="#e6e9f5">Two match sites become one-expression combinators; behavior unchanged.</text>
+<line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666"/>
+<text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+<text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+<line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+<rect x="80" y="270" width="840" height="300" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="325" font-size="26" fill="#c0caf5">current_subscription_present matches</text>
+<text x="108" y="380" font-size="23" fill="#a9b1d6">match JsFuture::from(promise).await</text>
+<text x="108" y="430" font-size="23" fill="#f7768e">Ok(v) =&gt; null checks, Err(_) =&gt; false</text>
+<text x="108" y="480" font-size="23" fill="#f7768e">five lines for a boolean question</text>
+<rect x="80" y="650" width="840" height="245" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="705" font-size="26" fill="#c0caf5">launcher probe matches on fetch</text>
+<text x="108" y="760" font-size="23" fill="#a9b1d6">match fetch_json::&lt;ProbeAgentsResponse&gt;</text>
+<text x="108" y="810" font-size="23" fill="#f7768e">Ok(resp) =&gt; Loaded(..), Err(_) =&gt; Unreachable</text>
+<rect x="1065" y="270" width="860" height="300" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="325" font-size="26" fill="#7aa2f7">is_ok_and in one expression</text>
+<text x="1093" y="380" font-size="23" fill="#a9b1d6">.await.is_ok_and(|v| !null &amp;&amp; !undefined)</text>
+<text x="1093" y="430" font-size="23" fill="#9ece6a">bool out, no Err arm left to maintain</text>
+<text x="1093" y="480" font-size="23" fill="#9ece6a">matches existing is_some_and style in repo</text>
+<rect x="1065" y="650" width="860" height="245" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="705" font-size="26" fill="#7aa2f7">map + unwrap_or in one chain</text>
+<text x="1093" y="760" font-size="23" fill="#a9b1d6">.map(|resp| Loaded(..)).unwrap_or(Unreachable)</text>
+<text x="1093" y="810" font-size="23" fill="#9ece6a">685 frontend tests green, clippy and fmt clean</text>
+<text x="55" y="1172" font-size="22" fill="#565f89">Scope: settings panels only; other Err(_) sites (early-return control flow) untouched.</text>
+</svg>

--- a/frontend/src/pages/settings/launchers_panel.rs
+++ b/frontend/src/pages/settings/launchers_panel.rs
@@ -582,17 +582,17 @@ pub fn launchers_panel() -> Html {
                         let id = l.launcher_id;
                         async move {
                             let path = format!("/api/launchers/{id}/probe-agents");
-                            let state = match utils::fetch_json::<shared::api::ProbeAgentsResponse>(
+                            let state = utils::fetch_json::<shared::api::ProbeAgentsResponse>(
                                 &path,
                                 On401::Ignore,
                             )
                             .await
-                            {
-                                Ok(resp) => ProbeState::Loaded(
+                            .map(|resp| {
+                                ProbeState::Loaded(
                                     resp.agents.into_iter().map(|a| (a.agent_type, a)).collect(),
-                                ),
-                                Err(_) => ProbeState::Unreachable,
-                            };
+                                )
+                            })
+                            .unwrap_or(ProbeState::Unreachable);
                             (id, state)
                         }
                     })

--- a/frontend/src/pages/settings/notifications_panel.rs
+++ b/frontend/src/pages/settings/notifications_panel.rs
@@ -426,10 +426,9 @@ async fn current_subscription_present() -> bool {
     let Ok(promise) = pm.get_subscription() else {
         return false;
     };
-    match JsFuture::from(promise).await {
-        Ok(v) => !v.is_null() && !v.is_undefined(),
-        Err(_) => false,
-    }
+    JsFuture::from(promise)
+        .await
+        .is_ok_and(|v| !v.is_null() && !v.is_undefined())
 }
 
 /// Request permission, subscribe, and register the subscription server-side.


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/d779d856fb3c73e21c85349d4fefb20b49a4441d/.0-pr-viz/001897.svg)

Two `match ... { Ok(..) => .., Err(_) => .. }` sites become one-expression combinators, behavior unchanged:

- `notifications_panel.rs` (`current_subscription_present`): match becomes `.is_ok_and(|v| !v.is_null() && !v.is_undefined())`
- `launchers_panel.rs` (agent probe): match becomes `.map(|resp| ProbeState::Loaded(..)).unwrap_or(ProbeState::Unreachable)`

`cargo fmt --check`, `cargo clippy -p frontend`, and `cargo test -p frontend` (685 passed) all green.