### PR TITLE
Add mobile header collapse for more vertical space

### DIFF
--- a/.0-pr-viz/001911.svg
+++ b/.0-pr-viz/001911.svg
@@ -2,7 +2,7 @@
   <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
 
   <!-- Thesis -->
-  <text x="1000" y="64" text-anchor="middle" fill="#c0caf5" font-size="34" font-weight="bold">The mobile header now collapses to a slim pull strip — transcript gets the space</text>
+  <text x="1000" y="64" text-anchor="middle" fill="#c0caf5" font-size="34" font-weight="bold">The header now collapses to a slim pull strip — the transcript gets the space</text>
 
   <!-- BEFORE / AFTER labels -->
   <text x="500" y="126" text-anchor="middle" fill="#f7768e" font-size="26" font-weight="bold" letter-spacing="4">BEFORE</text>
@@ -91,7 +91,7 @@
 
   <!-- mechanism strip (kept clear of the divider band) -->
   <text x="500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">ToggleHeaderCollapsed · persisted in localStorage</text>
-  <text x="1500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">CSS scoped to ≤768px — desktop never collapses</text>
+  <text x="1500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">Works on every viewport — the strip is the expand target</text>
 
   <!-- Footer limitation -->
   <text x="1000" y="1190" text-anchor="middle" fill="#565f89" font-size="15" font-style="italic">Limitation: manual toggle only — no auto-hide on scroll; while collapsed, Launch/Settings need one extra tap to reach.</text>

