### PR TITLE
Share the render-budget filter so hydration sends exactly what survives

### DIFF
--- a/.0-pr-viz/001918.svg
+++ b/.0-pr-viz/001918.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2000" height="1200" viewBox="0 0 2000 1200" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <!-- Thesis -->
+  <text x="1000" y="64" text-anchor="middle" fill="#c0caf5" font-size="34" font-weight="bold">One render-budget rule, shared: the server now sends exactly what the client keeps</text>
+
+  <!-- BEFORE / AFTER labels -->
+  <text x="500" y="126" text-anchor="middle" fill="#f7768e" font-size="26" font-weight="bold" letter-spacing="4">BEFORE</text>
+  <text x="1500" y="126" text-anchor="middle" fill="#9ece6a" font-size="26" font-weight="bold" letter-spacing="4">AFTER</text>
+  <line x1="1000" y1="96" x2="1000" y2="1140" stroke="#565f89" stroke-width="2" stroke-dasharray="8 8"/>
+
+  <!-- BEFORE -->
+  <g>
+    <text x="180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">The counting rule lived only in the frontend:</text>
+
+    <!-- request flow -->
+    <rect x="180" y="240" width="290" height="60" rx="10" fill="#1e202e" stroke="#7aa2f7" stroke-width="2"/>
+    <text x="325" y="266" text-anchor="middle" fill="#7aa2f7" font-size="16" font-family="monospace">GET /messages?limit=150</text>
+    <text x="325" y="288" text-anchor="middle" fill="#565f89" font-size="13" font-style="italic">a guess: 100 + 50 headroom</text>
+
+    <line x1="470" y1="270" x2="560" y2="270" stroke="#565f89" stroke-width="2.5"/>
+    <polygon points="560,270 544,263 544,277" fill="#565f89"/>
+
+    <rect x="560" y="240" width="280" height="60" rx="10" fill="#1e202e" stroke="#e0af68" stroke-width="2"/>
+    <text x="700" y="266" text-anchor="middle" fill="#e0af68" font-size="16">server: raw row count</text>
+    <text x="700" y="288" text-anchor="middle" fill="#565f89" font-size="13">has no idea what renders</text>
+
+    <!-- two failure modes -->
+    <rect x="150" y="360" width="700" height="200" rx="12" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="180" y="398" fill="#f7768e" font-size="18" font-weight="bold">Sparse-marker session (most sessions):</text>
+    <rect x="180" y="420" width="430" height="26" rx="5" fill="#16161e" stroke="#9ece6a" stroke-width="1"/>
+    <text x="395" y="438" text-anchor="middle" fill="#9ece6a" font-size="13">100 kept after trim</text>
+    <rect x="614" y="420" width="206" height="26" rx="5" fill="#16161e" stroke="#f7768e" stroke-width="1"/>
+    <text x="717" y="438" text-anchor="middle" fill="#f7768e" font-size="13">~50 rows parsed, discarded</text>
+    <text x="180" y="486" fill="#f7768e" font-size="18" font-weight="bold">Marker-dense window (long thinking turns):</text>
+    <rect x="180" y="508" width="640" height="26" rx="5" fill="#16161e" stroke="#e0af68" stroke-width="1"/>
+    <text x="500" y="526" text-anchor="middle" fill="#e0af68" font-size="13">150 rows, but &lt;100 renderable — buffer underfilled, history lost from view</text>
+
+    <rect x="150" y="620" width="700" height="200" rx="12" fill="#1e202e" stroke="#565f89" stroke-width="1.5"/>
+    <text x="180" y="658" fill="#a9b1d6" font-size="18" font-weight="bold">Two copies of the budget logic:</text>
+    <text x="180" y="694" fill="#c0caf5" font-size="16">- counts_toward_render_limit — frontend only</text>
+    <text x="180" y="722" fill="#c0caf5" font-size="16">- retain_newest_items_by_cost — frontend only</text>
+    <text x="180" y="750" fill="#c0caf5" font-size="16">- server pages by raw LIMIT; any drift between the two</text>
+    <text x="180" y="778" fill="#c0caf5" font-size="16">  sides is invisible until someone counts bytes</text>
+  </g>
+
+  <!-- AFTER -->
+  <g>
+    <text x="1180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">shared::render_budget — one definition, both sides:</text>
+
+    <rect x="1180" y="240" width="330" height="60" rx="10" fill="#1e202e" stroke="#7aa2f7" stroke-width="2"/>
+    <text x="1345" y="266" text-anchor="middle" fill="#7aa2f7" font-size="16" font-family="monospace">GET /messages?render_limit=100</text>
+    <text x="1345" y="288" text-anchor="middle" fill="#565f89" font-size="13" font-style="italic">the client's actual budget</text>
+
+    <line x1="1510" y1="270" x2="1590" y2="270" stroke="#565f89" stroke-width="2.5"/>
+    <polygon points="1590,270 1574,263 1574,277" fill="#565f89"/>
+
+    <rect x="1590" y="240" width="290" height="60" rx="10" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1735" y="266" text-anchor="middle" fill="#9ece6a" font-size="16">server counts renderable</text>
+    <text x="1735" y="288" text-anchor="middle" fill="#565f89" font-size="13">same predicate, same trim</text>
+
+    <rect x="1150" y="360" width="700" height="200" rx="12" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1180" y="398" fill="#9ece6a" font-size="18" font-weight="bold">Page = exactly the window the client keeps:</text>
+    <text x="1180" y="434" fill="#c0caf5" font-size="16">- 100 counting messages; thinking-token markers ride free</text>
+    <text x="1180" y="462" fill="#c0caf5" font-size="16">- zero rows fetched just to be trimmed away</text>
+    <text x="1180" y="490" fill="#c0caf5" font-size="16">- marker-dense windows fill the buffer completely (server</text>
+    <text x="1180" y="518" fill="#c0caf5" font-size="16">  extends the fetch instead of the client losing history)</text>
+
+    <rect x="1150" y="620" width="700" height="200" rx="12" fill="#1e202e" stroke="#bb9af7" stroke-width="1.5"/>
+    <text x="1180" y="658" fill="#bb9af7" font-size="18" font-weight="bold">Mechanics:</text>
+    <text x="1180" y="694" fill="#c0caf5" font-size="16">- one SQL fetch of render_limit + 64 slack rows, newest first;</text>
+    <text x="1180" y="722" fill="#c0caf5" font-size="16">  a second bounded fetch only if full AND underfilled</text>
+    <text x="1180" y="750" fill="#c0caf5" font-size="16">- frontend deletes its local copies, re-exports from shared</text>
+    <text x="1180" y="778" fill="#c0caf5" font-size="16">- parity test pins client trim == server window, item for item</text>
+  </g>
+
+  <!-- bottom strip -->
+  <text x="500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">render_limit is exclusive with limit/before/after (400 otherwise)</text>
+  <text x="1500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">Follow-up to #1915 · frontend embedded in backend, so no version skew</text>
+
+  <!-- Footer limitation -->
+  <text x="1000" y="1190" text-anchor="middle" fill="#565f89" font-size="15" font-style="italic">Limitation: the server now JSON-parses each fetched row to classify it (~164/request) — cheap, but the budget rule runs on Postgres rows, not in SQL.</text>
+</svg>

