### PR TITLE
Dedupe WebSocket error log-and-emit reporting

### DIFF
--- a/.0-pr-viz/001902.svg
+++ b/.0-pr-viz/001902.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200" font-family="'Segoe UI','Noto Sans','DejaVu Sans',ui-sans-serif,system-ui,sans-serif">
+<rect width="2000" height="1200" fill="#16161e"/>
+<text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1902 · dedupe WebSocket error log-and-emit reporting</text>
+<text x="55" y="100" font-size="34" fill="#e6e9f5">One report_ws_error helper; three failure paths repointed, behavior unchanged.</text>
+<line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666"/>
+<text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+<text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+<line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+<rect x="80" y="270" width="840" height="300" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="325" font-size="26" fill="#c0caf5">log + emit pair repeated 3x</text>
+<text x="108" y="380" font-size="23" fill="#a9b1d6">connect_websocket in session_view/websocket.rs</text>
+<text x="108" y="430" font-size="23" fill="#f7768e">send-queue, receive, and connect errors</text>
+<text x="108" y="480" font-size="23" fill="#f7768e">each hand-rolls log::error! + WsEvent::Error</text>
+<rect x="80" y="650" width="840" height="245" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="705" font-size="26" fill="#c0caf5">6 lines doing the work of 2</text>
+<text x="108" y="760" font-size="23" fill="#a9b1d6">identical shape, only the context string differs</text>
+<text x="108" y="810" font-size="23" fill="#f7768e">next edit must touch all three sites</text>
+<rect x="1065" y="270" width="860" height="300" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="325" font-size="26" fill="#7aa2f7">report_ws_error owns the pair</text>
+<text x="1093" y="380" font-size="23" fill="#a9b1d6">private fn: log::error! then emit WsEvent::Error</text>
+<text x="1093" y="430" font-size="23" fill="#9ece6a">same log strings, same UI events</text>
+<text x="1093" y="480" font-size="23" fill="#9ece6a">callers pass context + Debug error only</text>
+<rect x="1065" y="650" width="860" height="245" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="705" font-size="26" fill="#7aa2f7">Verified, zero behavior change</text>
+<text x="1093" y="760" font-size="23" fill="#a9b1d6">685 frontend tests green, clippy and fmt clean</text>
+<text x="1093" y="810" font-size="23" fill="#9ece6a">wasm32 check passes</text>
+<text x="55" y="1172" font-size="22" fill="#565f89">Scope: frontend only; optimistic forward-chip delete and registration error paths untouched.</text>
+</svg>

--- a/frontend/src/pages/dashboard/session_view/websocket.rs
+++ b/frontend/src/pages/dashboard/session_view/websocket.rs
@@ -73,6 +73,12 @@ pub enum WsEvent {
     Ephemeral(serde_json::Value),
 }
 
+/// Log a WebSocket failure and surface it to the UI as a [`WsEvent::Error`].
+fn report_ws_error(on_event: &Callback<WsEvent>, context: &str, err: impl std::fmt::Debug) {
+    log::error!("{context}: {err:?}");
+    on_event.emit(WsEvent::Error(format!("{err:?}")));
+}
+
 /// Connect to WebSocket and start receiving messages.
 /// Returns immediately, spawns async task to handle connection.
 pub fn connect_websocket(
@@ -127,8 +133,7 @@ pub fn connect_websocket(
                 spawn_local(async move {
                     while let Some(msg) = queue_rx.next().await {
                         if let Err(e) = sender.send(msg).await {
-                            log::error!("WebSocket send error: {:?}", e);
-                            on_event_for_send.emit(WsEvent::Error(format!("{:?}", e)));
+                            report_ws_error(&on_event_for_send, "WebSocket send error", e);
                             break;
                         }
                     }
@@ -140,16 +145,14 @@ pub fn connect_websocket(
                             handle_proxy_message(msg, &on_event);
                         }
                         Err(e) => {
-                            log::error!("WebSocket error: {:?}", e);
-                            on_event.emit(WsEvent::Error(format!("{:?}", e)));
+                            report_ws_error(&on_event, "WebSocket error", e);
                             break;
                         }
                     }
                 }
             }
             Err(e) => {
-                log::error!("Failed to connect WebSocket: {:?}", e);
-                on_event.emit(WsEvent::Error(format!("{:?}", e)));
+                report_ws_error(&on_event, "Failed to connect WebSocket", e);
             }
         }
     });


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/73bdb9950a3894e96f307f91022db877ab851141/.0-pr-viz/001902.svg)

Small DRY cleanup in the SessionView WebSocket plumbing: the three failure paths in connect_websocket (send-queue error, receive error, connect error) each repeated the same two lines — log::error! plus on_event.emit(WsEvent::Error(format!("{:?}", e))). They now share a tiny report_ws_error helper. No behavior change: same log strings, same UI events.