### PR TITLE
Dedupe launcher owner checks into helper

### DIFF
--- a/.0-pr-viz/001910.svg
+++ b/.0-pr-viz/001910.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200" font-family="'Segoe UI','Noto Sans','DejaVu Sans',ui-sans-serif,system-ui,sans-serif">
+<rect width="2000" height="1200" fill="#16161e"/>
+<text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1910 · dedupe launcher owner checks into helper</text>
+<text x="55" y="100" font-size="34" fill="#e6e9f5">Four endpoints route through require_launcher_owner; behavior unchanged.</text>
+<line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666"/>
+<text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+<text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+<line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+<rect x="80" y="270" width="840" height="300" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="325" font-size="26" fill="#c0caf5">four handlers hand-roll the owner check</text>
+<text x="108" y="380" font-size="23" fill="#a9b1d6">launcher_owner + 404/403 mapping, copied 4x</text>
+<text x="108" y="430" font-size="23" fill="#f7768e">list_directories, update, restart, probe_agents</text>
+<text x="108" y="480" font-size="23" fill="#f7768e">7-line guard block repeated per handler</text>
+<rect x="80" y="650" width="840" height="245" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="705" font-size="26" fill="#c0caf5">same guard drifts across edits</text>
+<text x="108" y="760" font-size="23" fill="#a9b1d6">helper exists but only 5 login/install callers use it</text>
+<text x="108" y="810" font-size="23" fill="#f7768e">one fix must land in five places at once</text>
+<rect x="1065" y="270" width="860" height="300" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="325" font-size="26" fill="#7aa2f7">all four call require_launcher_owner</text>
+<text x="1093" y="380" font-size="23" fill="#a9b1d6">one helper: launcher_owner + 404/403 mapping</text>
+<text x="1093" y="430" font-size="23" fill="#9ece6a">9 callers share one ownership rule</text>
+<text x="1093" y="480" font-size="23" fill="#9ece6a">328 backend tests green, clippy and fmt clean</text>
+<rect x="1065" y="650" width="860" height="245" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="705" font-size="26" fill="#7aa2f7">warn-logging check stays inline</text>
+<text x="1093" y="760" font-size="23" fill="#a9b1d6">resolve_launch_target logs the owner on mismatch</text>
+<text x="1093" y="810" font-size="23" fill="#9ece6a">deliberately untouched — extra behavior, not dup</text>
+<text x="55" y="1172" font-size="22" fill="#565f89">Scope: backend/src/handlers/launchers.rs only; no API or protocol change.</text>
+</svg>

--- a/.0-pr-viz/001910.svg
+++ b/.0-pr-viz/001910.svg
@@ -14,7 +14,7 @@
 <rect x="80" y="650" width="840" height="245" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
 <text x="108" y="705" font-size="26" fill="#c0caf5">same guard drifts across edits</text>
 <text x="108" y="760" font-size="23" fill="#a9b1d6">helper exists but only 5 login/install callers use it</text>
-<text x="108" y="810" font-size="23" fill="#f7768e">one fix must land in five places at once</text>
+<text x="108" y="810" font-size="23" fill="#f7768e">one fix must land in four places at once</text>
 <rect x="1065" y="270" width="860" height="300" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
 <text x="1093" y="325" font-size="26" fill="#7aa2f7">all four call require_launcher_owner</text>
 <text x="1093" y="380" font-size="23" fill="#a9b1d6">one helper: launcher_owner + 404/403 mapping</text>

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -475,14 +475,7 @@ pub async fn list_directories(
     Path(launcher_id): Path<Uuid>,
     Query(query): Query<DirectoryQuery>,
 ) -> Result<Json<DirectoryListingResponse>, AppError> {
-    // Verify the launcher belongs to this user
-    let owner = app_state
-        .session_manager
-        .launcher_owner(launcher_id)
-        .ok_or(AppError::NotFound("Launcher not found"))?;
-    if owner != user_id {
-        return Err(AppError::Forbidden);
-    }
+    require_launcher_owner(&app_state, launcher_id, user_id)?;
 
     let request_id = Uuid::new_v4();
     let rx = app_state.session_manager.register_dir_request(request_id);
@@ -561,15 +554,7 @@ pub async fn update_launcher(
     CurrentUserId(user_id): CurrentUserId,
     Path(launcher_id): Path<Uuid>,
 ) -> Result<EmptyResponse, AppError> {
-    {
-        let owner = app_state
-            .session_manager
-            .launcher_owner(launcher_id)
-            .ok_or(AppError::NotFound("Launcher not found"))?;
-        if owner != user_id {
-            return Err(AppError::Forbidden);
-        }
-    }
+    require_launcher_owner(&app_state, launcher_id, user_id)?;
 
     // Route through the evicting sender (not a cloned raw sender) so a dead
     // channel tears the stale connection down instead of lingering.
@@ -595,15 +580,7 @@ pub async fn restart_launcher(
     CurrentUserId(user_id): CurrentUserId,
     Path(launcher_id): Path<Uuid>,
 ) -> Result<EmptyResponse, AppError> {
-    {
-        let owner = app_state
-            .session_manager
-            .launcher_owner(launcher_id)
-            .ok_or(AppError::NotFound("Launcher not found"))?;
-        if owner != user_id {
-            return Err(AppError::Forbidden);
-        }
-    }
+    require_launcher_owner(&app_state, launcher_id, user_id)?;
 
     if !app_state
         .session_manager
@@ -639,15 +616,7 @@ pub async fn probe_agents(
     CurrentUserId(user_id): CurrentUserId,
     Path(launcher_id): Path<Uuid>,
 ) -> Result<Json<ProbeAgentsResponse>, AppError> {
-    {
-        let owner = app_state
-            .session_manager
-            .launcher_owner(launcher_id)
-            .ok_or(AppError::NotFound("Launcher not found"))?;
-        if owner != user_id {
-            return Err(AppError::Forbidden);
-        }
-    }
+    require_launcher_owner(&app_state, launcher_id, user_id)?;
 
     let request_id = Uuid::new_v4();
     let rx = app_state.session_manager.register_probe_request(request_id);


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/e2ff75e07e23e66349832a527b25222f81611acd/.0-pr-viz/001910.svg)

Four launcher endpoints (list_directories, update_launcher, restart_launcher, probe_agents) inlined the same launcher_owner lookup plus 404/403 mapping that require_launcher_owner already encapsulates for the agent-login/install handlers. Route them through the helper (+4/-35); behavior unchanged.

resolve_launch_target keeps its inline check deliberately — it logs a warn with the owner on mismatch, which the helper does not do.

cargo fmt clean, cargo clippy -p backend clean, cargo test -p backend --lib (328 passed) green.