### PR TITLE
Use matches macro in math placeholder assertions

### DIFF
--- a/frontend/src/components/markdown/mod.rs
+++ b/frontend/src/components/markdown/mod.rs
@@ -373,14 +373,12 @@ Where:\n\
         // The placeholders must land in plain Text events, where the renderer
         // can split them out into their own `MathSpan` elements. If they end
         // up in `Event::Html`/`Event::InlineHtml` the math is never typeset.
-        let math_in_text = events.iter().any(|e| match e {
-            Event::Text(t) => t.contains(MATH_OPEN),
-            _ => false,
-        });
-        let math_in_html = events.iter().any(|e| match e {
-            Event::Html(t) | Event::InlineHtml(t) => t.contains(MATH_OPEN),
-            _ => false,
-        });
+        let math_in_text = events
+            .iter()
+            .any(|e| matches!(e, Event::Text(t) if t.contains(MATH_OPEN)));
+        let math_in_html = events
+            .iter()
+            .any(|e| matches!(e, Event::Html(t) | Event::InlineHtml(t) if t.contains(MATH_OPEN)));
         assert!(math_in_text, "math placeholders should reach Event::Text");
         assert!(!math_in_html, "math should not leak into Event::Html");
     }


### PR DESCRIPTION
Test-only conciseness cleanup: the math-placeholder test in frontend/src/components/markdown/mod.rs used two verbose match blocks inside Iterator::any where the matches! macro with a guard says the same thing. The same file already uses matches! for event assertions a few lines below, so this just follows the local idiom. No behavior change.