### PR TITLE
Dedupe permission pretty-print fallback into helper

### DIFF
--- a/.0-pr-viz/001910.svg
+++ b/.0-pr-viz/001910.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200" font-family="'Segoe UI','Noto Sans','DejaVu Sans',ui-sans-serif,system-ui,sans-serif">
+<rect width="2000" height="1200" fill="#16161e"/>
+<text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1910 · dedupe launcher owner checks into helper</text>
+<text x="55" y="100" font-size="34" fill="#e6e9f5">Four endpoints route through require_launcher_owner; behavior unchanged.</text>
+<line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666"/>
+<text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+<text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+<line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+<rect x="80" y="270" width="840" height="300" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="325" font-size="26" fill="#c0caf5">four handlers hand-roll the owner check</text>
+<text x="108" y="380" font-size="23" fill="#a9b1d6">launcher_owner + 404/403 mapping, copied 4x</text>
+<text x="108" y="430" font-size="23" fill="#f7768e">list_directories, update, restart, probe_agents</text>
+<text x="108" y="480" font-size="23" fill="#f7768e">7-line guard block repeated per handler</text>
+<rect x="80" y="650" width="840" height="245" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="705" font-size="26" fill="#c0caf5">same guard drifts across edits</text>
+<text x="108" y="760" font-size="23" fill="#a9b1d6">helper exists but only 5 login/install callers use it</text>
+<text x="108" y="810" font-size="23" fill="#f7768e">one fix must land in five places at once</text>
+<rect x="1065" y="270" width="860" height="300" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="325" font-size="26" fill="#7aa2f7">all four call require_launcher_owner</text>
+<text x="1093" y="380" font-size="23" fill="#a9b1d6">one helper: launcher_owner + 404/403 mapping</text>
+<text x="1093" y="430" font-size="23" fill="#9ece6a">9 callers share one ownership rule</text>
+<text x="1093" y="480" font-size="23" fill="#9ece6a">328 backend tests green, clippy and fmt clean</text>
+<rect x="1065" y="650" width="860" height="245" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="705" font-size="26" fill="#7aa2f7">warn-logging check stays inline</text>
+<text x="1093" y="760" font-size="23" fill="#a9b1d6">resolve_launch_target logs the owner on mismatch</text>
+<text x="1093" y="810" font-size="23" fill="#9ece6a">deliberately untouched — extra behavior, not dup</text>
+<text x="55" y="1172" font-size="22" fill="#565f89">Scope: backend/src/handlers/launchers.rs only; no API or protocol change.</text>
+</svg>

--- a/.0-pr-viz/001910.svg
+++ b/.0-pr-viz/001910.svg
@@ -14,7 +14,7 @@
 <rect x="80" y="650" width="840" height="245" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
 <text x="108" y="705" font-size="26" fill="#c0caf5">same guard drifts across edits</text>
 <text x="108" y="760" font-size="23" fill="#a9b1d6">helper exists but only 5 login/install callers use it</text>
-<text x="108" y="810" font-size="23" fill="#f7768e">one fix must land in five places at once</text>
+<text x="108" y="810" font-size="23" fill="#f7768e">one fix must land in four places at once</text>
 <rect x="1065" y="270" width="860" height="300" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
 <text x="1093" y="325" font-size="26" fill="#7aa2f7">all four call require_launcher_owner</text>
 <text x="1093" y="380" font-size="23" fill="#a9b1d6">one helper: launcher_owner + 404/403 mapping</text>

