### PR TITLE
Add hold-mic-open setting for voice input pauses

### DIFF
--- a/.0-pr-viz/001914.svg
+++ b/.0-pr-viz/001914.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2000" height="1200" viewBox="0 0 2000 1200" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <!-- Thesis -->
+  <text x="1000" y="64" text-anchor="middle" fill="#c0caf5" font-size="34" font-weight="bold">Voice input can now hold the mic open across pauses — no more mid-thought cutoffs</text>
+
+  <!-- BEFORE / AFTER labels -->
+  <text x="500" y="126" text-anchor="middle" fill="#f7768e" font-size="26" font-weight="bold" letter-spacing="4">BEFORE</text>
+  <text x="1500" y="126" text-anchor="middle" fill="#9ece6a" font-size="26" font-weight="bold" letter-spacing="4">AFTER</text>
+  <line x1="1000" y1="96" x2="1000" y2="1140" stroke="#565f89" stroke-width="2" stroke-dasharray="8 8"/>
+
+  <!-- BEFORE: speech timeline cut at first pause -->
+  <g>
+    <text x="180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">Dictating one message with a natural pause:</text>
+
+    <!-- timeline -->
+    <line x1="180" y1="300" x2="860" y2="300" stroke="#3d4666" stroke-width="2"/>
+    <!-- speech block 1 -->
+    <rect x="180" y="272" width="240" height="56" rx="8" fill="#1e202e" stroke="#7aa2f7" stroke-width="2"/>
+    <text x="300" y="306" text-anchor="middle" fill="#7aa2f7" font-size="16">"refactor the io task…"</text>
+    <!-- pause -->
+    <rect x="430" y="284" width="90" height="32" rx="6" fill="#1e202e" stroke="#e0af68" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text x="475" y="305" text-anchor="middle" fill="#e0af68" font-size="14">~1s pause</text>
+    <!-- cutoff -->
+    <line x1="540" y1="250" x2="540" y2="350" stroke="#f7768e" stroke-width="3"/>
+    <text x="556" y="268" fill="#f7768e" font-size="16" font-weight="bold">endpointer fires: mic stops, message auto-sends</text>
+    <!-- lost speech -->
+    <rect x="560" y="284" width="270" height="32" rx="6" fill="#1e202e" stroke="#565f89" stroke-width="1"/>
+    <text x="695" y="305" text-anchor="middle" fill="#565f89" font-size="14">"…and also fix the tests" (lost)</text>
+
+    <!-- explanation card -->
+    <rect x="150" y="420" width="700" height="240" rx="12" fill="#1e202e" stroke="#565f89" stroke-width="1.5"/>
+    <text x="180" y="458" fill="#f7768e" font-size="19" font-weight="bold">The gap is the browser's, and it is not adjustable:</text>
+    <text x="180" y="494" fill="#c0caf5" font-size="17">- Web Speech API exposes no silence-timeout knob at all</text>
+    <text x="180" y="524" fill="#c0caf5" font-size="17">- voice_input.rs pinned continuous = false (one tap, one utterance)</text>
+    <text x="180" y="554" fill="#c0caf5" font-size="17">- so end-of-speech detection belonged entirely to the browser</text>
+    <text x="180" y="584" fill="#c0caf5" font-size="17">- pausing to think = message sent early, rest of the thought dropped</text>
+    <rect x="180" y="606" width="640" height="34" rx="6" fill="#16161e"/>
+    <text x="200" y="629" fill="#565f89" font-size="14" font-family="monospace">set_bool("continuous", false);  // browser decides when you're done</text>
+  </g>
+
+  <!-- AFTER: hold-open timeline -->
+  <g>
+    <text x="1180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">Hold-open mode: you decide when you're done</text>
+
+    <!-- timeline -->
+    <line x1="1180" y1="300" x2="1860" y2="300" stroke="#3d4666" stroke-width="2"/>
+    <rect x="1180" y="272" width="220" height="56" rx="8" fill="#1e202e" stroke="#7aa2f7" stroke-width="2"/>
+    <text x="1290" y="306" text-anchor="middle" fill="#7aa2f7" font-size="16">"refactor the io task…"</text>
+    <rect x="1410" y="284" width="90" height="32" rx="6" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text x="1455" y="305" text-anchor="middle" fill="#9ece6a" font-size="14">pause ok</text>
+    <rect x="1510" y="272" width="230" height="56" rx="8" fill="#1e202e" stroke="#7aa2f7" stroke-width="2"/>
+    <text x="1625" y="306" text-anchor="middle" fill="#7aa2f7" font-size="16">"…and also fix the tests"</text>
+    <!-- tap stop -->
+    <circle cx="1800" cy="300" r="26" fill="#1e202e" stroke="#9ece6a" stroke-width="2.5"/>
+    <text x="1800" y="307" text-anchor="middle" fill="#9ece6a" font-size="15" font-weight="bold">tap</text>
+    <text x="1800" y="356" text-anchor="middle" fill="#9ece6a" font-size="14">one full message sends</text>
+
+    <!-- settings card -->
+    <rect x="1150" y="420" width="700" height="240" rx="12" fill="#1e202e" stroke="#565f89" stroke-width="1.5"/>
+    <text x="1180" y="458" fill="#9ece6a" font-size="19" font-weight="bold">Settings → Appearance → "Voice input: hold mic open"</text>
+    <text x="1180" y="494" fill="#c0caf5" font-size="17">- opt-in; default keeps today's auto-stop + auto-send behavior</text>
+    <text x="1180" y="524" fill="#c0caf5" font-size="17">- continuous = true: finals accumulate across pauses until you tap</text>
+    <text x="1180" y="554" fill="#c0caf5" font-size="17">- safety ceiling 60s → 5min so long dictation isn't truncated</text>
+    <text x="1180" y="584" fill="#c0caf5" font-size="17">- server-STT recorder path unchanged (already records until tapped)</text>
+    <rect x="1180" y="606" width="640" height="34" rx="6" fill="#16161e"/>
+    <text x="1200" y="629" fill="#565f89" font-size="14" font-family="monospace">set_bool("continuous", load_voice_hold_open());  // your call now</text>
+  </g>
+
+  <!-- bottom mechanism cards -->
+  <rect x="150" y="720" width="700" height="120" rx="12" fill="#1e202e" stroke="#bb9af7" stroke-width="1.5"/>
+  <text x="500" y="762" text-anchor="middle" fill="#bb9af7" font-size="18" font-weight="bold">Why iOS made this easy</text>
+  <text x="500" y="794" text-anchor="middle" fill="#c0caf5" font-size="16">iOS Safari never auto-ends in continuous mode — formerly the</text>
+  <text x="500" y="820" text-anchor="middle" fill="#c0caf5" font-size="16">reason to avoid it (#840), here exactly the wanted behavior.</text>
+
+  <rect x="1150" y="720" width="700" height="120" rx="12" fill="#1e202e" stroke="#7dcfff" stroke-width="1.5"/>
+  <text x="1500" y="762" text-anchor="middle" fill="#7dcfff" font-size="18" font-weight="bold">No new plumbing</text>
+  <text x="1500" y="794" text-anchor="middle" fill="#c0caf5" font-size="16">final_acc already space-joins multiple final results; onend still</text>
+  <text x="1500" y="820" text-anchor="middle" fill="#c0caf5" font-size="16">drains it into one Final → one transcription → one send.</text>
+
+  <!-- storage note -->
+  <text x="500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">Persisted as claude-portal-voice-hold-open (localStorage)</text>
+  <text x="1500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">Applies on next recording; watchdogs otherwise unchanged</text>
+
+  <!-- Footer limitation -->
+  <text x="1000" y="1190" text-anchor="middle" fill="#565f89" font-size="15" font-style="italic">Limitation: a global toggle, not a per-recording gesture — and hold-open mode ends only on tap, so a forgotten mic runs until the 5-minute ceiling.</text>
+</svg>

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -43,4 +43,4 @@ pub use proxy_token_setup::ProxyTokenSetup;
 pub use schedule_dialog::ScheduleDialog;
 pub use share_dialog::ShareDialog;
 pub use turn_metrics_pill::TurnMetricsHeaderPill;
-pub use voice_input::VoiceInput;
+pub use voice_input::{load_voice_hold_open, save_voice_hold_open, VoiceInput};

--- a/frontend/src/components/voice_input.rs
+++ b/frontend/src/components/voice_input.rs
@@ -204,6 +204,42 @@ const STOP_WATCHDOG_MS: u32 = 1500;
 /// holding the mic indicator on iOS.
 const MAX_SESSION_MS: u32 = 60_000;
 
+/// Session ceiling in hold-open mode, where the whole point is dictating
+/// through long pauses — still bounded, just generously.
+const MAX_SESSION_HOLD_OPEN_MS: u32 = 300_000;
+
+/// Storage key for the "hold the mic open across pauses" preference.
+const VOICE_HOLD_OPEN_STORAGE_KEY: &str = "claude-portal-voice-hold-open";
+
+/// Whether the browser recognizer should keep listening across pauses
+/// (`continuous = true`) instead of letting the browser's end-of-speech
+/// detector stop the session (default). The browser endpointer's silence
+/// gap is aggressive and not configurable — this preference is the only
+/// lever the Web Speech API offers. The server-STT recorder path already
+/// records until tapped, so this only changes the browser path.
+pub fn load_voice_hold_open() -> bool {
+    utils::storage_get(VOICE_HOLD_OPEN_STORAGE_KEY)
+        .map(|v| v == "true")
+        .unwrap_or(false)
+}
+
+/// Save the hold-open preference to localStorage.
+pub fn save_voice_hold_open(enabled: bool) {
+    utils::storage_set(
+        VOICE_HOLD_OPEN_STORAGE_KEY,
+        if enabled { "true" } else { "false" },
+    );
+}
+
+/// The active session ceiling under the current hold-open preference.
+fn max_session_ms() -> u32 {
+    if load_voice_hold_open() {
+        MAX_SESSION_HOLD_OPEN_MS
+    } else {
+        MAX_SESSION_MS
+    }
+}
+
 /// How long to wait after `MediaRecorder::stop()` for the final chunk before
 /// declaring the recording lost. Assembling a blob is fast; this only has to
 /// beat a wedged recorder, and it deliberately does not cover the upload,
@@ -563,7 +599,7 @@ impl Component for VoiceInput {
                 if self.capture.is_some() {
                     log::warn!(
                         "Voice session exceeded {}ms — auto-stopping",
-                        MAX_SESSION_MS
+                        max_session_ms()
                     );
                     self.stop_capture(ctx);
                     true
@@ -687,7 +723,7 @@ impl VoiceInput {
     /// Arm the safety stop that keeps a wedged capture from holding the mic.
     fn arm_max_duration(&mut self, ctx: &Context<Self>) {
         let link = ctx.link().clone();
-        self.max_duration_timer = Some(Timeout::new(MAX_SESSION_MS, move || {
+        self.max_duration_timer = Some(Timeout::new(max_session_ms(), move || {
             link.send_message(VoiceInputMsg::MaxDurationReached);
         }));
     }
@@ -947,10 +983,15 @@ async fn start_session_async(
             &JsValue::from_bool(val),
         );
     };
-    // continuous=false: single-utterance per tap. With true, iOS Safari
-    // never auto-ends and our SessionView's "auto-send on Final" already
-    // implies a one-tap-one-utterance UX anyway. See #840 follow-up.
-    set_bool("continuous", false);
+    // Default (continuous=false): single-utterance per tap — the browser's
+    // end-of-speech detector stops the session, and "auto-send on Final"
+    // gives a one-tap-one-utterance UX (#840 follow-up). That detector's
+    // silence gap is aggressive and not configurable, so users who dictate
+    // with pauses can opt into hold-open mode (continuous=true): the mic
+    // stays open across pauses — accumulating final results — until they
+    // tap again (iOS Safari never auto-ends in continuous mode, which is
+    // exactly the behavior wanted here).
+    set_bool("continuous", load_voice_hold_open());
     set_bool("interimResults", true);
 
     let lang = document_language().unwrap_or_else(|| "en-US".to_string());

--- a/frontend/src/pages/settings/appearance_panel.rs
+++ b/frontend/src/pages/settings/appearance_panel.rs
@@ -1,3 +1,4 @@
+use crate::components::{load_voice_hold_open, save_voice_hold_open};
 use crate::pages::dashboard::{
     load_group_by_host, load_rail_position, load_vim_mode, save_group_by_host, save_rail_position,
     save_vim_mode, RailPosition,
@@ -16,6 +17,7 @@ pub fn appearance_panel() -> Html {
     let position = use_state(load_rail_position);
     let vim_enabled = use_state(load_vim_mode);
     let group_by_host = use_state(load_group_by_host);
+    let voice_hold_open = use_state(load_voice_hold_open);
 
     let on_toggle_group_by_host = {
         let group_by_host = group_by_host.clone();
@@ -24,6 +26,16 @@ pub fn appearance_panel() -> Html {
             let enabled = input.checked();
             save_group_by_host(enabled);
             group_by_host.set(enabled);
+        })
+    };
+
+    let on_toggle_voice_hold_open = {
+        let voice_hold_open = voice_hold_open.clone();
+        Callback::from(move |e: Event| {
+            let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+            let enabled = input.checked();
+            save_voice_hold_open(enabled);
+            voice_hold_open.set(enabled);
         })
     };
 
@@ -108,6 +120,21 @@ pub fn appearance_panel() -> Html {
                         onchange={on_toggle_vim}
                     />
                     <span>{ if *vim_enabled { "Enabled" } else { "Disabled" } }</span>
+                </label>
+            </div>
+
+            <div class="appearance-setting">
+                <h3>{ "Voice input: hold mic open" }</h3>
+                <p class="setting-description">
+                    { "By default the browser stops listening after a short pause                        in speech, and that silence gap is not adjustable. Enable                        this to keep the mic open across pauses — dictation                        continues until you tap the mic again (or 5 minutes                        elapse). Applies to browser speech recognition;                        server-side transcription already records until tapped.                        Takes effect on the next recording." }
+                </p>
+                <label class="toggle-label">
+                    <input
+                        type="checkbox"
+                        checked={*voice_hold_open}
+                        onchange={on_toggle_voice_hold_open}
+                    />
+                    <span>{ if *voice_hold_open { "Enabled" } else { "Disabled" } }</span>
                 </label>
             </div>
         </section>


### PR DESCRIPTION
![visual](https://raw.githubusercontent.com/meawoppl/agent-portal/voice-hold-open/.0-pr-viz/001914.svg)

The browser's Web Speech endpointer ends recognition after a short pause in speech, and that silence gap is **not configurable** — `continuous = true` is the only lever the API offers. Users who dictate with natural pauses get cut off mid-thought.

- New opt-in toggle, **Settings → Appearance → "Voice input: hold mic open"** (localStorage, same `toggle-label` pattern as vim mode). Off by default, preserving the current one-tap-one-utterance auto-send UX.
- Enabled, the recognizer runs with `continuous = true`: final results accumulate across pauses (the existing `final_acc` join already handles multi-final sessions) and dictation ends when the user taps the mic again. On iOS Safari continuous mode never auto-ends — previously the reason to avoid it, here exactly the wanted behavior.
- The runaway-session safety ceiling stretches from 60s to 5 minutes in hold-open mode so long dictation isn't truncated; all other watchdogs unchanged.
- Server-STT (`MediaRecorder`) path is untouched — it already records until tapped.
