### PR TITLE
Update claude-codes to 2.1.266

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,9 +1156,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-codes"
-version = "2.1.263"
+version = "2.1.266"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f08040316a6e918e745cde39d3dc3cc49251660cd1603c65c64807436b80a1ab"
+checksum = "cd76756862e148c4bd0595a5d6979397b665ff6a56648d0f872ff4bdd8556ab2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Claude Code integration
-claude-codes = { version = "2.1.263", default-features = false, features = ["types"] }
+claude-codes = { version = "2.1.266", default-features = false, features = ["types"] }
 
 # Muse CLI integration
 muse-codes = { version = "1.0.3", default-features = false, features = ["types"] }

--- a/claude-session-lib/src/proxy_session/wiggum.rs
+++ b/claude-session-lib/src/proxy_session/wiggum.rs
@@ -550,6 +550,7 @@ mod tests {
             user_message_uuid: None,
             user_message_uuids: Vec::new(),
             queued_turn_count: None,
+            runner_exit: None,
             fast_mode_disabled_reason: None,
         }
     }


### PR DESCRIPTION
Update `claude-codes` from 2.1.263 to 2.1.266 and initialize the new optional `ResultMessage.runner_exit` field in the Wiggum test fixture.

Reviewed the [upstream changelog](https://github.com/meawoppl/rust-code-agent-sdks/blob/main/claude-codes/CHANGELOG.md#21266---2026-09-09) and published source diff. This release adds optional replay, input-provenance, startup-timing, and runner-exit metadata plus the `dev_intent` system event. The existing typed serialization forwards the metadata, the generic system renderer accepts the event, and error results retain their existing failure handling. No production-code changes are required.

Validation passed: `cargo fmt --all`, `cargo check --workspace --all-targets --locked`, `cargo check -p frontend -p shared --target wasm32-unknown-unknown --locked`, and `cargo test -p claude-session-lib --lib --locked` (89 tests). Full CI will gate the merge.

Checked crates.io and main's manifest/lockfile: `codex-codes` 0.153.4 and `muse-codes` 1.0.3 are already current. This PR only updates Claude. `no-visual` applies to this dependency bump and its test-fixture compatibility adjustment.