--- a/.0-pr-viz/001919.svg
+++ b/.0-pr-viz/001919.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200" font-family="'Segoe UI','Noto Sans','DejaVu Sans',ui-sans-serif,system-ui,sans-serif">
+<rect width="2000" height="1200" fill="#16161e"/>
+<text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1919 · dedupe permission pretty-print fallback into helper</text>
+<text x="55" y="100" font-size="34" fill="#e6e9f5">One pretty_input helper serves four call sites; behavior unchanged.</text>
+<line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666"/>
+<text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+<text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+<line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+<rect x="80" y="270" width="840" height="300" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="325" font-size="26" fill="#c0caf5">three call sites hand-roll the fallback</text>
+<text x="108" y="380" font-size="23" fill="#a9b1d6">to_string_pretty + unwrap_or_else debug, copied 3x</text>
+<text x="108" y="430" font-size="23" fill="#f7768e">claude fallback, codex Permissions, AskUserQuestion</text>
+<text x="108" y="480" font-size="23" fill="#f7768e">13-line incantation repeated per formatter</text>
+<rect x="80" y="650" width="840" height="245" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="705" font-size="26" fill="#c0caf5">ApplyPatch empty arm swallows failure</text>
+<text x="108" y="760" font-size="23" fill="#a9b1d6">unwrap_or_default renders an empty string</text>
+<text x="108" y="810" font-size="23" fill="#f7768e">serialize failure shows a blank permission card</text>
+<rect x="1065" y="270" width="860" height="300" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="325" font-size="26" fill="#7aa2f7">all four route through pretty_input</text>
+<text x="1093" y="380" font-size="23" fill="#a9b1d6">one generic helper: pretty-print, debug fallback</text>
+<text x="1093" y="430" font-size="23" fill="#9ece6a">format_claude + three format_codex arms share it</text>
+<text x="1093" y="480" font-size="23" fill="#9ece6a">5 frontend tests green, clippy and fmt clean</text>
+<rect x="1065" y="650" width="860" height="245" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="705" font-size="26" fill="#7aa2f7">empty ApplyPatch shows debug form</text>
+<text x="1093" y="760" font-size="23" fill="#a9b1d6">near-impossible failure now renders something</text>
+<text x="1093" y="810" font-size="23" fill="#9ece6a">no more silent blank card on that path</text>
+<text x="55" y="1172" font-size="22" fill="#565f89">Scope: frontend/src/pages/dashboard/types.rs only; no UI or protocol change.</text>
+</svg>

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -475,14 +475,7 @@ pub async fn list_directories(
     Path(launcher_id): Path<Uuid>,
     Query(query): Query<DirectoryQuery>,
 ) -> Result<Json<DirectoryListingResponse>, AppError> {
-    // Verify the launcher belongs to this user
-    let owner = app_state
-        .session_manager
-        .launcher_owner(launcher_id)
-        .ok_or(AppError::NotFound("Launcher not found"))?;
-    if owner != user_id {
-        return Err(AppError::Forbidden);
-    }
+    require_launcher_owner(&app_state, launcher_id, user_id)?;
 
     let request_id = Uuid::new_v4();
     let rx = app_state.session_manager.register_dir_request(request_id);
@@ -561,15 +554,7 @@ pub async fn update_launcher(
     CurrentUserId(user_id): CurrentUserId,
     Path(launcher_id): Path<Uuid>,
 ) -> Result<EmptyResponse, AppError> {
-    {
-        let owner = app_state
-            .session_manager
-            .launcher_owner(launcher_id)
-            .ok_or(AppError::NotFound("Launcher not found"))?;
-        if owner != user_id {
-            return Err(AppError::Forbidden);
-        }
-    }
+    require_launcher_owner(&app_state, launcher_id, user_id)?;
 
     // Route through the evicting sender (not a cloned raw sender) so a dead
     // channel tears the stale connection down instead of lingering.
@@ -595,15 +580,7 @@ pub async fn restart_launcher(
     CurrentUserId(user_id): CurrentUserId,
     Path(launcher_id): Path<Uuid>,
 ) -> Result<EmptyResponse, AppError> {
-    {
-        let owner = app_state
-            .session_manager
-            .launcher_owner(launcher_id)
-            .ok_or(AppError::NotFound("Launcher not found"))?;
-        if owner != user_id {
-            return Err(AppError::Forbidden);
-        }
-    }
+    require_launcher_owner(&app_state, launcher_id, user_id)?;
 
     if !app_state
         .session_manager
@@ -639,15 +616,7 @@ pub async fn probe_agents(
     CurrentUserId(user_id): CurrentUserId,
     Path(launcher_id): Path<Uuid>,
 ) -> Result<Json<ProbeAgentsResponse>, AppError> {
-    {
-        let owner = app_state
-            .session_manager
-            .launcher_owner(launcher_id)
-            .ok_or(AppError::NotFound("Launcher not found"))?;
-        if owner != user_id {
-            return Err(AppError::Forbidden);
-        }
-    }
+    require_launcher_owner(&app_state, launcher_id, user_id)?;
 
     let request_id = Uuid::new_v4();
     let rx = app_state.session_manager.register_probe_request(request_id);

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -259,6 +259,12 @@ pub fn format_permission_input(tool_name: &str, input: &serde_json::Value) -> St
     format_claude_permission_input(tool_name, input)
 }
 
+/// Pretty-print a permission input, falling back to its debug form when
+/// pretty-printing fails.
+fn pretty_input<T: serde::Serialize + std::fmt::Debug + ?Sized>(input: &T) -> String {
+    serde_json::to_string_pretty(input).unwrap_or_else(|_| format!("{:?}", input))
+}
+
 /// Render a Claude-side permission tool input from the SDK's named,
 /// typed `ToolInput` parser.
 fn format_claude_permission_input(tool_name: &str, input: &serde_json::Value) -> String {
@@ -267,7 +273,7 @@ fn format_claude_permission_input(tool_name: &str, input: &serde_json::Value) ->
         ToolInput::Read(read) => read.file_path,
         ToolInput::Edit(edit) => edit.file_path,
         ToolInput::Write(write) => write.file_path,
-        _ => serde_json::to_string_pretty(input).unwrap_or_else(|_| format!("{:?}", input)),
+        _ => pretty_input(input),
     }
 }
 
@@ -306,7 +312,7 @@ fn format_codex_permission_input(input: &shared::CodexPermissionInput) -> String
         C::ApplyPatch { file_changes, .. } => {
             let paths: Vec<String> = file_changes.keys().cloned().collect();
             if paths.is_empty() {
-                serde_json::to_string_pretty(file_changes).unwrap_or_default()
+                pretty_input(file_changes)
             } else {
                 format!("Patch {} file(s):\n  {}", paths.len(), paths.join("\n  "))
             }
@@ -318,9 +324,7 @@ fn format_codex_permission_input(input: &shared::CodexPermissionInput) -> String
             .as_deref()
             .filter(|s| !s.is_empty())
             .map(|s| s.to_string())
-            .unwrap_or_else(|| {
-                serde_json::to_string_pretty(input).unwrap_or_else(|_| format!("{:?}", input))
-            }),
+            .unwrap_or_else(|| pretty_input(input)),
         C::McpElicitation { server_name } => {
             if server_name.is_empty() {
                 "MCP server is asking for input".to_string()
@@ -333,7 +337,7 @@ fn format_codex_permission_input(input: &shared::CodexPermissionInput) -> String
             // permission dialog; this code path is only hit for the
             // standard-permission summary preview, so fall back to the
             // typed pretty-print.
-            serde_json::to_string_pretty(input).unwrap_or_else(|_| format!("{:?}", input))
+            pretty_input(input)
         }
     }
 }


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/026c7868be3b6e17c4d3c029ccfc72b1fb40e895/.0-pr-viz/001919.svg)

Hoists the repeated `serde_json::to_string_pretty(..).unwrap_or_else(|_| format!("{:?}", ..))` fallback in the dashboard permission formatters into a single `pretty_input` helper, and routes the ApplyPatch empty-diff arm through it too (previously `unwrap_or_default`, which silently rendered nothing on the near-impossible serialize failure).