### PR TITLE
Dedupe pretty-print fallback in tool renderers

### DIFF
--- a/.0-pr-viz/001901.svg
+++ b/.0-pr-viz/001901.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200" font-family="'Segoe UI','Noto Sans','DejaVu Sans',ui-sans-serif,system-ui,sans-serif">
+<rect width="2000" height="1200" fill="#16161e"/>
+<text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1901 · Dedupe pretty-print fallback in tool renderers</text>
+<text x="55" y="100" font-size="34" fill="#e6e9f5">Five copies of one pretty-print fallback lived in tools.rs;</text>
+<text x="55" y="140" font-size="34" fill="#e6e9f5">now one pretty_json helper owns it — same output, one home.</text>
+<line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666"/>
+<text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+<text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+<line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+<rect x="80" y="270" width="840" height="300" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="325" font-size="26" fill="#c0caf5">same fallback expression, 5 copies</text>
+<text x="108" y="380" font-size="23" fill="#a9b1d6">serde_json::to_string_pretty(x)</text>
+<text x="108" y="430" font-size="23" fill="#a9b1d6">.unwrap_or_else(|_| x.to_string())</text>
+<text x="108" y="480" font-size="23" fill="#f7768e">a 6th copy would paste it again</text>
+<text x="108" y="520" font-size="23" fill="#f7768e">a fix would need 5 matching edits</text>
+<rect x="80" y="620" width="840" height="260" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="675" font-size="26" fill="#c0caf5">5 call sites in tools.rs</text>
+<text x="108" y="730" font-size="23" fill="#a9b1d6">render_web_search_result, render_code_execution_result,</text>
+<text x="108" y="780" font-size="23" fill="#a9b1d6">render_mcp_tool_result, render_container_upload,</text>
+<text x="108" y="830" font-size="23" fill="#a9b1d6">render_unknown_block</text>
+<rect x="1065" y="270" width="860" height="300" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="325" font-size="26" fill="#7aa2f7">fn pretty_json(value: &amp;Value) -&gt; String</text>
+<text x="1093" y="380" font-size="23" fill="#a9b1d6">to_string_pretty, falling back to value.to_string()</text>
+<text x="1093" y="430" font-size="23" fill="#9ece6a">one home for the fallback logic</text>
+<text x="1093" y="480" font-size="23" fill="#9ece6a">body moved verbatim, zero behavior change</text>
+<rect x="1065" y="620" width="860" height="260" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="675" font-size="26" fill="#7aa2f7">5 call sites go one line each</text>
+<text x="1093" y="730" font-size="23" fill="#a9b1d6">pretty_json(content) / pretty_json(data) / pretty_json(value)</text>
+<text x="1093" y="780" font-size="23" fill="#9ece6a">same rendered output, next renderer reuses it</text>
+<text x="1093" y="830" font-size="23" fill="#9ece6a">685 frontend tests green, clippy and fmt clean</text>
+<text x="55" y="1172" font-size="22" fill="#565f89">Scope: tools.rs only; the unwrap_or_default pretty-prints in assistant.rs and render_structured_block are untouched.</text>
+</svg>

--- a/frontend/src/components/message_renderer/renderers/tools.rs
+++ b/frontend/src/components/message_renderer/renderers/tools.rs
@@ -2,6 +2,12 @@ use crate::components::expandable::ExpandableText;
 use serde_json::Value;
 use yew::prelude::*;
 
+/// Pretty-print a JSON value, falling back to its compact form when
+/// pretty-printing fails.
+fn pretty_json(value: &Value) -> String {
+    serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+}
+
 pub(super) fn render_server_tool_use(name: &str, input: &Value) -> Html {
     let badge_label = if name.contains("web_search") || name.contains("search") {
         "Web Search"
@@ -25,7 +31,7 @@ pub(super) fn render_server_tool_use(name: &str, input: &Value) -> Html {
 }
 
 pub(super) fn render_web_search_result(content: &Value) -> Html {
-    let preview = serde_json::to_string_pretty(content).unwrap_or_else(|_| content.to_string());
+    let preview = pretty_json(content);
     html! {
         <div class="tool-result web-search-result">
             <div class="tool-use-header">
@@ -37,7 +43,7 @@ pub(super) fn render_web_search_result(content: &Value) -> Html {
 }
 
 pub(super) fn render_code_execution_result(content: &Value) -> Html {
-    let preview = serde_json::to_string_pretty(content).unwrap_or_else(|_| content.to_string());
+    let preview = pretty_json(content);
     html! {
         <div class="tool-result code-execution-result">
             <div class="tool-use-header">
@@ -75,7 +81,7 @@ pub(super) fn render_mcp_tool_result(content: &Value, is_error: bool) -> Html {
     } else {
         "tool-result mcp-tool-result"
     };
-    let preview = serde_json::to_string_pretty(content).unwrap_or_else(|_| content.to_string());
+    let preview = pretty_json(content);
     html! {
         <div class={class}>
             <div class="tool-use-header">
@@ -89,7 +95,7 @@ pub(super) fn render_mcp_tool_result(content: &Value, is_error: bool) -> Html {
 }
 
 pub(super) fn render_container_upload(data: &Value) -> Html {
-    let preview = serde_json::to_string_pretty(data).unwrap_or_else(|_| data.to_string());
+    let preview = pretty_json(data);
     html! {
         <div class="tool-use container-upload">
             <div class="tool-use-header">
@@ -101,7 +107,7 @@ pub(super) fn render_container_upload(data: &Value) -> Html {
 }
 
 pub(super) fn render_unknown_block(value: &Value) -> Html {
-    let preview = serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string());
+    let preview = pretty_json(value);
     html! {
         <div class="tool-use unknown-block">
             <div class="tool-use-header">


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/39f3d47caf0e0b11dc23eae6ad0b6053d91b19d4/.0-pr-viz/001901.svg)

Extracts a small pretty_json helper behind the five identical serde_json::to_string_pretty(..).unwrap_or_else(..to_string()) call sites in the tool renderers. No behavior change.