### PR TITLE
Keep the composer usable while the server restarts

### DIFF
--- a/.0-pr-viz/001922.svg
+++ b/.0-pr-viz/001922.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2000" height="1200" viewBox="0 0 2000 1200" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <!-- Thesis -->
+  <text x="1000" y="64" text-anchor="middle" fill="#c0caf5" font-size="34" font-weight="bold">The text bar stays usable through a server restart — typing queues, reconnect delivers</text>
+
+  <!-- BEFORE / AFTER labels -->
+  <text x="500" y="126" text-anchor="middle" fill="#f7768e" font-size="26" font-weight="bold" letter-spacing="4">BEFORE</text>
+  <text x="1500" y="126" text-anchor="middle" fill="#9ece6a" font-size="26" font-weight="bold" letter-spacing="4">AFTER</text>
+  <line x1="1000" y1="96" x2="1000" y2="1140" stroke="#565f89" stroke-width="2" stroke-dasharray="8 8"/>
+
+  <!-- BEFORE -->
+  <g>
+    <text x="180" y="210" fill="#a9b1d6" font-size="19" font-weight="bold">During a restart / deploy window:</text>
+
+    <!-- banner -->
+    <rect x="180" y="250" width="680" height="44" rx="8" fill="#1e202e" stroke="#e0af68" stroke-width="1.5"/>
+    <text x="520" y="278" text-anchor="middle" fill="#e0af68" font-size="15">Server restarting (update) — reconnecting…</text>
+
+    <!-- locked input bar -->
+    <rect x="180" y="320" width="560" height="52" rx="10" fill="#1e202e" stroke="#3d4666" stroke-width="1.5" opacity="0.5"/>
+    <text x="200" y="352" fill="#565f89" font-size="15" opacity="0.6">Type your message…</text>
+    <rect x="756" y="320" width="104" height="52" rx="10" fill="#1e202e" stroke="#3d4666" stroke-width="1.5" opacity="0.5"/>
+    <text x="808" y="352" text-anchor="middle" fill="#565f89" font-size="15" opacity="0.6">Send</text>
+    <text x="520" y="404" text-anchor="middle" fill="#f7768e" font-size="15" font-style="italic">disabled — clicks and keystrokes bounce off for the whole window</text>
+
+    <rect x="150" y="460" width="700" height="230" rx="12" fill="#1e202e" stroke="#565f89" stroke-width="1.5"/>
+    <text x="180" y="498" fill="#f7768e" font-size="19" font-weight="bold">The irony: offline delivery already existed</text>
+    <text x="180" y="534" fill="#c0caf5" font-size="16">- the outbox records every send, flushes on reconnect,</text>
+    <text x="180" y="562" fill="#c0caf5" font-size="16">  and the backend dedupes by client_msg_id (#1236)</text>
+    <text x="180" y="590" fill="#c0caf5" font-size="16">- but disabled={!ws_connected} on the textarea + Send button</text>
+    <text x="180" y="618" fill="#c0caf5" font-size="16">  meant nothing could ever reach that machinery</text>
+    <text x="180" y="646" fill="#c0caf5" font-size="16">- your half-formed thought waits on someone else's deploy</text>
+  </g>
+
+  <!-- AFTER -->
+  <g>
+    <text x="1180" y="210" fill="#a9b1d6" font-size="19" font-weight="bold">Same restart window:</text>
+
+    <rect x="1180" y="250" width="680" height="44" rx="8" fill="#1e202e" stroke="#e0af68" stroke-width="1.5"/>
+    <text x="1520" y="278" text-anchor="middle" fill="#e0af68" font-size="15">Server restarting (update) — reconnecting…</text>
+
+    <!-- live input bar -->
+    <rect x="1180" y="320" width="560" height="52" rx="10" fill="#1e202e" stroke="#7aa2f7" stroke-width="1.5"/>
+    <text x="1200" y="352" fill="#c0caf5" font-size="15">also update the readme when you're done|</text>
+    <rect x="1756" y="320" width="104" height="52" rx="10" fill="#1e202e" stroke="#7aa2f7" stroke-width="1.5"/>
+    <text x="1808" y="352" text-anchor="middle" fill="#7aa2f7" font-size="15">Send</text>
+    <!-- pending echo -->
+    <rect x="1180" y="392" width="500" height="40" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="1200" y="417" fill="#c0caf5" font-size="14">also update the readme when you're done</text>
+    <text x="1640" y="417" fill="#e0af68" font-size="13">sent ●</text>
+    <text x="1520" y="462" text-anchor="middle" fill="#9ece6a" font-size="15" font-style="italic">queued as pending; flushes the moment the socket returns</text>
+
+    <rect x="1150" y="500" width="700" height="230" rx="12" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1180" y="538" fill="#9ece6a" font-size="19" font-weight="bold">What changed (input_bar.rs only):</text>
+    <text x="1180" y="574" fill="#c0caf5" font-size="16">- textarea + Send + mode toggle: no longer gated on the socket</text>
+    <text x="1180" y="602" fill="#c0caf5" font-size="16">- placeholder while down: "Reconnecting — messages will send</text>
+    <text x="1180" y="630" fill="#c0caf5" font-size="16">  when the server is back"</text>
+    <text x="1180" y="658" fill="#c0caf5" font-size="16">- attachments stay socket-gated: upload chunk frames are</text>
+    <text x="1180" y="686" fill="#c0caf5" font-size="16">  fire-and-forget and genuinely need the live connection</text>
+  </g>
+
+  <!-- bottom strip -->
+  <text x="500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">Delivery machinery untouched — this only unlocks the door to it</text>
+  <text x="1500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">Reconnect still hands focus back to the focused session's bar</text>
+
+  <!-- Footer limitation -->
+  <text x="1000" y="1190" text-anchor="middle" fill="#565f89" font-size="15" font-style="italic">Limitation: voice input stays disabled while disconnected (server STT needs the backend), and the 50-entry outbox cap still bounds a long offline backlog.</text>
+</svg>

--- a/frontend/src/pages/dashboard/session_view/input_bar.rs
+++ b/frontend/src/pages/dashboard/session_view/input_bar.rs
@@ -251,11 +251,11 @@ impl Component for InputBar {
         let became_focused = now_focused && !self.was_focused;
         self.was_focused = now_focused;
 
-        // A just-launched session mounts with its socket still down, so the
-        // textarea is `disabled` and the mount-time focus (see `rendered`)
-        // no-ops on a disabled node. Re-apply focus when the socket comes up
-        // while this bar is the focused session's, so the composer is ready to
-        // type in without a stray click (#1405).
+        // Re-apply focus when the socket comes up while this bar is the
+        // focused session's, so after a launch or a server restart the
+        // composer is ready to type in without a stray click (#1405). (The
+        // textarea itself stays enabled while disconnected — sends queue in
+        // the outbox — but page-load/dialog focus stealing still applies.)
         let now_connected = ctx.props().ws_connected;
         let became_connected = now_connected && !self.was_ws_connected;
         self.was_ws_connected = now_connected;
@@ -272,12 +272,10 @@ impl Component for InputBar {
             self.focus_after_render = false;
             // Focus immediately for the common case (switching to an
             // already-mounted, enabled session). Two things can defeat that
-            // synchronous focus, and both hit the new-session path (#1405):
-            //   1. the textarea is `disabled` while the just-launched session's
-            //      socket comes up, so `.focus()` no-ops on it; and
-            //   2. even once it lands, the browser can restore focus to the
-            //      document as a page load — or a just-closed launch dialog —
-            //      settles, silently stealing it (#1373).
+            // synchronous focus on the new-session path (#1405): the browser
+            // can restore focus to the document as a page load — or a
+            // just-closed launch dialog — settles, silently stealing it
+            // (#1373).
             // Re-apply on the next macrotask, after that settles. Originally
             // only the first-render (page-load) path got this retry; the
             // new-session path reaches here via the `became_focused` /
@@ -663,11 +661,18 @@ impl Component for InputBar {
                                 && self.vim.borrow().mode == vim::VimMode::Normal)
                                 .then_some("vim-normal")
                         )}
-                        placeholder={self.pending_suggestion.clone().unwrap_or_else(|| "Type your message... (Shift+Enter for new line)".into())}
+                        placeholder={self.pending_suggestion.clone().unwrap_or_else(|| if ctx.props().ws_connected {
+                            "Type your message... (Shift+Enter for new line)".into()
+                        } else {
+                            // The composer stays usable through a server
+                            // restart: sends queue in the outbox and flush on
+                            // reconnect (#1236), so say so instead of locking
+                            // the box.
+                            "Reconnecting — messages will send when the server is back".into()
+                        })}
                         oninput={handle_input}
                         onkeydown={handle_keydown}
                         onpaste={handle_paste}
-                        disabled={!ctx.props().ws_connected}
                         rows="1"
                     />
                     if self.pending_suggestion.is_some() && self.input_text.is_empty() {
@@ -1068,7 +1073,7 @@ impl InputBar {
                 <button
                     type="submit"
                     class="send-button"
-                    disabled={!ws_connected || is_uploading}
+                    disabled={is_uploading}
                     onclick={on_send}
                 >
                     { "Send" }
@@ -1076,7 +1081,7 @@ impl InputBar {
                 <button
                     type="button"
                     class="send-mode-toggle"
-                    disabled={!ws_connected || is_uploading}
+                    disabled={is_uploading}
                     onclick={on_toggle_dropdown}
                 >
                     { "\u{25bc}" }
@@ -1104,6 +1109,8 @@ impl InputBar {
                     <button
                         type="button"
                         class="dropdown-option attachment"
+                        disabled={!ws_connected}
+                        title={if ws_connected { "" } else { "File uploads need the live connection" }}
                         onclick={on_attach_dropdown}
                     >
                         { "Send with attachment(s)" }


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/cab01179351d7129345b08b3201c0ebd7ee9fa6d/.0-pr-viz/001922.svg)

During a server restart the composer textarea, Send button, and mode toggle were all `disabled={!ws_connected}` — the text bar locked for the whole reconnect window. The irony: the offline-delivery machinery already existed end-to-end (outbox records every send, renders it as a pending echo, flushes on reconnect, backend dedupes by `client_msg_id`), but the disabled attributes meant nothing could reach it.

- Textarea, Send, and the send-mode toggle stay enabled while the socket is down; sends queue and flush on reconnect.
- The placeholder switches to "Reconnecting — messages will send when the server is back" so the state is legible.
- Attachments remain socket-gated (upload chunk frames are fire-and-forget and genuinely need the live connection), with a tooltip saying why.
- The reconnect-time focus handoff to the focused session's bar is kept; its comments now describe the real reason (focus stealing) rather than the removed disabled-node problem.