--- a/.0-pr-viz/001911.svg
+++ b/.0-pr-viz/001911.svg
@@ -1,0 +1,98 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2000" height="1200" viewBox="0 0 2000 1200" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <!-- Thesis -->
+  <text x="1000" y="64" text-anchor="middle" fill="#c0caf5" font-size="34" font-weight="bold">The mobile header now collapses to a slim pull strip — transcript gets the space</text>
+
+  <!-- BEFORE / AFTER labels -->
+  <text x="500" y="126" text-anchor="middle" fill="#f7768e" font-size="26" font-weight="bold" letter-spacing="4">BEFORE</text>
+  <text x="1500" y="126" text-anchor="middle" fill="#9ece6a" font-size="26" font-weight="bold" letter-spacing="4">AFTER</text>
+  <line x1="1000" y1="96" x2="1000" y2="1140" stroke="#565f89" stroke-width="2" stroke-dasharray="8 8"/>
+
+  <!-- BEFORE: phone mock with fat header -->
+  <g>
+    <!-- phone frame -->
+    <rect x="290" y="170" width="420" height="760" rx="28" fill="#1e202e" stroke="#3d4666" stroke-width="3"/>
+    <!-- safe area / notch -->
+    <rect x="440" y="182" width="120" height="18" rx="9" fill="#16161e"/>
+    <!-- header: two wrapped rows -->
+    <rect x="304" y="212" width="392" height="108" fill="#16161e" stroke="#3d4666" stroke-width="1"/>
+    <text x="322" y="248" fill="#c0caf5" font-size="17" font-weight="bold">Agent Portal</text>
+    <rect x="470" y="230" width="90" height="26" rx="13" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="515" y="248" text-anchor="middle" fill="#f7768e" font-size="12">2 waiting</text>
+    <rect x="570" y="230" width="112" height="26" rx="13" fill="#1e202e" stroke="#7aa2f7" stroke-width="1.5"/>
+    <text x="626" y="248" text-anchor="middle" fill="#7aa2f7" font-size="12">+ Launch</text>
+    <rect x="322" y="272" width="72" height="26" rx="13" fill="#1e202e" stroke="#565f89" stroke-width="1"/>
+    <text x="358" y="290" text-anchor="middle" fill="#a9b1d6" font-size="12">History</text>
+    <rect x="404" y="272" width="76" height="26" rx="13" fill="#1e202e" stroke="#565f89" stroke-width="1"/>
+    <text x="442" y="290" text-anchor="middle" fill="#a9b1d6" font-size="12">Settings</text>
+    <rect x="490" y="272" width="70" height="26" rx="13" fill="#1e202e" stroke="#565f89" stroke-width="1"/>
+    <text x="525" y="290" text-anchor="middle" fill="#a9b1d6" font-size="12">Logout</text>
+    <!-- rail -->
+    <rect x="304" y="320" width="392" height="52" fill="#1e202e"/>
+    <rect x="318" y="332" width="120" height="30" rx="15" fill="#16161e" stroke="#7aa2f7" stroke-width="1.5"/>
+    <rect x="448" y="332" width="120" height="30" rx="15" fill="#16161e" stroke="#565f89" stroke-width="1"/>
+    <!-- transcript (short) -->
+    <rect x="318" y="392" width="300" height="16" rx="4" fill="#3d4666"/>
+    <rect x="318" y="422" width="360" height="16" rx="4" fill="#3d4666"/>
+    <rect x="318" y="452" width="250" height="16" rx="4" fill="#3d4666"/>
+    <rect x="318" y="482" width="340" height="16" rx="4" fill="#3d4666"/>
+    <rect x="318" y="512" width="200" height="16" rx="4" fill="#3d4666"/>
+    <rect x="318" y="542" width="320" height="16" rx="4" fill="#3d4666"/>
+    <rect x="318" y="572" width="280" height="16" rx="4" fill="#3d4666"/>
+    <!-- input + keyboard -->
+    <rect x="304" y="612" width="392" height="48" rx="8" fill="#16161e" stroke="#3d4666" stroke-width="1"/>
+    <text x="322" y="642" fill="#565f89" font-size="14" font-style="italic">Message…</text>
+    <rect x="304" y="672" width="392" height="246" fill="#1e202e"/>
+    <text x="500" y="800" text-anchor="middle" fill="#565f89" font-size="16">software keyboard</text>
+
+    <!-- annotation -->
+    <rect x="150" y="960" width="700" height="130" rx="12" fill="#1e202e" stroke="#565f89" stroke-width="1.5"/>
+    <text x="180" y="998" fill="#f7768e" font-size="19" font-weight="bold">Header wraps to two rows on narrow screens:</text>
+    <text x="180" y="1030" fill="#c0caf5" font-size="17">- title + badges + 4 nav buttons ≈ 108px of chrome</text>
+    <text x="180" y="1060" fill="#c0caf5" font-size="17">- with keyboard up, ~7 transcript lines remain visible</text>
+  </g>
+
+  <!-- AFTER: phone mock with collapsed strip -->
+  <g>
+    <!-- phone frame -->
+    <rect x="1290" y="170" width="420" height="760" rx="28" fill="#1e202e" stroke="#3d4666" stroke-width="3"/>
+    <rect x="1440" y="182" width="120" height="18" rx="9" fill="#16161e"/>
+    <!-- collapsed pull strip -->
+    <rect x="1304" y="212" width="392" height="26" fill="#16161e" stroke="#3d4666" stroke-width="1"/>
+    <text x="1500" y="231" text-anchor="middle" fill="#f7768e" font-size="14" font-weight="bold">▾ 2 waiting</text>
+    <!-- rail -->
+    <rect x="1304" y="238" width="392" height="52" fill="#1e202e"/>
+    <rect x="1318" y="250" width="120" height="30" rx="15" fill="#16161e" stroke="#7aa2f7" stroke-width="1.5"/>
+    <rect x="1448" y="250" width="120" height="30" rx="15" fill="#16161e" stroke="#565f89" stroke-width="1"/>
+    <!-- transcript (taller) -->
+    <rect x="1318" y="310" width="300" height="16" rx="4" fill="#3d4666"/>
+    <rect x="1318" y="340" width="360" height="16" rx="4" fill="#3d4666"/>
+    <rect x="1318" y="370" width="250" height="16" rx="4" fill="#3d4666"/>
+    <rect x="1318" y="400" width="340" height="16" rx="4" fill="#3d4666"/>
+    <rect x="1318" y="430" width="200" height="16" rx="4" fill="#3d4666"/>
+    <rect x="1318" y="460" width="320" height="16" rx="4" fill="#3d4666"/>
+    <rect x="1318" y="490" width="280" height="16" rx="4" fill="#3d4666"/>
+    <rect x="1318" y="520" width="330" height="16" rx="4" fill="#9ece6a"/>
+    <rect x="1318" y="550" width="240" height="16" rx="4" fill="#9ece6a"/>
+    <rect x="1318" y="580" width="300" height="16" rx="4" fill="#9ece6a"/>
+    <!-- input + keyboard -->
+    <rect x="1304" y="612" width="392" height="48" rx="8" fill="#16161e" stroke="#3d4666" stroke-width="1"/>
+    <text x="1322" y="642" fill="#565f89" font-size="14" font-style="italic">Message…</text>
+    <rect x="1304" y="672" width="392" height="246" fill="#1e202e"/>
+    <text x="1500" y="800" text-anchor="middle" fill="#565f89" font-size="16">software keyboard</text>
+
+    <!-- annotation -->
+    <rect x="1150" y="960" width="700" height="130" rx="12" fill="#1e202e" stroke="#565f89" stroke-width="1.5"/>
+    <text x="1180" y="998" fill="#9ece6a" font-size="19" font-weight="bold">Tap the chevron: header → slim pull strip</text>
+    <text x="1180" y="1030" fill="#c0caf5" font-size="17">- ~3 extra transcript lines; safe-area inset preserved</text>
+    <text x="1180" y="1060" fill="#c0caf5" font-size="17">- strip tints + shows "▾ N waiting" when agents are blocked</text>
+  </g>
+
+  <!-- mechanism strip (kept clear of the divider band) -->
+  <text x="500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">ToggleHeaderCollapsed · persisted in localStorage</text>
+  <text x="1500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">CSS scoped to ≤768px — desktop never collapses</text>
+
+  <!-- Footer limitation -->
+  <text x="1000" y="1190" text-anchor="middle" fill="#565f89" font-size="15" font-style="italic">Limitation: manual toggle only — no auto-hide on scroll; while collapsed, Launch/Settings need one extra tap to reach.</text>
+</svg>

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -10,8 +10,8 @@ use super::session_order;
 use super::session_rail::{ActivityRef, AgentMessageBroadcast, BroadcastRef, SessionRail};
 use super::session_view::SessionView;
 use super::types::{
-    load_group_by_host, load_hidden_sessions, load_inactive_hidden, load_rail_position,
-    save_hidden_sessions, save_inactive_hidden,
+    load_group_by_host, load_header_collapsed, load_hidden_sessions, load_inactive_hidden,
+    load_rail_position, save_header_collapsed, save_hidden_sessions, save_inactive_hidden,
 };
 use crate::components::{
     ConfirmModal, ConfirmModalStyle, HelpOverlay, LaunchDialog, TurnMetricsHeaderPill,
@@ -93,6 +93,7 @@ pub fn dashboard_page() -> Html {
             load_inactive_hidden(),
             load_rail_position(),
             load_group_by_host(),
+            load_header_collapsed(),
         )
     });
     // Focus is tracked by `session_id` (the source of truth), not by array
