### PR TITLE
Dedupe unbalanced-closer check in link trimmer

### DIFF
--- a/.0-pr-viz/001900.svg
+++ b/.0-pr-viz/001900.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200" font-family="'Segoe UI','Noto Sans','DejaVu Sans',ui-sans-serif,system-ui,sans-serif">
+<rect width="2000" height="1200" fill="#16161e"/>
+<text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1900 · dedupe unbalanced-closer check in link trimmer</text>
+<text x="55" y="100" font-size="34" fill="#e6e9f5">One single-pass helper in links.rs; paren and bracket trims share it.</text>
+<line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666"/>
+<text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+<text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+<line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+<rect x="80" y="270" width="840" height="300" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="325" font-size="26" fill="#c0caf5">unbalanced ")" check, four lines</text>
+<text x="108" y="380" font-size="23" fill="#a9b1d6">trim_url_punctuation in links.rs</text>
+<text x="108" y="430" font-size="23" fill="#f7768e">filter count ( and ), then compare</text>
+<text x="108" y="480" font-size="23" fill="#f7768e">two full passes over the URL per check</text>
+<rect x="80" y="650" width="840" height="245" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="705" font-size="26" fill="#c0caf5">unbalanced "]" check, four lines</text>
+<text x="108" y="760" font-size="23" fill="#a9b1d6">same function, ten lines below</text>
+<text x="108" y="810" font-size="23" fill="#f7768e">identical count logic, second copy</text>
+<rect x="1065" y="270" width="860" height="300" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="325" font-size="26" fill="#7aa2f7">has_unbalanced_closer(url, open, close)</text>
+<text x="1093" y="380" font-size="23" fill="#a9b1d6">single pub(super) helper in links.rs</text>
+<text x="1093" y="430" font-size="23" fill="#9ece6a">one pass counts both chars</text>
+<text x="1093" y="480" font-size="23" fill="#9ece6a">trim loop dispatches on ) vs ]</text>
+<rect x="1065" y="650" width="860" height="245" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="705" font-size="26" fill="#7aa2f7">Shared copy pinned by unit tests</text>
+<text x="1093" y="760" font-size="23" fill="#a9b1d6">helper cases plus parenthesized-URL case</text>
+<text x="1093" y="810" font-size="23" fill="#9ece6a">46 markdown tests green, clippy and fmt clean</text>
+<text x="55" y="1172" font-size="22" fill="#565f89">Scope: components/markdown only; trim decisions unchanged.</text>
+</svg>

--- a/frontend/src/components/markdown/links.rs
+++ b/frontend/src/components/markdown/links.rs
@@ -136,33 +136,35 @@ fn find_url_end(text: &str) -> usize {
     end
 }
 
+/// True when `url` holds more `close` chars than matching `open` chars, i.e. a
+/// trailing closer is sentence punctuation rather than part of the URL.
+pub(super) fn has_unbalanced_closer(url: &str, open: char, close: char) -> bool {
+    let (mut opens, mut closes) = (0usize, 0usize);
+    for ch in url.chars() {
+        if ch == open {
+            opens += 1;
+        } else if ch == close {
+            closes += 1;
+        }
+    }
+    closes > opens
+}
+
 /// Trim trailing punctuation that's commonly not part of URLs.
 fn trim_url_punctuation(url: &str) -> &str {
     let mut url = url;
     let trim_chars = ['.', ',', '!', '?', ';', ':', '"', '\''];
 
     while let Some(c) = url.chars().last() {
-        // Handle unbalanced closing parens/brackets
-        if c == ')' {
-            let open = url.chars().filter(|&ch| ch == '(').count();
-            let close = url.chars().filter(|&ch| ch == ')').count();
-            if close > open {
-                url = &url[..url.len() - 1];
-                continue;
+        // A trailing closer with no matching opener is sentence punctuation,
+        // not part of the URL; a balanced one ends the URL here.
+        if c == ')' || c == ']' {
+            let (open, close) = if c == ')' { ('(', ')') } else { ('[', ']') };
+            if !has_unbalanced_closer(url, open, close) {
+                break;
             }
-            break;
-        }
-        if c == ']' {
-            let open = url.chars().filter(|&ch| ch == '[').count();
-            let close = url.chars().filter(|&ch| ch == ']').count();
-            if close > open {
-                url = &url[..url.len() - 1];
-                continue;
-            }
-            break;
-        }
-        // Trim common trailing punctuation
-        if trim_chars.contains(&c) {
+            url = &url[..url.len() - 1];
+        } else if trim_chars.contains(&c) {
             url = &url[..url.len() - c.len_utf8()];
         } else {
             break;

--- a/frontend/src/components/markdown/mod.rs
+++ b/frontend/src/components/markdown/mod.rs
@@ -23,7 +23,7 @@ use shared::system_reminder::{has_collapsible_notice, split_collapsible_notices,
 use system_reminder::{SystemReminderBar, TaskNotificationBar};
 
 #[cfg(test)]
-use links::{find_next_url, is_valid_url};
+use links::{find_next_url, has_unbalanced_closer, is_valid_url};
 #[cfg(test)]
 use math::{
     extract_math_placeholders, restore_math, split_math_segments, MathSegment, MATH_CLOSE,
@@ -170,6 +170,29 @@ mod tests {
     fn test_find_next_url_none() {
         let result = find_next_url("No URLs here");
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_has_unbalanced_closer() {
+        assert!(!has_unbalanced_closer("https://example.com", '(', ')'));
+        assert!(!has_unbalanced_closer(
+            "https://en.wikipedia.org/wiki/Rust_(programming_language)",
+            '(',
+            ')'
+        ));
+        assert!(has_unbalanced_closer("https://example.com/foo)", '(', ')'));
+        assert!(!has_unbalanced_closer(
+            "https://example.com/[foo]",
+            '[',
+            ']'
+        ));
+        assert!(has_unbalanced_closer("https://example.com/foo]", '[', ']'));
+    }
+
+    #[test]
+    fn test_find_next_url_wrapped_in_parens() {
+        let result = find_next_url("See (https://example.com/foo) here");
+        assert_eq!(result, Some(("See (", "https://example.com/foo", ") here")));
     }
 
     #[test]


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/172cc3e4886b00c18fe92100d09721a4fae2172f/.0-pr-viz/001900.svg)

The trailing-paren and trailing-bracket trims in trim_url_punctuation were the same four lines twice (two full string passes each). Hoists the count into a single-pass has_unbalanced_closer helper shared by both closers. No behavior change: same counts, same trim decisions.

Adds unit tests for the helper plus a find_next_url case for a parenthesized URL.