### PR TITLE
Hoist error_body helper into frontend utils

### DIFF
--- a/.0-pr-viz/001905.svg
+++ b/.0-pr-viz/001905.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200" font-family="'Segoe UI','Noto Sans','DejaVu Sans',ui-sans-serif,system-ui,sans-serif">
+<rect width="2000" height="1200" fill="#16161e"/>
+<text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1905 · hoist error_body helper into frontend utils</text>
+<text x="55" y="100" font-size="34" fill="#e6e9f5">One canonical copy in utils.rs; four call sites repointed, behavior unchanged.</text>
+<line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666"/>
+<text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+<text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+<line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+<rect x="80" y="270" width="840" height="300" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="325" font-size="26" fill="#c0caf5">error_body private to agent_login.rs</text>
+<text x="108" y="380" font-size="23" fill="#a9b1d6">start_login, submit_code, poll_login use it</text>
+<text x="108" y="430" font-size="23" fill="#f7768e">a sibling module cannot reach a private fn</text>
+<text x="108" y="480" font-size="23" fill="#f7768e">so the helper stops at one file boundary</text>
+<rect x="80" y="650" width="840" height="245" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="705" font-size="26" fill="#c0caf5">install_agent hand-rolls the same fallback</text>
+<text x="108" y="760" font-size="23" fill="#a9b1d6">unwrap_or_default plus empty check, six lines</text>
+<text x="108" y="810" font-size="23" fill="#f7768e">two homes for one three-line idiom</text>
+<rect x="1065" y="270" width="860" height="300" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="325" font-size="26" fill="#7aa2f7">utils.rs owns pub async error_body</text>
+<text x="1093" y="380" font-size="23" fill="#a9b1d6">body text wins; empty or unreadable falls back</text>
+<text x="1093" y="430" font-size="23" fill="#9ece6a">moved verbatim next to fetch_json, send_json</text>
+<text x="1093" y="480" font-size="23" fill="#9ece6a">general doc note: backends relay CLI text</text>
+<rect x="1065" y="650" width="860" height="245" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="705" font-size="26" fill="#7aa2f7">Both settings panels import from utils</text>
+<text x="1093" y="760" font-size="23" fill="#a9b1d6">install_agent collapses to a one-line Err</text>
+<text x="1093" y="810" font-size="23" fill="#9ece6a">685 frontend tests green, clippy and fmt clean</text>
+<text x="55" y="1172" font-size="22" fill="#565f89">Scope: settings panels only; subdomains_tab empty-body variant untouched.</text>
+</svg>

--- a/frontend/src/pages/settings/agent_install.rs
+++ b/frontend/src/pages/settings/agent_install.rs
@@ -154,13 +154,7 @@ async fn install_agent(
         .await
         .map_err(|e| e.to_string())?;
     if !resp.ok() {
-        let status = resp.status();
-        let body = resp.text().await.unwrap_or_default();
-        return Err(if body.trim().is_empty() {
-            format!("HTTP {status}")
-        } else {
-            body
-        });
+        return Err(utils::error_body(resp).await);
     }
     resp.json::<InstallAgentResponse>()
         .await

--- a/frontend/src/pages/settings/agent_login.rs
+++ b/frontend/src/pages/settings/agent_login.rs
@@ -355,7 +355,7 @@ async fn start_login(
         .await
         .map_err(|e| e.to_string())?;
     if !resp.ok() {
-        return Err(error_body(resp).await);
+        return Err(utils::error_body(resp).await);
     }
     resp.json::<StartAgentLoginResponse>()
         .await
@@ -375,7 +375,7 @@ async fn submit_code(
         .await
         .map_err(|e| e.to_string())?;
     if !resp.ok() {
-        return Err(error_body(resp).await);
+        return Err(utils::error_body(resp).await);
     }
     resp.json::<AgentLoginOutcome>()
         .await
@@ -388,7 +388,7 @@ async fn poll_login(launcher_id: Uuid, flow_id: Uuid) -> Result<AgentLoginOutcom
     ));
     let resp = Request::get(&url).send().await.map_err(|e| e.to_string())?;
     if !resp.ok() {
-        return Err(error_body(resp).await);
+        return Err(utils::error_body(resp).await);
     }
     resp.json::<AgentLoginOutcome>()
         .await
@@ -404,16 +404,6 @@ fn cancel_login(launcher_id: Uuid, flow_id: Uuid) {
         ));
         let _ = Request::post(&url).send().await;
     });
-}
-
-/// Read a non-2xx response body as the error message, falling back to the
-/// status. The backend relays the agent CLI's own text on login-start failures.
-async fn error_body(resp: gloo_net::http::Response) -> String {
-    let status = resp.status();
-    match resp.text().await {
-        Ok(t) if !t.trim().is_empty() => t,
-        _ => format!("HTTP {status}"),
-    }
 }
 
 #[cfg(test)]

--- a/frontend/src/utils.rs
+++ b/frontend/src/utils.rs
@@ -108,6 +108,17 @@ pub async fn send_json(
     builder.json(body)?.send().await
 }
 
+/// Read a non-2xx response body as the error message, falling back to the
+/// status when the body is empty or unreadable. Backends relay upstream
+/// agent-CLI text on launcher failures, which is more useful than the status.
+pub async fn error_body(resp: gloo_net::http::Response) -> String {
+    let status = resp.status();
+    match resp.text().await {
+        Ok(t) if !t.trim().is_empty() => t,
+        _ => format!("HTTP {status}"),
+    }
+}
+
 /// Build a full WebSocket URL from a path (e.g., "/ws/client" -> "ws://localhost:3000/ws/client")
 pub fn ws_url(path: &str) -> String {
     format!("{}{}", get_ws_url(), path)


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/ff9ff445e81a2d857189577cb9b9b8293514583a/.0-pr-viz/001905.svg)

agent_login.rs owned a private error_body (read non-2xx body, fall back to HTTP status) used 3x, while agent_install.rs inlined the identical logic. Hoist it to utils::error_body and reuse in both. No behavior change: the old unwrap_or_default + empty-check is equivalent to the match arms.