### PR TITLE
Fix dashboard reload thundering herd

### DIFF
--- a/.0-pr-viz/001917.svg
+++ b/.0-pr-viz/001917.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2000" height="1200" viewBox="0 0 2000 1200" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <!-- Thesis -->
+  <text x="1000" y="64" text-anchor="middle" fill="#c0caf5" font-size="34" font-weight="bold">Reload herd fixed: focused session first, the rest drip in, 90% less JSON parsed</text>
+
+  <!-- BEFORE / AFTER labels -->
+  <text x="500" y="126" text-anchor="middle" fill="#f7768e" font-size="26" font-weight="bold" letter-spacing="4">BEFORE</text>
+  <text x="1500" y="126" text-anchor="middle" fill="#9ece6a" font-size="26" font-weight="bold" letter-spacing="4">AFTER</text>
+  <line x1="1000" y1="96" x2="1000" y2="1140" stroke="#565f89" stroke-width="2" stroke-dasharray="8 8"/>
+
+  <!-- BEFORE: the herd -->
+  <g>
+    <text x="180" y="196" fill="#a9b1d6" font-size="19" font-weight="bold">Reload with 8 sessions — one render flush:</text>
+
+    <!-- stacked simultaneous request bars -->
+    <text x="180" y="248" fill="#7aa2f7" font-size="15" font-family="monospace">s1</text>
+    <rect x="230" y="232" width="560" height="24" rx="5" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="510" y="249" text-anchor="middle" fill="#f7768e" font-size="13">1000 msgs + metrics + WS</text>
+    <text x="180" y="288" fill="#7aa2f7" font-size="15" font-family="monospace">s2</text>
+    <rect x="230" y="272" width="560" height="24" rx="5" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="510" y="289" text-anchor="middle" fill="#f7768e" font-size="13">1000 msgs + metrics + WS</text>
+    <text x="180" y="328" fill="#7aa2f7" font-size="15" font-family="monospace">s3</text>
+    <rect x="230" y="312" width="560" height="24" rx="5" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="510" y="329" text-anchor="middle" fill="#f7768e" font-size="13">1000 msgs + metrics + WS</text>
+    <text x="180" y="368" fill="#7aa2f7" font-size="15" font-family="monospace">s4</text>
+    <rect x="230" y="352" width="560" height="24" rx="5" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="180" y="408" fill="#7aa2f7" font-size="15" font-family="monospace">s5</text>
+    <rect x="230" y="392" width="560" height="24" rx="5" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="180" y="448" fill="#7aa2f7" font-size="15" font-family="monospace">s6</text>
+    <rect x="230" y="432" width="560" height="24" rx="5" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="180" y="488" fill="#7aa2f7" font-size="15" font-family="monospace">s7</text>
+    <rect x="230" y="472" width="560" height="24" rx="5" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="180" y="528" fill="#7aa2f7" font-size="15" font-family="monospace">s8</text>
+    <rect x="230" y="512" width="560" height="24" rx="5" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+
+    <text x="230" y="580" fill="#f7768e" font-size="16" font-weight="bold">16 HTTP requests + 8 sockets at t=0, then the main thread</text>
+    <text x="230" y="606" fill="#f7768e" font-size="16" font-weight="bold">parses 8 × 1000 messages — keeping only 100 of each</text>
+
+    <rect x="150" y="650" width="700" height="220" rx="12" fill="#1e202e" stroke="#565f89" stroke-width="1.5"/>
+    <text x="180" y="688" fill="#a9b1d6" font-size="18" font-weight="bold">Why it felt like "a static page taking forever":</text>
+    <text x="180" y="722" fill="#c0caf5" font-size="16">- page_focus activated every visible session at once</text>
+    <text x="180" y="750" fill="#c0caf5" font-size="16">- fetch limit defaulted to MESSAGE_RETENTION_COUNT (1000)</text>
+    <text x="180" y="778" fill="#c0caf5" font-size="16">- render buffer keeps 100 → ~90% of parse work discarded</text>
+    <text x="180" y="806" fill="#c0caf5" font-size="16">- one WASM thread chewed through it all before feeling responsive</text>
+  </g>
+
+  <!-- AFTER: focused first + drip -->
+  <g>
+    <text x="1180" y="196" fill="#a9b1d6" font-size="19" font-weight="bold">Focused session first, the rest drip in:</text>
+
+    <text x="1180" y="248" fill="#9ece6a" font-size="15" font-family="monospace">s1*</text>
+    <rect x="1240" y="232" width="180" height="24" rx="5" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1330" y="249" text-anchor="middle" fill="#9ece6a" font-size="13">150 msgs → WS live</text>
+
+    <text x="1180" y="288" fill="#7aa2f7" font-size="15" font-family="monospace">s2</text>
+    <rect x="1300" y="272" width="150" height="24" rx="5" fill="#1e202e" stroke="#7aa2f7" stroke-width="1.5"/>
+    <text x="1180" y="328" fill="#7aa2f7" font-size="15" font-family="monospace">s3</text>
+    <rect x="1300" y="312" width="150" height="24" rx="5" fill="#1e202e" stroke="#7aa2f7" stroke-width="1.5"/>
+    <text x="1180" y="368" fill="#7aa2f7" font-size="15" font-family="monospace">s4</text>
+    <rect x="1400" y="352" width="150" height="24" rx="5" fill="#1e202e" stroke="#7aa2f7" stroke-width="1.5"/>
+    <text x="1180" y="408" fill="#7aa2f7" font-size="15" font-family="monospace">s5</text>
+    <rect x="1400" y="392" width="150" height="24" rx="5" fill="#1e202e" stroke="#7aa2f7" stroke-width="1.5"/>
+    <text x="1180" y="448" fill="#7aa2f7" font-size="15" font-family="monospace">s6</text>
+    <rect x="1500" y="432" width="150" height="24" rx="5" fill="#1e202e" stroke="#7aa2f7" stroke-width="1.5"/>
+    <text x="1180" y="488" fill="#7aa2f7" font-size="15" font-family="monospace">s7</text>
+    <rect x="1500" y="472" width="150" height="24" rx="5" fill="#1e202e" stroke="#7aa2f7" stroke-width="1.5"/>
+    <text x="1180" y="528" fill="#7aa2f7" font-size="15" font-family="monospace">s8</text>
+    <rect x="1600" y="512" width="150" height="24" rx="5" fill="#1e202e" stroke="#7aa2f7" stroke-width="1.5"/>
+
+    <text x="1240" y="580" fill="#9ece6a" font-size="16" font-weight="bold">drip: 2 sessions / 400ms, most-recently-messaged first —</text>
+    <text x="1240" y="606" fill="#9ece6a" font-size="16" font-weight="bold">tap any pill and it activates instantly, tick cancelled</text>
+
+    <rect x="1150" y="650" width="700" height="220" rx="12" fill="#1e202e" stroke="#565f89" stroke-width="1.5"/>
+    <text x="1180" y="688" fill="#a9b1d6" font-size="18" font-weight="bold">Rail flags don't go blind while sessions queue:</text>
+    <text x="1180" y="722" fill="#c0caf5" font-size="16">- one batched GET /api/agent/sessions at load seeds the</text>
+    <text x="1180" y="750" fill="#c0caf5" font-size="16">  red "waiting" flags (pending_permission_requests, server-side)</text>
+    <text x="1180" y="778" fill="#c0caf5" font-size="16">- each view refines its own flag as it hydrates</text>
+    <text x="1180" y="806" fill="#c0caf5" font-size="16">- cold-load log: navigation start → focused session's live WS</text>
+  </g>
+
+  <!-- bottom strip -->
+  <text x="500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">?limit=150 vs 1000 — headroom over the 100-row render buffer</text>
+  <text x="1500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">Closes #1915 · builds on #1916 (metrics off the WS critical path)</text>
+
+  <!-- Footer limitation -->
+  <text x="1000" y="1190" text-anchor="middle" fill="#565f89" font-size="15" font-style="italic">Limitation: a cold pill tapped before its drip turn now pays its own hydration (~1 fetch + parse) instead of being pre-warmed; no IndexedDB cache — history refetches every reload.</text>
+</svg>

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -34,6 +34,8 @@ wasm-bindgen-futures = { workspace = true }
 # Web APIs
 web-sys = { workspace = true, features = [
     "Window",
+    # Cold-load telemetry (#1915): performance.now() since navigation start.
+    "Performance",
     "Document",
     "Element",
     "NodeList",

--- a/frontend/src/pages/dashboard/page.rs
+++ b/frontend/src/pages/dashboard/page.rs
@@ -167,6 +167,38 @@ pub fn dashboard_page() -> Html {
         session_state.clone(),
     );
 
+    // Seed the rail's awaiting flags from the server as soon as the session
+    // list lands (#1915). The per-view `is_awaiting` signal only exists once a
+    // session hydrates, and background sessions now hydrate on a drip — without
+    // this seed, a session blocked on a permission wouldn't show its red flag
+    // until its turn in the queue. One batched request; each view's own signal
+    // refines (and can clear) the flag as it hydrates.
+    {
+        let session_state = session_state.clone();
+        use_effect_with(loading, move |is_loading| {
+            if !*is_loading {
+                spawn_local(async move {
+                    if let Ok(data) = utils::fetch_json::<shared::api::AgentSessionsResponse>(
+                        "/api/agent/sessions",
+                        utils::On401::Ignore,
+                    )
+                    .await
+                    {
+                        for session in data.sessions {
+                            if session.awaiting_permission {
+                                session_state.dispatch(DashboardSessionAction::SetAwaiting {
+                                    session_id: session.id,
+                                    awaiting: true,
+                                });
+                            }
+                        }
+                    }
+                });
+            }
+            || ()
+        });
+    }
+
     // Push-notification deep link (mobile-apps plan D4). `sw.js` opens
     // `/dashboard?session=<uuid>` on notification click; parse that id once at
     // mount and hold it until the target session shows up in `active_sessions`

--- a/frontend/src/pages/dashboard/page_focus.rs
+++ b/frontend/src/pages/dashboard/page_focus.rs
@@ -1,10 +1,18 @@
 use super::page_state::{active_session_ids, DashboardSessionAction, DashboardSessionState};
 use super::session_order;
 use super::types::{load_last_active_session, save_last_active_session};
+use gloo::timers::callback::Timeout;
 use shared::SessionInfo;
 use std::collections::HashSet;
 use uuid::Uuid;
 use yew::prelude::*;
+
+/// Background sessions activated per hydration tick (#1915).
+const HYDRATION_BATCH: usize = 2;
+/// Delay between hydration ticks. With a batch of 2, twenty background
+/// sessions are all warm ~4s after load — without the reload thundering herd
+/// of every history fetch, socket, and transcript parse landing in one flush.
+const HYDRATION_DRIP_MS: u32 = 400;
 
 pub(super) struct DashboardFocus {
     pub focused_index: usize,
@@ -108,7 +116,11 @@ pub(super) fn use_dashboard_focus(
         );
     }
 
-    // On initial load, focus first non-hidden session and activate all non-hidden sessions.
+    // On initial load, focus the saved (or first non-hidden) session and
+    // activate ONLY it (#1915). Background sessions hydrate through the drip
+    // effect below instead of all at once — the reload thundering herd was
+    // every visible session firing its history fetch, socket connect, and
+    // transcript parse in a single render flush.
     {
         let active_sessions = active_sessions.clone();
         let effective_hidden_sessions = effective_hidden_sessions.clone();
@@ -140,32 +152,61 @@ pub(super) fn use_dashboard_focus(
                             .map(|s| s.id)
                     });
 
-                    let mut activate_ids: Vec<Uuid> = focus_id.into_iter().collect();
-                    activate_ids.extend(
-                        sessions
-                            .iter()
-                            .filter(visible)
-                            .map(|s| s.id)
-                            .filter(|id| Some(*id) != focus_id),
-                    );
-                    if activate_ids.is_empty() {
-                        activate_ids.extend(sessions.iter().map(|s| s.id));
-                    }
-
                     if let Some(id) = focus_id {
                         save_last_active_session(id);
                     }
 
-                    // Activate the preferred session first. The reducer stores
-                    // a set, but the dashboard render also prioritizes the
-                    // focused id so the saved session's websocket starts
-                    // before background sessions on reload.
                     session_state.dispatch(DashboardSessionAction::InitializeFocus {
                         focus_id,
-                        activate_ids,
+                        activate_ids: focus_id.into_iter().collect(),
                     });
                 }
                 || ()
+            },
+        );
+    }
+
+    // Background hydration drip (#1915): activate the not-yet-activated
+    // visible sessions HYDRATION_BATCH at a time, most recently messaged
+    // first. Each Activate re-renders the page, which re-runs this effect
+    // and schedules the next tick, so the drip is self-perpetuating and
+    // stops on its own once nothing is pending. Selecting a session
+    // activates it immediately (FocusAndActivate) regardless of the drip;
+    // that dispatch also changes this effect's deps, cancelling the armed
+    // tick so the user's selection hydrates without contention.
+    {
+        let active_sessions = active_sessions.clone();
+        let hidden_sessions = effective_hidden_sessions.clone();
+        let activated = session_state.activated_sessions.clone();
+        let initialized = session_state.initial_focus_set;
+        let session_state = session_state.clone();
+
+        use_effect_with(
+            (
+                initialized,
+                activated.clone(),
+                active_session_ids(&active_sessions),
+                hidden_sessions.clone(),
+            ),
+            move |_| {
+                let mut tick = None;
+                if initialized {
+                    let mut pending: Vec<&SessionInfo> = active_sessions
+                        .iter()
+                        .filter(|s| !hidden_sessions.contains(&s.id) && !activated.contains(&s.id))
+                        .collect();
+                    if !pending.is_empty() {
+                        pending.sort_by(|a, b| session_order::history_hydration_cmp(a, b));
+                        let next: Vec<Uuid> =
+                            pending.iter().take(HYDRATION_BATCH).map(|s| s.id).collect();
+                        tick = Some(Timeout::new(HYDRATION_DRIP_MS, move || {
+                            for id in next {
+                                session_state.dispatch(DashboardSessionAction::Activate(id));
+                            }
+                        }));
+                    }
+                }
+                move || drop(tick)
             },
         );
     }

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -296,7 +296,11 @@ impl Component for SessionView {
             let mut last_message_time: Option<String> = None;
 
             if let Ok(data) = utils::fetch_json::<MessagesResponse>(
-                &format!("/api/sessions/{}/messages", session_id),
+                &format!(
+                    "/api/sessions/{}/messages?limit={}",
+                    session_id,
+                    crate::pages::dashboard::types::HISTORY_FETCH_LIMIT
+                ),
                 On401::Ignore,
             )
             .await
@@ -459,6 +463,20 @@ impl Component for SessionView {
                 false
             }
             SessionViewMsg::WebSocketConnected(sender) => {
+                // Cold-load telemetry (#1915): first live connection of the
+                // focused session, measured from navigation start.
+                if !self.ws_connected && self.reconnect_attempt == 0 && ctx.props().focused {
+                    if let Some(now) = web_sys::window()
+                        .and_then(|w| w.performance())
+                        .map(|p| p.now())
+                    {
+                        log::info!(
+                            "cold-load: focused session {} live in {:.0}ms",
+                            ctx.props().session.id,
+                            now
+                        );
+                    }
+                }
                 self.ws_connected = true;
                 self.ws_sender = Some(sender);
                 self.reconnect_attempt = 0;

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -51,6 +51,15 @@ pub const VIM_MODE_STORAGE_KEY: &str = "claude-portal-vim-mode";
 /// the live view, though nothing is lost server-side.
 pub const MAX_MESSAGES_PER_SESSION: usize = 100;
 
+/// How many messages the REST history fetch requests (#1915). The live buffer
+/// keeps [`MAX_MESSAGES_PER_SESSION`] renderable rows, so fetching the
+/// server-side default (`MESSAGE_RETENTION_COUNT`, typically 1000) meant
+/// parsing ~10x more JSON than survives the trim — on every session, on every
+/// reload, on the WASM main thread. The headroom above 100 absorbs rows that
+/// don't count toward the render limit (thinking-token system frames; see
+/// `counts_toward_render_limit`).
+pub const HISTORY_FETCH_LIMIT: usize = 150;
+
 /// Type alias for WebSocket sender.
 ///
 /// This is the **producer half** of an unbounded mpsc queue that feeds a


### PR DESCRIPTION
![visual](https://raw.githubusercontent.com/meawoppl/agent-portal/solve-reload-herd/.0-pr-viz/001917.svg)

Implements the remaining slices of the verified triage in #1915. A reload previously activated every visible session at once — N history fetches (1000 messages each), N metrics fetches, N WebSocket connects in one render flush, then N×1000-message JSON parses on the WASM main thread.

**1. History fetch capped at what survives the trim.** `handle_load_history` keeps 100 renderable rows (`MAX_MESSAGES_PER_SESSION`), but the fetch used the server default limit (`MESSAGE_RETENTION_COUNT`, 1000) — ~90% of the parse work was discarded. Now `?limit=150` (headroom for non-counting thinking-token rows). This is the main-thread win, and it makes WS-first focused hydration unnecessary: the focused session is one small request racing nothing.

**2. Staggered background hydration.** Initial load activates only the focused session; the rest activate 2 per 400ms tick, most-recently-messaged first (`history_hydration_cmp`), via a self-perpetuating effect that stops when nothing is pending. Selecting a session activates it immediately and cancels the armed tick — user intent never waits on the queue. ~20 sessions are fully warm ≈4s after load.

**3. Rail flags survive lazy hydration.** The red "waiting" flags previously came from each session's fetched history; with hydration deferred they'd be blind for seconds. One batched `/api/agent/sessions` request (existing endpoint — cookie auth, `pending_permission_requests` server-side) seeds `SetAwaiting` at load; each view's own signal refines/clears as it hydrates.

Plus a cold-load telemetry log (navigation start → focused session's live WS) using `performance.now()`.

Deliberately not done: IndexedDB caching (phase 2 in the triage; with the herd gone and the focused session down to one small fetch, it's not currently warranted).

Closes #1915
