### PR TITLE
Render upload notices as attachment chips, not user prose

### DIFF
--- a/.0-pr-viz/001921.svg
+++ b/.0-pr-viz/001921.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2000" height="1200" viewBox="0 0 2000 1200" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <!-- Thesis -->
+  <text x="1000" y="64" text-anchor="middle" fill="#c0caf5" font-size="34" font-weight="bold">Upload notices render as attachment chips — the boilerplate stays on the wire only</text>
+
+  <!-- BEFORE / AFTER labels -->
+  <text x="500" y="126" text-anchor="middle" fill="#f7768e" font-size="26" font-weight="bold" letter-spacing="4">BEFORE</text>
+  <text x="1500" y="126" text-anchor="middle" fill="#9ece6a" font-size="26" font-weight="bold" letter-spacing="4">AFTER</text>
+  <line x1="1000" y1="96" x2="1000" y2="1140" stroke="#565f89" stroke-width="2" stroke-dasharray="8 8"/>
+
+  <!-- BEFORE -->
+  <g>
+    <text x="180" y="210" fill="#a9b1d6" font-size="19" font-weight="bold">Pasting a screenshot into a muse session showed:</text>
+
+    <!-- user message card -->
+    <rect x="180" y="250" width="680" height="170" rx="10" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <rect x="196" y="266" width="52" height="24" rx="12" fill="#3d4666"/>
+    <text x="222" y="283" text-anchor="middle" fill="#c0caf5" font-size="13">You</text>
+    <text x="200" y="330" fill="#c0caf5" font-size="16">I've uploaded the following files to your working</text>
+    <text x="200" y="358" fill="#c0caf5" font-size="16">directory:</text>
+    <text x="200" y="392" fill="#c0caf5" font-size="16">- portal_pasted_image_260909_093931.png (33.6 KB)</text>
+
+    <rect x="150" y="480" width="700" height="230" rx="12" fill="#1e202e" stroke="#565f89" stroke-width="1.5"/>
+    <text x="180" y="518" fill="#f7768e" font-size="19" font-weight="bold">Machine text impersonating the user:</text>
+    <text x="180" y="554" fill="#c0caf5" font-size="16">- the sentence is real and necessary — but for the AGENT,</text>
+    <text x="180" y="582" fill="#c0caf5" font-size="16">  whose working directory just grew a file</text>
+    <text x="180" y="610" fill="#c0caf5" font-size="16">- the transcript rendered it verbatim under the "You" badge</text>
+    <text x="180" y="638" fill="#c0caf5" font-size="16">- worst on muse: no inline media preview softens it, so the</text>
+    <text x="180" y="666" fill="#c0caf5" font-size="16">  boilerplate IS the whole message</text>
+  </g>
+
+  <!-- AFTER -->
+  <g>
+    <text x="1180" y="210" fill="#a9b1d6" font-size="19" font-weight="bold">Same wire text, rendered as what it is:</text>
+
+    <rect x="1180" y="250" width="680" height="170" rx="10" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <rect x="1196" y="266" width="52" height="24" rx="12" fill="#3d4666"/>
+    <text x="1222" y="283" text-anchor="middle" fill="#c0caf5" font-size="13">You</text>
+    <text x="1200" y="330" fill="#c0caf5" font-size="16">check this layout please</text>
+    <!-- attachment chip -->
+    <rect x="1200" y="352" width="500" height="36" rx="16" fill="#1e202e" stroke="#565f89" stroke-width="1.5"/>
+    <path d="M 1222 378 l 10 -12 a5 5 0 0 1 8 6 l -11 13 a8 8 0 0 1 -12 -10 l 11 -13" fill="none" stroke="#7dcfff" stroke-width="2"/>
+    <text x="1248" y="376" fill="#c0caf5" font-size="15">portal_pasted_image_260909_093931.png</text>
+    <text x="1590" y="376" fill="#565f89" font-size="13">33.6 KB</text>
+
+    <rect x="1150" y="480" width="700" height="230" rx="12" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1180" y="518" fill="#9ece6a" font-size="19" font-weight="bold">components::upload_notice — builder + parser together:</text>
+    <text x="1180" y="554" fill="#c0caf5" font-size="16">- build_upload_message moved out of input_bar; a strict</text>
+    <text x="1180" y="582" fill="#c0caf5" font-size="16">  split_upload_notice recovers user text + (name, size) rows</text>
+    <text x="1180" y="610" fill="#c0caf5" font-size="16">- round-trip test pins builder output == parser input</text>
+    <text x="1180" y="638" fill="#c0caf5" font-size="16">- anything that doesn't parse exactly stays prose — quoting</text>
+    <text x="1180" y="666" fill="#c0caf5" font-size="16">  the sentence never rewrites a real message into chips</text>
+  </g>
+
+  <!-- bottom strip -->
+  <text x="500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">Agent-facing wire text unchanged — the agent still gets told</text>
+  <text x="1500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">Both render paths patched: optimistic echo + durable user frames</text>
+
+  <!-- Footer limitation -->
+  <text x="1000" y="1190" text-anchor="middle" fill="#565f89" font-size="15" font-style="italic">Limitation: chips show name + size only — no thumbnail preview of the uploaded image, and old transcripts re-render but the wire rows keep the prose.</text>
+</svg>

