### PR TITLE
Move the Visual PR check to meawoppl/visual-pr@v3

### DIFF
--- a/.github/workflows/visual-pr.yml
+++ b/.github/workflows/visual-pr.yml
@@ -37,7 +37,7 @@ jobs:
           path: pr-head
           sparse-checkout: .0-pr-viz
 
-      - uses: meawoppl/visual-pr@v2
+      - uses: meawoppl/visual-pr@v3
         with:
           head-path: pr-head
           style: .github/visual-pr/style.json


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/0f98f3fee9ace08753137897e9734fd4ff71282b/.0-pr-viz/001925.svg)

`v3` of the upstream action shrinks the validator's glyph allowlist to ASCII + Latin-1. `v2` admitted arrows (`→`), math operators (`− ≤ ≈`), dashes and check marks that then rendered as empty boxes on a real reviewer's screen — the failure the allowlist exists to prevent (meawoppl/visual-pr#10). Under `v3` those are hard errors and the error names the ASCII replacement (`->`, `<=`, `~`, `-`, `...`, `+`, `x`; `&lt;` for `<` in SVG text).

Merged visuals are never re-checked; only new PRs feel this. Nothing else about the check changes.

