### PR TITLE
Dedupe launcher list fetch into utils helper

### DIFF
--- a/.0-pr-viz/001899.svg
+++ b/.0-pr-viz/001899.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200" font-family="'Segoe UI','Noto Sans','DejaVu Sans',ui-sans-serif,system-ui,sans-serif">
+<rect width="2000" height="1200" fill="#16161e"/>
+<text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1899 · dedupe launcher list fetch into utils helper</text>
+<text x="55" y="100" font-size="34" fill="#e6e9f5">One canonical fetch_launchers() in utils.rs; three call sites repointed, behavior unchanged.</text>
+<line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666"/>
+<text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+<text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+<line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+<rect x="80" y="270" width="840" height="300" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="325" font-size="26" fill="#c0caf5">Same fetch spelled out three times</text>
+<text x="108" y="380" font-size="23" fill="#a9b1d6">launch_dialog.rs, schedule_dialog.rs, launchers_panel.rs</text>
+<text x="108" y="430" font-size="23" fill="#f7768e">fetch_json::&lt;Vec&lt;LauncherInfo&gt;&gt;("/api/launchers", Ignore)</text>
+<text x="108" y="480" font-size="23" fill="#f7768e">path, element type, and 401 policy repeated verbatim</text>
+<rect x="80" y="650" width="840" height="245" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="705" font-size="26" fill="#c0caf5">Three-line if-let-Ok at every site</text>
+<text x="108" y="760" font-size="23" fill="#a9b1d6">each call wraps the generic fetch_json signature</text>
+<text x="108" y="810" font-size="23" fill="#f7768e">a path typo in one copy would fetch silently wrong</text>
+<rect x="1065" y="270" width="860" height="300" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="325" font-size="26" fill="#7aa2f7">utils.rs owns fetch_launchers()</text>
+<text x="1093" y="380" font-size="23" fill="#a9b1d6">single pub helper: path, type, and Ignore in one place</text>
+<text x="1093" y="430" font-size="23" fill="#9ece6a">each site collapses to a one-line if-let-Ok</text>
+<text x="1093" y="480" font-size="23" fill="#9ece6a">same endpoint, same type, same 401 policy — zero behavior change</text>
+<rect x="1065" y="650" width="860" height="245" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="705" font-size="26" fill="#7aa2f7">Dead import trimmed, suite green</text>
+<text x="1093" y="760" font-size="23" fill="#a9b1d6">schedule_dialog drops its now-unused LauncherInfo import</text>
+<text x="1093" y="810" font-size="23" fill="#9ece6a">685 frontend tests green, clippy and fmt clean</text>
+<text x="55" y="1172" font-size="22" fill="#565f89">Scope: frontend only; On401::Ignore semantics and downstream selection logic untouched.</text>
+</svg>

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -343,9 +343,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
         let probing_agents = probing_agents.clone();
         use_effect_with(props.launcher_refresh, move |_| {
             spawn_local(async move {
-                if let Ok(data) =
-                    utils::fetch_json::<Vec<LauncherInfo>>("/api/launchers", On401::Ignore).await
-                {
+                if let Ok(data) = utils::fetch_launchers().await {
                     // A live refresh must not yank a selection that is
                     // still valid — but a selection whose launcher just
                     // dropped off the list is stale, and launching against

--- a/frontend/src/components/schedule_dialog.rs
+++ b/frontend/src/components/schedule_dialog.rs
@@ -9,7 +9,7 @@ use shared::api::{
     CreateScheduledTaskRequest, ScheduledTaskInfo, ScheduledTaskListResponse,
     UpdateScheduledTaskRequest,
 };
-use shared::{LauncherInfo, SessionInfo};
+use shared::SessionInfo;
 use uuid::Uuid;
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
@@ -103,9 +103,7 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
         let hostname = hostname.clone();
         use_effect_with(hostname.clone(), move |_| {
             spawn_local(async move {
-                if let Ok(launchers) =
-                    utils::fetch_json::<Vec<LauncherInfo>>("/api/launchers", On401::Ignore).await
-                {
+                if let Ok(launchers) = utils::fetch_launchers().await {
                     if let Some(l) = launchers.iter().find(|l| l.hostname == hostname) {
                         launcher_version.set(l.version.clone());
                     }

--- a/frontend/src/pages/settings/launchers_panel.rs
+++ b/frontend/src/pages/settings/launchers_panel.rs
@@ -636,9 +636,7 @@ pub fn launchers_panel() -> Html {
             let loading = loading.clone();
 
             spawn_local(async move {
-                if let Ok(data) =
-                    utils::fetch_json::<Vec<LauncherInfo>>("/api/launchers", On401::Ignore).await
-                {
+                if let Ok(data) = utils::fetch_launchers().await {
                     launchers.set(data);
                 }
                 loading.set(false);

--- a/frontend/src/utils.rs
+++ b/frontend/src/utils.rs
@@ -60,6 +60,13 @@ pub async fn fetch_json<T: DeserializeOwned>(path: &str, on_401: On401) -> Resul
         .map_err(|e| FetchError::Decode(e.to_string()))
 }
 
+/// GET the launcher list (e.g. for install-mode auto-select or version
+/// probes). The path, element type, and 401 policy are identical at every
+/// call site, so they live here instead of being repeated.
+pub async fn fetch_launchers() -> Result<Vec<shared::LauncherInfo>, FetchError> {
+    fetch_json("/api/launchers", On401::Ignore).await
+}
+
 /// Read `(protocol, host)` from the browser location, with per-field fallbacks.
 ///
 /// Returns `None` only when there is no window (e.g. SSR/tests); per-field


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/78de742b22caf688aef4771ac67d175653f09600/.0-pr-viz/001899.svg)

Three launcher-list consumers now use one `utils::fetch_launchers()` helper, preserving `/api/launchers`, `Vec<LauncherInfo>`, and `On401::Ignore` behavior.

Rebased onto the completed cleanup batch. The semantic delta remains the launcher-fetch deduplication only.