--- a/frontend/src/components/message_renderer/renderers/user.rs
+++ b/frontend/src/components/message_renderer/renderers/user.rs
@@ -9,6 +9,7 @@ use crate::components::markdown::render_markdown_for_session;
 use crate::components::tool_renderers::{
     has_askuserquestion_answers, render_askuserquestion_result,
 };
+use crate::components::{split_upload_notice, UploadNotice};
 use shared::UserFrame as OptimisticUserMessage;
 use uuid::Uuid;
 use yew::prelude::*;
@@ -128,11 +129,38 @@ pub fn render_optimistic_user_message_content(
     msg: &OptimisticUserMessage,
     session_id: Uuid,
 ) -> Option<Html> {
-    (!msg.content.trim().is_empty()).then(|| {
-        html! {
-            <div class="user-text">{ render_markdown_for_session(&preserve_user_newlines(&msg.content), session_id) }</div>
-        }
+    if msg.content.trim().is_empty() {
+        return None;
+    }
+    if let Some(notice) = split_upload_notice(&msg.content) {
+        return Some(render_upload_notice(&notice, session_id));
+    }
+    Some(html! {
+        <div class="user-text">{ render_markdown_for_session(&preserve_user_newlines(&msg.content), session_id) }</div>
     })
+}
+
+/// Render the upload pipeline's agent-facing notice as the user's own words
+/// plus compact attachment chips. The wire text (which the agent needs — the
+/// files just appeared in its working directory) is untouched; only the
+/// transcript stops impersonating the user with machine boilerplate.
+fn render_upload_notice(notice: &UploadNotice<'_>, session_id: Uuid) -> Html {
+    html! {
+        <>
+            if let Some(text) = notice.user_text {
+                <div class="user-text">{ render_markdown_for_session(&preserve_user_newlines(text), session_id) }</div>
+            }
+            <div class="upload-notice">
+                { for notice.files.iter().map(|(name, size)| html! {
+                    <span class="upload-chip">
+                        <span aria-hidden="true">{ "📎" }</span>
+                        <span class="upload-chip-name">{ *name }</span>
+                        <span class="upload-chip-size">{ *size }</span>
+                    </span>
+                }) }
+            </div>
+        </>
+    }
 }
 
 /// Render a user message's body, returning `None` when it produces nothing
@@ -151,6 +179,8 @@ pub fn render_user_message_content(msg: &shared::UserMessage, session_id: Uuid) 
         render_content_blocks(&msg.message.content, session_id)
     } else if text_content.is_empty() {
         None
+    } else if let Some(notice) = split_upload_notice(&text_content) {
+        Some(render_upload_notice(&notice, session_id))
     } else {
         Some(html! {
             <div class="user-text">{ render_markdown_for_session(&preserve_user_newlines(&text_content), session_id) }</div>

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -27,6 +27,7 @@ pub(crate) mod tool_card;
 mod tool_renderers;
 pub(crate) mod turn_metrics_display;
 mod turn_metrics_pill;
+mod upload_notice;
 mod voice_input;
 
 pub use confirm_modal::{ConfirmModal, ConfirmModalStyle};
@@ -45,4 +46,5 @@ pub use proxy_token_setup::ProxyTokenSetup;
 pub use schedule_dialog::ScheduleDialog;
 pub use share_dialog::ShareDialog;
 pub use turn_metrics_pill::TurnMetricsHeaderPill;
+pub use upload_notice::{build_upload_message, split_upload_notice, UploadNotice};
 pub use voice_input::{load_voice_hold_open, save_voice_hold_open, VoiceInput};

--- a/frontend/src/components/upload_notice.rs
+++ b/frontend/src/components/upload_notice.rs
@@ -1,0 +1,162 @@
+//! The upload-notice message, built and parsed under one roof.
+//!
+//! When files are uploaded, the input bar composes an agent-facing sentence
+//! ("I've uploaded the following files to your working directory: …") because
+//! the agent genuinely needs to be told — the files just appeared on disk.
+//! But the transcript used to render that machine boilerplate as if the user
+//! typed it, most gratingly on agents with no inline media preview (muse).
+//!
+//! [`build_upload_message`] composes the wire text; [`split_upload_notice`]
+//! recovers its structure so the transcript renders the user's own words plus
+//! compact attachment chips instead of the prose. They live in one module with
+//! a round-trip test so the builder and parser cannot drift.
+
+use shared::fmt::format_file_size;
+
+/// The fixed header line of the agent-facing notice. The wire format is
+/// `[user text\n\n]HEADER\n- <name> (<size>)…` — one file per line.
+const UPLOAD_NOTICE_HEADER: &str = "I've uploaded the following files to your working directory:";
+
+/// Compose the combined user-text + file-list message the upload pipeline
+/// sends to the agent after the last chunk lands.
+pub fn build_upload_message(user_input: &str, files: &[(String, u64)]) -> String {
+    let file_list: Vec<String> = files
+        .iter()
+        .map(|(name, size)| format!("- {} ({})", name, format_file_size(*size)))
+        .collect();
+    let list = file_list.join("\n");
+    if user_input.is_empty() {
+        format!("{UPLOAD_NOTICE_HEADER}\n{list}")
+    } else {
+        format!("{user_input}\n\n{UPLOAD_NOTICE_HEADER}\n{list}")
+    }
+}
+
+/// A parsed upload notice: what the user actually said, and the attachments.
+pub struct UploadNotice<'a> {
+    /// The user's own words, if they sent any alongside the upload.
+    pub user_text: Option<&'a str>,
+    /// `(file name, human-readable size)` in upload order.
+    pub files: Vec<(&'a str, &'a str)>,
+}
+
+/// Recognize a [`build_upload_message`] product and recover its parts.
+///
+/// Deliberately strict: the header must open the text or follow the exact
+/// `\n\n` separator, and every subsequent line must parse as a `- name (size)`
+/// row — anything else returns `None` and renders as ordinary prose, so a
+/// user who merely *mentions* the header sentence never gets their message
+/// rewritten into chips.
+pub fn split_upload_notice(text: &str) -> Option<UploadNotice<'_>> {
+    let separator = format!("\n\n{UPLOAD_NOTICE_HEADER}");
+    let (user_text, list) = if let Some(rest) = text.strip_prefix(UPLOAD_NOTICE_HEADER) {
+        (None, rest)
+    } else {
+        let at = text.find(&separator)?;
+        let rest = &text[at + separator.len()..];
+        (Some(&text[..at]), rest)
+    };
+
+    let mut files = Vec::new();
+    for line in list.lines() {
+        if line.is_empty() {
+            continue;
+        }
+        let entry = line.strip_prefix("- ")?;
+        let open = entry.rfind(" (")?;
+        let size = entry[open + 2..].strip_suffix(')')?;
+        files.push((&entry[..open], size));
+    }
+    if files.is_empty() {
+        return None;
+    }
+    Some(UploadNotice {
+        user_text: user_text.filter(|t| !t.trim().is_empty()),
+        files,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_with_user_text_prepends_text_and_blank_line() {
+        let files = vec![("a.txt".to_string(), 100u64)];
+        let out = build_upload_message("hello", &files);
+        assert_eq!(
+            out,
+            "hello\n\nI've uploaded the following files to your working directory:\n- a.txt (100 B)"
+        );
+    }
+
+    #[test]
+    fn build_without_user_text_omits_blank_line_and_header() {
+        let files = vec![("a.txt".to_string(), 100u64)];
+        let out = build_upload_message("", &files);
+        assert_eq!(
+            out,
+            "I've uploaded the following files to your working directory:\n- a.txt (100 B)"
+        );
+    }
+
+    #[test]
+    fn build_lists_one_file_per_line_in_input_order() {
+        let files = vec![
+            ("first.png".to_string(), 1024u64),
+            ("second.jpg".to_string(), 2 * 1024 * 1024),
+            ("third.txt".to_string(), 42u64),
+        ];
+        let out = build_upload_message("ship it", &files);
+        let expected = "ship it\n\nI've uploaded the following files to your working directory:\n- first.png (1.0 KB)\n- second.jpg (2.0 MB)\n- third.txt (42 B)";
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn build_with_empty_file_list_still_renders_header() {
+        // Defensive: the upload pipeline always supplies at least one file,
+        // and the parser refuses a file-less notice (renders as prose).
+        let out = build_upload_message("", &[]);
+        assert_eq!(
+            out,
+            "I've uploaded the following files to your working directory:\n"
+        );
+        assert!(split_upload_notice(&out).is_none());
+    }
+
+    /// The invariant this module exists for: anything the builder emits, the
+    /// parser recovers — names, sizes, order, and the user's own words.
+    #[test]
+    fn parser_round_trips_the_builder() {
+        let files = vec![
+            ("portal_pasted_image_260909_093931.png".to_string(), 34_406),
+            ("notes (final).txt".to_string(), 42u64),
+        ];
+        for user_text in ["", "look at this"] {
+            let wire = build_upload_message(user_text, &files);
+            let notice = split_upload_notice(&wire).expect("builder output must parse");
+            assert_eq!(
+                notice.user_text,
+                (!user_text.is_empty()).then_some(user_text)
+            );
+            assert_eq!(
+                notice.files,
+                vec![
+                    ("portal_pasted_image_260909_093931.png", "33.6 KB"),
+                    ("notes (final).txt", "42 B"),
+                ]
+            );
+        }
+    }
+
+    #[test]
+    fn prose_that_mentions_the_header_stays_prose() {
+        assert!(split_upload_notice("what does \"I've uploaded the following files to your working directory:\" mean?\nnothing follows").is_none());
+        assert!(split_upload_notice("plain message").is_none());
+        // Header present but a malformed list row: prose, not chips.
+        assert!(split_upload_notice(
+            "I've uploaded the following files to your working directory:\nnot a list row"
+        )
+        .is_none());
+    }
+}

--- a/frontend/src/pages/dashboard/session_view/input_bar.rs
+++ b/frontend/src/pages/dashboard/session_view/input_bar.rs
@@ -15,6 +15,7 @@
 
 use super::history::CommandHistory;
 use super::vim::{self, VimState};
+use crate::components::build_upload_message;
 use crate::components::VoiceInput;
 use crate::pages::dashboard::load_vim_mode;
 use crate::utils::format_file_size;
@@ -1122,29 +1123,6 @@ impl InputBar {
     }
 }
 
-/// Compose the combined user-text + file-list message the upload pipeline
-/// sends to Claude after the last chunk lands. Pulled out so the message
-/// shape (preserved verbatim from the pre-extraction behavior) is
-/// unit-testable without a `web_sys::File`.
-fn build_upload_message(user_input: &str, files: &[(String, u64)]) -> String {
-    let file_list: Vec<String> = files
-        .iter()
-        .map(|(name, size)| format!("- {} ({})", name, format_file_size(*size)))
-        .collect();
-    let list = file_list.join("\n");
-    if user_input.is_empty() {
-        format!(
-            "I've uploaded the following files to your working directory:\n{}",
-            list
-        )
-    } else {
-        format!(
-            "{}\n\nI've uploaded the following files to your working directory:\n{}",
-            user_input, list
-        )
-    }
-}
-
 /// Add agent-facing context to text produced by speech recognition. The
 /// reminder stays out of the textarea and command history, while the shared
 /// markdown path renders it as the established compact reminder bumper in the
@@ -1168,56 +1146,6 @@ mod tests {
         );
         assert!(prompt.contains("consider phonetic interpretations"));
         assert!(shared::system_reminder::has_system_reminder(&prompt));
-    }
-
-    // --- build_upload_message ---
-
-    #[test]
-    fn build_upload_message_with_user_text_prepends_text_and_blank_line() {
-        let files = vec![("a.txt".to_string(), 100u64)];
-        let out = build_upload_message("hello", &files);
-        assert_eq!(
-            out,
-            "hello\n\nI've uploaded the following files to your working directory:\n- a.txt (100 B)"
-        );
-    }
-
-    #[test]
-    fn build_upload_message_without_user_text_omits_blank_line_and_header() {
-        let files = vec![("a.txt".to_string(), 100u64)];
-        let out = build_upload_message("", &files);
-        assert_eq!(
-            out,
-            "I've uploaded the following files to your working directory:\n- a.txt (100 B)"
-        );
-    }
-
-    #[test]
-    fn build_upload_message_lists_one_file_per_line_in_input_order() {
-        let files = vec![
-            ("first.png".to_string(), 1024u64),
-            ("second.jpg".to_string(), 2 * 1024 * 1024),
-            ("third.txt".to_string(), 42u64),
-        ];
-        let out = build_upload_message("ship it", &files);
-        // Verify the ordering matches the input vec — the bar relies on
-        // this so the user sees the files they picked in the order they
-        // picked them.
-        let expected = "ship it\n\nI've uploaded the following files to your working directory:\n- first.png (1.0 KB)\n- second.jpg (2.0 MB)\n- third.txt (42 B)";
-        assert_eq!(out, expected);
-    }
-
-    #[test]
-    fn build_upload_message_with_empty_file_list_still_renders_header() {
-        // Defensive: an empty list shouldn't crash, even though the
-        // upload pipeline always supplies at least one file. The format
-        // ends with just the header + a trailing colon + newline; no list
-        // rows.
-        let out = build_upload_message("", &[]);
-        assert_eq!(
-            out,
-            "I've uploaded the following files to your working directory:\n"
-        );
     }
 
     // --- slash command pass-through ---

--- a/frontend/styles/messages.css
+++ b/frontend/styles/messages.css
@@ -154,6 +154,36 @@
     border-left: 3px solid #7dcfff;
 }
 
+/* Upload receipt: the transcript rendering of the agent-facing "I've
+   uploaded the following files…" notice — the user's own words (if any)
+   above a row of attachment chips, instead of machine boilerplate presented
+   as the user's message. */
+.upload-notice {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.25rem;
+}
+
+.upload-chip {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.4rem;
+    background: rgba(125, 207, 255, 0.08);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 0.25rem 0.6rem;
+    font-size: 0.85rem;
+    color: var(--text-primary);
+    word-break: break-all;
+}
+
+.upload-chip-size {
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    white-space: nowrap;
+}
+
 /* Secret-drop receipt: the transcript's only record of a Ctrl+Shift+Enter
    secret send — a lock, the generated drop filename, and the byte count.
    Without the gap the spans run together ("…548a19 bytes"). The filename can


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/721629d71bf6d7323f91c946777674ef50f21afa/.0-pr-viz/001921.svg)

The upload pipeline sends the agent "I've uploaded the following files to your working directory: …" — necessary wire text (the files really did just appear on the agent's disk), but the transcript rendered that boilerplate verbatim under the **You** badge, as if the user typed it. Most grating on muse sessions, where no inline media preview softens it: the boilerplate *is* the whole message.

- `build_upload_message` moves from `input_bar` into a new `components::upload_notice` module, paired with a strict `split_upload_notice` parser that recovers the user's own words and the `(name, size)` rows. One module, one round-trip test — builder and parser cannot drift.
- Both user-message render paths (optimistic echo and durable user frames) now show the user's words plus compact 📎 attachment chips instead of the prose. Parsing is deliberately strict: a message that merely quotes the sentence, or a malformed row, renders as ordinary prose.
- Agent-facing wire text is byte-identical — the agent still gets told about its new files.
