### PR TITLE
Dedupe empty-string guard in permission display

### DIFF
--- a/.0-pr-viz/001924.svg
+++ b/.0-pr-viz/001924.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200" font-family="'Segoe UI','Noto Sans','DejaVu Sans',ui-sans-serif,system-ui,sans-serif">
+<rect width="2000" height="1200" fill="#16161e"/>
+<text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1924 · dedupe empty-string guard in permission display</text>
+<text x="55" y="100" font-size="34" fill="#e6e9f5">One non_empty helper serves three call sites; behavior unchanged.</text>
+<line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666"/>
+<text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+<text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+<line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+<rect x="80" y="270" width="840" height="300" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="325" font-size="26" fill="#c0caf5">three call sites hand-roll the guard</text>
+<text x="108" y="380" font-size="23" fill="#a9b1d6">.as_deref().filter(|s| !s.is_empty()), copied 3x</text>
+<text x="108" y="430" font-size="23" fill="#f7768e">FileChange reason, grantRoot, Permissions reason</text>
+<text x="108" y="480" font-size="23" fill="#f7768e">empty-string rule lives in three places</text>
+<rect x="80" y="650" width="840" height="245" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="705" font-size="26" fill="#c0caf5">no test pins the empty case</text>
+<text x="108" y="760" font-size="23" fill="#a9b1d6">empty reason renders nothing, but only by convention</text>
+<text x="108" y="810" font-size="23" fill="#f7768e">a future arm could easily emit a blank line</text>
+<rect x="1065" y="270" width="860" height="300" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="325" font-size="26" fill="#7aa2f7">all three route through non_empty</text>
+<text x="1093" y="380" font-size="23" fill="#a9b1d6">one fn: keep Option&lt;&amp;str&gt; only when non-empty</text>
+<text x="1093" y="430" font-size="23" fill="#9ece6a">FileChange reason + grantRoot, Permissions share it</text>
+<text x="1093" y="480" font-size="23" fill="#9ece6a">6 frontend tests green, clippy and fmt clean</text>
+<rect x="1065" y="650" width="860" height="245" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="705" font-size="26" fill="#7aa2f7">new test pins empty omission</text>
+<text x="1093" y="760" font-size="23" fill="#a9b1d6">empty reason/grantRoot render no extra lines</text>
+<text x="1093" y="810" font-size="23" fill="#9ece6a">the rule now has one home and one guard test</text>
+<text x="55" y="1172" font-size="22" fill="#565f89">Scope: frontend/src/pages/dashboard/types.rs only; no UI or protocol change.</text>
+</svg>

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -280,6 +280,12 @@ fn pretty_input<T: serde::Serialize + std::fmt::Debug + ?Sized>(input: &T) -> St
     serde_json::to_string_pretty(input).unwrap_or_else(|_| format!("{:?}", input))
 }
 
+/// Keep an optional string only when it is present and non-empty, so empty
+/// `reason`/`grant_root` fields are omitted instead of rendering blank lines.
+fn non_empty(opt: Option<&str>) -> Option<&str> {
+    opt.filter(|s| !s.is_empty())
+}
+
 /// Render a Claude-side permission tool input from the SDK's named,
 /// typed `ToolInput` parser.
 fn format_claude_permission_input(tool_name: &str, input: &serde_json::Value) -> String {
@@ -316,10 +322,10 @@ fn format_codex_permission_input(input: &shared::CodexPermissionInput) -> String
                 lines.extend(paths.iter().map(|p| format!("  {}", p)));
                 lines
             };
-            if let Some(r) = reason.as_deref().filter(|s| !s.is_empty()) {
+            if let Some(r) = non_empty(reason.as_deref()) {
                 lines.push(format!("Reason: {}", r));
             }
-            if let Some(g) = grant_root.as_deref().filter(|s| !s.is_empty()) {
+            if let Some(g) = non_empty(grant_root.as_deref()) {
                 lines.push(format!("Grant root: {}", g));
             }
             lines.join("\n")
@@ -335,9 +341,7 @@ fn format_codex_permission_input(input: &shared::CodexPermissionInput) -> String
         C::Bash { command, .. } | C::ExecCommand { command, .. } => {
             format!("$ {}", command)
         }
-        C::Permissions { reason, .. } => reason
-            .as_deref()
-            .filter(|s| !s.is_empty())
+        C::Permissions { reason, .. } => non_empty(reason.as_deref())
             .map(|s| s.to_string())
             .unwrap_or_else(|| pretty_input(input)),
         C::McpElicitation { server_name } => {
@@ -419,6 +423,22 @@ mod tests {
         assert_eq!(
             format_permission_input("FileChange", &input),
             "File change 2 file(s):\n  src/main.rs\n  tests/app.rs\nReason: needs approval"
+        );
+    }
+
+    #[test]
+    fn format_codex_file_change_omits_empty_reason_and_grant_root() {
+        let input = serde_json::json!({
+            "tool": "fileChange",
+            "itemId": "fc1",
+            "paths": ["src/main.rs"],
+            "reason": "",
+            "grantRoot": ""
+        });
+
+        assert_eq!(
+            format_permission_input("FileChange", &input),
+            "File change 1 file(s):\n  src/main.rs"
         );
     }
 }


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/e1b1d0bf2eae6189723e85e5483ed1238eadda5f/.0-pr-viz/001924.svg)

Dedupes the three `.filter(|s| !s.is_empty())` guards in `format_codex_permission_input` into a small `non_empty` helper. No behavior change; adds a regression test pinning that empty reason/grantRoot are omitted.