### PR TITLE
Adopt send_json in forwarding panel toggle

### DIFF
--- a/.0-pr-viz/001898.svg
+++ b/.0-pr-viz/001898.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200" font-family="'Segoe UI','Noto Sans','DejaVu Sans',ui-sans-serif,system-ui,sans-serif">
+<rect width="2000" height="1200" fill="#16161e"/>
+<text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1898 · adopt send_json in forwarding panel toggle</text>
+<text x="55" y="100" font-size="34" fill="#e6e9f5">The public/private toggle's two-step build-then-send becomes one send_json call;</text>
+<text x="55" y="140" font-size="34" fill="#e6e9f5">behavior unchanged.</text>
+<line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666"/>
+<text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+<text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+<line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+<rect x="80" y="270" width="840" height="330" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="325" font-size="26" fill="#c0caf5">on_toggle builds, then sends</text>
+<text x="108" y="380" font-size="23" fill="#a9b1d6">if let Ok(req) = Request::patch(&amp;url).json(..)</text>
+<text x="108" y="430" font-size="23" fill="#f7768e">encode failure silently skipped by if-let</text>
+<text x="108" y="480" font-size="23" fill="#a9b1d6">let _ = req.send().await; // send errors ignored</text>
+<text x="108" y="530" font-size="23" fill="#f7768e">two steps for one fire-and-forget PATCH</text>
+<rect x="1065" y="270" width="860" height="330" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="325" font-size="26" fill="#7aa2f7">one send_json call</text>
+<text x="1093" y="380" font-size="23" fill="#a9b1d6">utils::send_json(Request::patch(&amp;url),</text>
+<text x="1093" y="430" font-size="23" fill="#a9b1d6">&amp;SetForwardPublicRequest { public }).await</text>
+<text x="1093" y="480" font-size="23" fill="#9ece6a">encode + send failures still ignored via let _</text>
+<text x="1093" y="530" font-size="23" fill="#9ece6a">toggle still refetches after firing</text>
+<text x="55" y="1172" font-size="22" fill="#565f89">Scope: forwarding toggle only; fork_dialog's manual .json match and body-less GET/DELETE sites untouched.</text>
+</svg>

--- a/frontend/src/pages/settings/forwarding_panel.rs
+++ b/frontend/src/pages/settings/forwarding_panel.rs
@@ -47,9 +47,8 @@ pub fn forwarding_panel() -> Html {
             let reload = reload.clone();
             spawn_local(async move {
                 let url = utils::api_url(&format!("/api/sessions/{session_id}/forwards/public"));
-                if let Ok(req) = Request::patch(&url).json(&SetForwardPublicRequest { public }) {
-                    let _ = req.send().await;
-                }
+                let _ = utils::send_json(Request::patch(&url), &SetForwardPublicRequest { public })
+                    .await;
                 // Refetch so the row reflects the server (and any concurrent
                 // registration/revocation).
                 reload();


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/d0c382a8b1f54c16e2905ee92585c85b031feea0/.0-pr-viz/001898.svg)

Follow-up to #1892/#1896: the public/private toggle in forwarding_panel.rs was the last manual Request::patch(...).json(...) + if-let-Ok site that silently drops serialization failures. Route it through the shared utils::send_json helper.

No behavior change: encode and send failures were ignored before (let _) and still are; the toggle still refetches after firing.

cargo fmt --check, cargo clippy -p frontend, and cargo test -p frontend (685 passed) all green.