--- a/backend/src/handlers/messages.rs
+++ b/backend/src/handlers/messages.rs
@@ -56,6 +56,14 @@ pub struct ListMessagesQuery {
     /// `created_at > after`.
     #[serde(default)]
     pub after: Option<String>,
+    /// Size the page by the *render budget* instead of raw rows (#1915): the
+    /// newest window containing exactly N messages that count toward the
+    /// frontend's render limit (`shared::render_budget`), with non-counting
+    /// rows (thinking-token markers) riding along free. Sized server-side so
+    /// the client never fetches rows its trim would immediately discard.
+    /// Mutually exclusive with `limit`/`before`/`after`.
+    #[serde(default)]
+    pub render_limit: Option<i64>,
 }
 
 /// Request body for creating a new message
@@ -149,7 +157,14 @@ pub async fn list_messages(
             "`before` and `after` are mutually exclusive",
         ));
     }
-    if let Some(l) = params.limit {
+    if params.render_limit.is_some()
+        && (params.limit.is_some() || params.before.is_some() || params.after.is_some())
+    {
+        return Err(AppError::BadRequest(
+            "`render_limit` cannot be combined with `limit`, `before`, or `after`",
+        ));
+    }
+    if let Some(l) = params.limit.or(params.render_limit) {
         if l <= 0 {
             return Err(AppError::BadRequest("`limit` must be > 0"));
         }
@@ -182,7 +197,9 @@ pub async fn list_messages(
     // in-memory before serializing so the wire shape stays chronological —
     // matches the prior `order(created_at.asc())` contract that the frontend
     // depends on (it appends to a chronological vector and trims the front).
-    let message_list: Vec<Message> = if let Some(after) = after_ts {
+    let message_list: Vec<Message> = if let Some(render_limit) = params.render_limit {
+        fetch_render_window(&mut conn, session_id, render_limit as usize)?
+    } else if let Some(after) = after_ts {
         messages::table
             .filter(messages::session_id.eq(session_id))
             .filter(messages::created_at.gt(after))
@@ -225,6 +242,50 @@ pub async fn list_messages(
         messages: enriched,
         total,
     }))
+}
+
+/// Slack rows fetched beyond `render_limit` on the first pass, absorbing the
+/// typical density of non-counting thinking-token markers without a second
+/// query. Underfill past the slack (a marker-dense window) falls back to one
+/// bounded full fetch.
+const RENDER_WINDOW_SLACK: i64 = 64;
+
+/// Fetch the newest window containing `render_limit` *counting* messages
+/// (`shared::render_budget`), chronological order out. One SQL round trip in
+/// the common case; a second, bounded by [`MAX_LIST_MESSAGES_LIMIT`], only
+/// when the first page was both full and underfilled with counting rows.
+fn fetch_render_window(
+    conn: &mut crate::db::DbConnection,
+    session_id: uuid::Uuid,
+    render_limit: usize,
+) -> Result<Vec<Message>, AppError> {
+    use shared::render_budget::{counts_toward_render_limit, take_render_window_newest_first};
+
+    let fetch_newest = |conn: &mut crate::db::DbConnection, sql_limit: i64| {
+        messages::table
+            .filter(messages::session_id.eq(session_id))
+            .order(messages::created_at.desc())
+            .limit(sql_limit)
+            .load::<Message>(conn)
+    };
+
+    let first_limit = (render_limit as i64 + RENDER_WINDOW_SLACK).min(MAX_LIST_MESSAGES_LIMIT);
+    let mut newest_first = fetch_newest(conn, first_limit)?;
+
+    let counting = newest_first
+        .iter()
+        .filter(|m| counts_toward_render_limit(&m.content))
+        .count();
+    let page_was_full = newest_first.len() as i64 == first_limit;
+    if counting < render_limit && page_was_full && first_limit < MAX_LIST_MESSAGES_LIMIT {
+        newest_first = fetch_newest(conn, MAX_LIST_MESSAGES_LIMIT)?;
+    }
+
+    Ok(take_render_window_newest_first(
+        newest_first,
+        render_limit,
+        |m| counts_toward_render_limit(&m.content),
+    ))
 }
 
 // =============================================================================

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -316,11 +316,14 @@ impl Component for SessionView {
         spawn_local(async move {
             let mut last_message_time: Option<String> = None;
 
+            // `render_limit` sizes the page server-side to exactly what the
+            // local trim keeps (`shared::render_budget`, #1915) — no rows
+            // fetched just to be discarded, no underfilled buffer when a turn
+            // was dense with free-riding thinking-token markers.
             if let Ok(data) = utils::fetch_json::<MessagesResponse>(
                 &format!(
-                    "/api/sessions/{}/messages?limit={}",
-                    session_id,
-                    crate::pages::dashboard::types::HISTORY_FETCH_LIMIT
+                    "/api/sessions/{}/messages?render_limit={}",
+                    session_id, MAX_MESSAGES_PER_SESSION
                 ),
                 On401::Ignore,
             )

--- a/frontend/src/pages/dashboard/session_view/state.rs
+++ b/frontend/src/pages/dashboard/session_view/state.rs
@@ -11,32 +11,7 @@ use shared::TurnMetrics;
 /// Items for which `counts_toward_limit` is false remain alongside the newest
 /// counted tail without displacing it. Free items older than that tail are
 /// discarded too, preventing detached metadata from growing without bound.
-pub(super) fn retain_newest_items_by_cost<T>(
-    items: &mut Vec<T>,
-    max_cost: usize,
-    counts_toward_limit: impl Fn(&T) -> bool,
-) {
-    let excess = items
-        .iter()
-        .filter(|item| counts_toward_limit(item))
-        .count()
-        .saturating_sub(max_cost);
-    if excess == 0 {
-        return;
-    }
-
-    let mut counted = 0;
-    let keep_from = items
-        .iter()
-        .position(|item| {
-            if counts_toward_limit(item) {
-                counted += 1;
-            }
-            counted == excess
-        })
-        .map_or(items.len(), |index| index + 1);
-    items.drain(0..keep_from);
-}
+pub(super) use shared::render_budget::retain_newest_items_by_cost;
 
 /// Append one live message and apply the same retention rule as history
 /// hydration and replay batches.
@@ -52,13 +27,10 @@ pub(super) fn push_message_with_cost_limit<T>(
 
 /// Claude emits many bodyless cumulative thinking-token markers during one
 /// turn. They render as one compact chip and therefore cost nothing against
-/// the live DOM budget.
-pub(super) fn counts_toward_render_limit(content: &str) -> bool {
-    !matches!(
-        serde_json::from_str::<shared::ClaudeOutput>(content),
-        Ok(shared::ClaudeOutput::System(message)) if message.is_thinking_tokens()
-    )
-}
+/// the live DOM budget. The rule lives in `shared::render_budget` — the same
+/// definition sizes the backend's `render_limit` hydration page, so the page
+/// sent and the buffer kept can never disagree (#1915).
+pub(super) use shared::render_budget::counts_toward_render_limit;
 
 /// Insert one live `TurnMetrics` into the buffer, preserving `started_at ASC`
 /// order and deduping by populated DB `id`.

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -54,15 +54,6 @@ pub const HEADER_COLLAPSED_STORAGE_KEY: &str = "claude-portal-header-collapsed";
 /// the live view, though nothing is lost server-side.
 pub const MAX_MESSAGES_PER_SESSION: usize = 100;
 
-/// How many messages the REST history fetch requests (#1915). The live buffer
-/// keeps [`MAX_MESSAGES_PER_SESSION`] renderable rows, so fetching the
-/// server-side default (`MESSAGE_RETENTION_COUNT`, typically 1000) meant
-/// parsing ~10x more JSON than survives the trim — on every session, on every
-/// reload, on the WASM main thread. The headroom above 100 absorbs rows that
-/// don't count toward the render limit (thinking-token system frames; see
-/// `counts_toward_render_limit`).
-pub const HISTORY_FETCH_LIMIT: usize = 150;
-
 /// Type alias for WebSocket sender.
 ///
 /// This is the **producer half** of an unbounded mpsc queue that feeds a

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -135,6 +135,8 @@ pub mod time;
 
 // `<system-reminder>` splitting, shared by the frontend renderer (collapse to
 // a bar) and backend text classification (strip before summarizing)
+pub mod render_budget;
+
 pub mod system_reminder;
 
 // Substantive-user-message detection (the history viewer's "User msgs" count)

--- a/shared/src/render_budget.rs
+++ b/shared/src/render_budget.rs
@@ -1,0 +1,139 @@
+//! The transcript render budget, shared by both sides of the hydration wire.
+//!
+//! The dashboard keeps a bounded live buffer per session — a **rendering**
+//! budget, since every buffered record is a live DOM subtree. The budget is
+//! counted in *renderable* messages: Claude emits many bodyless cumulative
+//! thinking-token markers per turn that render as one compact chip, so they
+//! ride along without counting.
+//!
+//! This module is the single implementation of that counting rule and the
+//! newest-window trim it drives. The backend uses it to size a hydration page
+//! (`GET /api/sessions/{id}/messages?render_limit=N`) to exactly what the
+//! client will keep, and the client applies the same trim to its live buffer —
+//! one definition, so the page the server sends and the buffer the client
+//! retains can never disagree (#1915).
+
+/// Whether one stored wire frame counts against the render budget.
+///
+/// Claude's cumulative thinking-token system markers are free: many arrive per
+/// turn and the frontend collapses them into a single chip.
+pub fn counts_toward_render_limit(content: &str) -> bool {
+    !matches!(
+        serde_json::from_str::<crate::ClaudeOutput>(content),
+        Ok(crate::ClaudeOutput::System(message)) if message.is_thinking_tokens()
+    )
+}
+
+/// Trim `items` (chronological, oldest first) to the newest window containing
+/// at most `max_cost` counting items. Non-counting items inside the kept
+/// window survive; everything older than the window is dropped, counting or
+/// not.
+pub fn retain_newest_items_by_cost<T>(
+    items: &mut Vec<T>,
+    max_cost: usize,
+    counts_toward_limit: impl Fn(&T) -> bool,
+) {
+    let excess = items
+        .iter()
+        .filter(|item| counts_toward_limit(item))
+        .count()
+        .saturating_sub(max_cost);
+    if excess == 0 {
+        return;
+    }
+
+    let mut counted = 0;
+    let keep_from = items
+        .iter()
+        .position(|item| {
+            if counts_toward_limit(item) {
+                counted += 1;
+            }
+            counted == excess
+        })
+        .map_or(items.len(), |index| index + 1);
+    items.drain(0..keep_from);
+}
+
+/// Size a newest-first page to exactly `render_limit` counting items: keep
+/// rows from the newest backwards until the budget is spent (non-counting
+/// rows in that window ride along), drop the rest, and return the kept rows
+/// in chronological order. The server-side twin of
+/// [`retain_newest_items_by_cost`] for pages fetched `created_at DESC`.
+pub fn take_render_window_newest_first<T>(
+    mut newest_first: Vec<T>,
+    render_limit: usize,
+    counts_toward_limit: impl Fn(&T) -> bool,
+) -> Vec<T> {
+    let mut counting = 0;
+    let mut cut = newest_first.len();
+    for (index, item) in newest_first.iter().enumerate() {
+        if counts_toward_limit(item) {
+            if counting == render_limit {
+                cut = index;
+                break;
+            }
+            counting += 1;
+        }
+    }
+    // The loop cuts at the (limit+1)-th counting item, so non-counting items
+    // older than the limit-th counting one stay in the window until the next
+    // counting item — exactly where `retain_newest_items_by_cost`'s drain
+    // lands, keeping the two sides' kept sets identical.
+    newest_first.truncate(cut);
+    newest_first.reverse();
+    newest_first
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const THINKING: &str = r#"{"type":"system","subtype":"thinking_tokens","session_id":"s","cumulative_thinking_tokens":42}"#;
+    const TEXTISH: &str = r#"{"type":"user","content":"hello"}"#;
+
+    #[test]
+    fn thinking_token_markers_ride_free() {
+        assert!(!counts_toward_render_limit(THINKING));
+        assert!(counts_toward_render_limit(TEXTISH));
+        assert!(counts_toward_render_limit("not json at all"));
+    }
+
+    /// The client trim and the server window must agree: trimming a
+    /// chronological vector and windowing its newest-first reversal produce
+    /// the same kept set.
+    #[test]
+    fn client_trim_and_server_window_agree() {
+        let chronological: Vec<i32> = (0..20).collect();
+        let counts = |n: &i32| n % 3 != 0; // every third item rides free
+
+        let mut trimmed = chronological.clone();
+        retain_newest_items_by_cost(&mut trimmed, 5, counts);
+
+        let mut newest_first = chronological;
+        newest_first.reverse();
+        let windowed = take_render_window_newest_first(newest_first, 5, counts);
+
+        assert_eq!(trimmed, windowed);
+        assert_eq!(windowed.iter().filter(|n| counts(n)).count(), 5);
+    }
+
+    #[test]
+    fn window_keeps_interspersed_free_items_but_not_older_ones() {
+        // newest-first: [counting, free, counting, free, counting, ...]
+        let newest_first = vec![(1, true), (2, false), (3, true), (4, false), (5, true)];
+        let kept = take_render_window_newest_first(newest_first, 2, |(_, c)| *c);
+        // Budget of 2 counting items → the free rows between AND immediately
+        // older than the kept counting rows ride along (the window extends to
+        // the next counting item, matching the client drain); the older
+        // counting row (5) falls out. Chronological order out.
+        assert_eq!(kept, vec![(4, false), (3, true), (2, false), (1, true)]);
+    }
+
+    #[test]
+    fn underfilled_window_keeps_everything() {
+        let newest_first = vec![1, 2, 3];
+        let kept = take_render_window_newest_first(newest_first, 10, |_| true);
+        assert_eq!(kept, vec![3, 2, 1]);
+    }
+}


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/5d3371b677c2440a4a036f1f9cadff7c0663239d/.0-pr-viz/001918.svg)

Follow-up to #1915, reusing the frontend's hydration filters server-side so the rehydrate payload carries only rows the client will keep.

**The problem with `limit=150`**: the frontend's render budget is 100 *counting* messages — Claude's thinking-token markers ride free — but the counting rule lived only in the frontend. The server paged by raw rows, so the fetch either over-shipped (~50 rows parsed on the WASM main thread and discarded, the common case) or underfilled the buffer when a window was marker-dense (long thinking turns), silently losing visible history.

**The fix**: `shared::render_budget` now holds the single implementation of the counting predicate (`counts_toward_render_limit`) and the newest-window trim — the frontend deletes its local copies and re-exports. `list_messages` gains a `?render_limit=N` mode (exclusive with `limit`/`before`/`after`) that sizes the page server-side with the same rule: one SQL fetch of N+64 rows newest-first, a second bounded fetch only when that page was both full and underfilled. The dashboard requests `render_limit=100` instead of guessing.

A parity test pins the invariant that matters: trimming a chronological buffer client-side and windowing the newest-first page server-side keep **identical** sets — including the subtle case of non-counting rows immediately older than the last counting row, which the client drain keeps (found by the test, matched by the server).

No version-skew concern: the frontend is embedded in the backend binary, so the new query param and its handler always deploy together.