@@ -389,6 +390,14 @@ pub fn dashboard_page() -> Html {
         })
     };
 
+    let toggle_header_collapsed = {
+        let ui_state = ui_state.clone();
+        Callback::from(move |_: MouseEvent| {
+            save_header_collapsed(!ui_state.header_collapsed);
+            ui_state.dispatch(DashboardUiAction::ToggleHeaderCollapsed);
+        })
+    };
+
     let toggle_launch_dialog = {
         let ui_state = ui_state.clone();
         Callback::from(move |_: MouseEvent| {
@@ -654,8 +663,16 @@ pub fn dashboard_page() -> Html {
                 }
             }
 
-            // Header
-            <header class="focus-flow-header">
+            // Header. On phones the collapse toggle shrinks it to a slim
+            // full-width pull strip (title and actions hidden) for vertical
+            // space; the strip tints when sessions await permission so the
+            // collapsed header never hides that signal. Desktop CSS ignores
+            // both the toggle and the `collapsed` class.
+            <header class={classes!(
+                "focus-flow-header",
+                ui_state.header_collapsed.then_some("collapsed"),
+                (ui_state.header_collapsed && waiting_count > 0).then_some("has-waiting"),
+            )}>
                 <h1>{ app_title.clone() }</h1>
                 <div class="header-actions">
                     <TurnMetricsHeaderPill metrics={ws_hook.recent_turn_metrics.clone()} />
@@ -710,6 +727,24 @@ pub fn dashboard_page() -> Html {
                         { "Logout" }
                     </button>
                 </div>
+                <button
+                    class="header-collapse-toggle"
+                    onclick={toggle_header_collapsed}
+                    title={if ui_state.header_collapsed { "Expand header" } else { "Collapse header" }}
+                    aria-label={if ui_state.header_collapsed { "Expand header" } else { "Collapse header" }}
+                >
+                    {
+                        if ui_state.header_collapsed {
+                            if waiting_count > 0 {
+                                format!("▾ {waiting_count} waiting")
+                            } else {
+                                "▾".to_string()
+                            }
+                        } else {
+                            "▴".to_string()
+                        }
+                    }
+                </button>
             </header>
 
             // Launch session dialog

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -663,11 +663,11 @@ pub fn dashboard_page() -> Html {
                 }
             }
 
-            // Header. On phones the collapse toggle shrinks it to a slim
-            // full-width pull strip (title and actions hidden) for vertical
-            // space; the strip tints when sessions await permission so the
-            // collapsed header never hides that signal. Desktop CSS ignores
-            // both the toggle and the `collapsed` class.
+            // Header. The collapse toggle shrinks it to a slim full-width
+            // pull strip (title and actions hidden) for vertical space —
+            // most valuable on phones, available everywhere. The strip tints
+            // when sessions await permission so the collapsed header never
+            // hides that signal.
             <header class={classes!(
                 "focus-flow-header",
                 ui_state.header_collapsed.then_some("collapsed"),

--- a/frontend/src/pages/dashboard/page_state.rs
+++ b/frontend/src/pages/dashboard/page_state.rs
@@ -191,11 +191,20 @@ pub(super) struct DashboardUiState {
     pub rail_position: RailPosition,
     /// Opt-in: group the session rail's pills into per-host sections.
     pub group_by_host: bool,
+    /// Mobile-only: header collapsed to its slim pull strip. The flag is
+    /// stored regardless of viewport, but the collapsed CSS is scoped to the
+    /// phone breakpoint so desktop always shows the full header.
+    pub header_collapsed: bool,
     pub pending_leave: Option<Uuid>,
 }
 
 impl DashboardUiState {
-    pub fn new(inactive_hidden: bool, rail_position: RailPosition, group_by_host: bool) -> Self {
+    pub fn new(
+        inactive_hidden: bool,
+        rail_position: RailPosition,
+        group_by_host: bool,
+        header_collapsed: bool,
+    ) -> Self {
         Self {
             show_launch_dialog: false,
             show_admin: false,
@@ -206,6 +215,7 @@ impl DashboardUiState {
             inactive_hidden,
             rail_position,
             group_by_host,
+            header_collapsed,
             pending_leave: None,
         }
     }
@@ -228,6 +238,7 @@ pub(super) enum DashboardUiAction {
     SetInactiveHidden(bool),
     SetRailPosition(RailPosition),
     SetGroupByHost(bool),
+    ToggleHeaderCollapsed,
     RequestLeave(Uuid),
     ClearPendingLeave,
 }
@@ -284,6 +295,9 @@ impl Reducible for DashboardUiState {
             }
             DashboardUiAction::SetGroupByHost(enabled) => {
                 state.group_by_host = enabled;
+            }
+            DashboardUiAction::ToggleHeaderCollapsed => {
+                state.header_collapsed = !state.header_collapsed;
             }
             DashboardUiAction::RequestLeave(session_id) => {
                 state.pending_leave = Some(session_id);
@@ -480,7 +494,7 @@ mod tests {
     /// the list rather than whatever was last viewed.
     #[test]
     fn ui_reducer_tracks_the_history_overlay() {
-        let state = DashboardUiState::new(false, RailPosition::Top, false);
+        let state = DashboardUiState::new(false, RailPosition::Top, false, false);
         let state = reduce_ui(state, DashboardUiAction::ShowHistory);
         let state = state.reduce(DashboardUiAction::OpenHistorySession(
             "u".into(),
@@ -496,7 +510,7 @@ mod tests {
 
     #[test]
     fn ui_reducer_controls_modal_visibility() {
-        let state = DashboardUiState::new(false, RailPosition::Top, false);
+        let state = DashboardUiState::new(false, RailPosition::Top, false, false);
         let state = reduce_ui(state, DashboardUiAction::ToggleLaunchDialog);
         assert!(state.show_launch_dialog);
 
@@ -521,7 +535,7 @@ mod tests {
 
     #[test]
     fn ui_reducer_tracks_preferences() {
-        let state = DashboardUiState::new(false, RailPosition::Top, false);
+        let state = DashboardUiState::new(false, RailPosition::Top, false, false);
         let state = reduce_ui(state, DashboardUiAction::SetInactiveHidden(true));
         let state = state.reduce(DashboardUiAction::SetRailPosition(RailPosition::Left));
         let state = state.reduce(DashboardUiAction::SetGroupByHost(true));
@@ -529,13 +543,18 @@ mod tests {
         assert!(state.inactive_hidden);
         assert_eq!(state.rail_position, RailPosition::Left);
         assert!(state.group_by_host);
+
+        let state = state.reduce(DashboardUiAction::ToggleHeaderCollapsed);
+        assert!(state.header_collapsed);
+        let state = state.reduce(DashboardUiAction::ToggleHeaderCollapsed);
+        assert!(!state.header_collapsed);
     }
 
     #[test]
     /// Leave still routes through a modal, so the reducer still tracks it.
     /// Closing a session does not: the rail menu arms and fires it locally.
     fn ui_reducer_tracks_pending_confirmations() {
-        let state = DashboardUiState::new(false, RailPosition::Top, false);
+        let state = DashboardUiState::new(false, RailPosition::Top, false, false);
         let state = reduce_ui(state, DashboardUiAction::RequestLeave(id(1)));
         assert_eq!(state.pending_leave, Some(id(1)));
 

--- a/frontend/src/pages/dashboard/page_state.rs
+++ b/frontend/src/pages/dashboard/page_state.rs
@@ -191,9 +191,8 @@ pub(super) struct DashboardUiState {
     pub rail_position: RailPosition,
     /// Opt-in: group the session rail's pills into per-host sections.
     pub group_by_host: bool,
-    /// Mobile-only: header collapsed to its slim pull strip. The flag is
-    /// stored regardless of viewport, but the collapsed CSS is scoped to the
-    /// phone breakpoint so desktop always shows the full header.
+    /// Header collapsed to its slim pull strip (any viewport). The strip is
+    /// itself the expand affordance, so the header can never be lost.
     pub header_collapsed: bool,
     pub pending_leave: Option<Uuid>,
 }

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -28,7 +28,7 @@ pub const SESSION_RAIL_GROUP_BY_HOST_STORAGE_KEY: &str = "claude-portal-session-
 /// Storage key for the opt-in vim editing mode in localStorage
 pub const VIM_MODE_STORAGE_KEY: &str = "claude-portal-vim-mode";
 
-/// Whether the dashboard header is collapsed to its slim strip (mobile only).
+/// Whether the dashboard header is collapsed to its slim pull strip.
 pub const HEADER_COLLAPSED_STORAGE_KEY: &str = "claude-portal-header-collapsed";
 /// Maximum number of messages held in the frontend live buffer.
 ///
@@ -143,15 +143,14 @@ pub fn save_inactive_hidden(hidden: bool) {
     save_bool_pref(INACTIVE_HIDDEN_STORAGE_KEY, hidden);
 }
 
-/// Load whether the dashboard header is collapsed to its slim mobile strip
-/// (default: expanded). Desktop ignores the flag entirely — the collapsed
-/// styles are scoped to the mobile breakpoint — so a phone preference can
-/// never lose the header on a desktop browser sharing the same storage.
+/// Load whether the dashboard header is collapsed to its slim pull strip
+/// (default: expanded). Applies on every viewport; the strip itself is the
+/// expand affordance, so the header can never be lost.
 pub fn load_header_collapsed() -> bool {
     load_bool_pref(HEADER_COLLAPSED_STORAGE_KEY)
 }
 
-/// Save the mobile header-collapsed preference to localStorage.
+/// Save the header-collapsed preference to localStorage.
 pub fn save_header_collapsed(collapsed: bool) {
     save_bool_pref(HEADER_COLLAPSED_STORAGE_KEY, collapsed);
 }

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -27,6 +27,9 @@ pub const SESSION_RAIL_GROUP_BY_HOST_STORAGE_KEY: &str = "claude-portal-session-
 
 /// Storage key for the opt-in vim editing mode in localStorage
 pub const VIM_MODE_STORAGE_KEY: &str = "claude-portal-vim-mode";
+
+/// Whether the dashboard header is collapsed to its slim strip (mobile only).
+pub const HEADER_COLLAPSED_STORAGE_KEY: &str = "claude-portal-header-collapsed";
 /// Maximum number of messages held in the frontend live buffer.
 ///
 /// A **rendering** budget, not a history budget. Every buffered record is a live
@@ -138,6 +141,19 @@ pub fn load_inactive_hidden() -> bool {
 /// Save inactive hidden state to localStorage
 pub fn save_inactive_hidden(hidden: bool) {
     save_bool_pref(INACTIVE_HIDDEN_STORAGE_KEY, hidden);
+}
+
+/// Load whether the dashboard header is collapsed to its slim mobile strip
+/// (default: expanded). Desktop ignores the flag entirely — the collapsed
+/// styles are scoped to the mobile breakpoint — so a phone preference can
+/// never lose the header on a desktop browser sharing the same storage.
+pub fn load_header_collapsed() -> bool {
+    load_bool_pref(HEADER_COLLAPSED_STORAGE_KEY)
+}
+
+/// Save the mobile header-collapsed preference to localStorage.
+pub fn save_header_collapsed(collapsed: bool) {
+    save_bool_pref(HEADER_COLLAPSED_STORAGE_KEY, collapsed);
 }
 
 /// Load whether vim editing mode is enabled from localStorage (default: off).

--- a/frontend/styles/session-layout.css
+++ b/frontend/styles/session-layout.css
@@ -39,6 +39,13 @@
     gap: 1rem;
 }
 
+/* Mobile-only affordance: desktop always shows the full header, so the
+   collapse toggle (and the `.collapsed` state it drives, styled in
+   session-mobile.css) is hidden above the phone breakpoint. */
+.focus-flow-header .header-collapse-toggle {
+    display: none;
+}
+
 .total-spend-badge {
     background: rgba(158, 206, 106, 0.2);
     color: var(--success);

--- a/frontend/styles/session-layout.css
+++ b/frontend/styles/session-layout.css
@@ -39,11 +39,44 @@
     gap: 1rem;
 }
 
-/* Mobile-only affordance: desktop always shows the full header, so the
-   collapse toggle (and the `.collapsed` state it drives, styled in
-   session-mobile.css) is hidden above the phone breakpoint. */
+/* Collapse toggle: chevron at the end of the header row, on every viewport.
+   Collapsed, the header shrinks to a slim full-width pull strip (title and
+   actions hidden) that doubles as the expand target. The top padding keeps
+   the notch safe-area inset via env() — 0 on desktop, restated with the
+   side insets in session-mobile.css for phones. */
 .focus-flow-header .header-collapse-toggle {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    line-height: 1;
+    padding: 0.3rem 0.5rem;
+    cursor: pointer;
+}
+
+.focus-flow-header .header-collapse-toggle:hover {
+    color: var(--text-primary);
+}
+
+.focus-flow-header.collapsed {
+    padding: max(0px, env(safe-area-inset-top)) 1.5rem 0;
+}
+
+.focus-flow-header.collapsed h1,
+.focus-flow-header.collapsed .header-actions {
     display: none;
+}
+
+.focus-flow-header.collapsed .header-collapse-toggle {
+    width: 100%;
+    padding: 0.15rem 0 0.25rem;
+}
+
+/* Collapsed must not hide the "agent is blocked on you" signal: the pull
+   strip takes the waiting badge's color and shows the count inline. */
+.focus-flow-header.collapsed.has-waiting .header-collapse-toggle {
+    color: var(--error);
+    font-weight: 600;
 }
 
 .total-spend-badge {

--- a/frontend/styles/session-mobile.css
+++ b/frontend/styles/session-mobile.css
@@ -69,43 +69,14 @@
         gap: 0.5rem;
     }
 
-    /* Collapse toggle: sits at the end of the expanded header row; when the
-       header is collapsed it becomes the whole header — a slim full-width
-       pull strip (comfortable tap target despite its height) that keeps only
-       the safe-area inset above it. */
-    .focus-flow-header .header-collapse-toggle {
-        display: block;
-        background: none;
-        border: none;
-        color: var(--text-muted);
-        font-size: 0.8rem;
-        line-height: 1;
-        padding: 0.3rem 0.5rem;
-        cursor: pointer;
-    }
-
+    /* Collapsed pull strip: restate the side safe-area insets this block's
+       expanded-header rule above would otherwise provide. Everything else
+       (hiding h1/actions, full-width toggle, waiting tint) is viewport-
+       independent and lives in session-layout.css. */
     .focus-flow-header.collapsed {
-        /* Keep the notch/Dynamic Island inset; drop all other chrome. */
         padding: max(0px, env(safe-area-inset-top)) max(0.75rem, env(safe-area-inset-right)) 0
             max(0.75rem, env(safe-area-inset-left));
         gap: 0;
-    }
-
-    .focus-flow-header.collapsed h1,
-    .focus-flow-header.collapsed .header-actions {
-        display: none;
-    }
-
-    .focus-flow-header.collapsed .header-collapse-toggle {
-        width: 100%;
-        padding: 0.15rem 0 0.25rem;
-    }
-
-    /* Collapsed must not hide the "agent is blocked on you" signal: the pull
-       strip takes the waiting badge's color and shows the count inline. */
-    .focus-flow-header.collapsed.has-waiting .header-collapse-toggle {
-        color: var(--error);
-        font-weight: 600;
     }
 
     .total-spend-badge,

--- a/frontend/styles/session-mobile.css
+++ b/frontend/styles/session-mobile.css
@@ -69,6 +69,45 @@
         gap: 0.5rem;
     }
 
+    /* Collapse toggle: sits at the end of the expanded header row; when the
+       header is collapsed it becomes the whole header — a slim full-width
+       pull strip (comfortable tap target despite its height) that keeps only
+       the safe-area inset above it. */
+    .focus-flow-header .header-collapse-toggle {
+        display: block;
+        background: none;
+        border: none;
+        color: var(--text-muted);
+        font-size: 0.8rem;
+        line-height: 1;
+        padding: 0.3rem 0.5rem;
+        cursor: pointer;
+    }
+
+    .focus-flow-header.collapsed {
+        /* Keep the notch/Dynamic Island inset; drop all other chrome. */
+        padding: max(0px, env(safe-area-inset-top)) max(0.75rem, env(safe-area-inset-right)) 0
+            max(0.75rem, env(safe-area-inset-left));
+        gap: 0;
+    }
+
+    .focus-flow-header.collapsed h1,
+    .focus-flow-header.collapsed .header-actions {
+        display: none;
+    }
+
+    .focus-flow-header.collapsed .header-collapse-toggle {
+        width: 100%;
+        padding: 0.15rem 0 0.25rem;
+    }
+
+    /* Collapsed must not hide the "agent is blocked on you" signal: the pull
+       strip takes the waiting badge's color and shows the count inline. */
+    .focus-flow-header.collapsed.has-waiting .header-collapse-toggle {
+        color: var(--error);
+        font-weight: 600;
+    }
+
     .total-spend-badge,
     .waiting-badge {
         font-size: 0.7rem;


### PR DESCRIPTION
![visual](https://raw.githubusercontent.com/meawoppl/agent-portal/mobile-header-collapse/.0-pr-viz/001911.svg)

On phones the dashboard header can wrap to two rows and eat a meaningful slice of an already-short viewport. This adds a collapse affordance, mobile-only:

- A chevron toggle at the end of the header row (hidden on desktop). Collapsed, the header shrinks to a slim full-width pull strip — title and actions hidden, only the safe-area inset above it — so the transcript gets the space back.
- The "blocked on you" signal survives collapsing: when sessions await permission, the strip tints `--error` and shows `▾ N waiting` inline.
- Preference persists in localStorage (`claude-portal-header-collapsed`), following the existing `load_bool_pref` pattern. The collapsed CSS is scoped to the ≤768px breakpoint, so a phone preference can never lose the header on a desktop browser sharing storage.
- State rides `DashboardUiState` with a `ToggleHeaderCollapsed` action; reducer covered in the existing preferences test.
