### PR TITLE
Show the running model in the session header for every agent

### DIFF
--- a/.0-pr-viz/001925.svg
+++ b/.0-pr-viz/001925.svg
@@ -25,7 +25,7 @@
   <g>
     <rect x="80" y="430" width="620" height="150" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
     <text x="104" y="470" font-size="26" fill="#c0caf5">v2 check_svg.py glyph allowlist</text>
-    <text x="104" y="508" font-size="23" fill="#a9b1d6">Latin-1 + Greek + Cyrillic + 2190-21FF + 2200-22FF + ...</text>
+    <text x="104" y="508" font-size="23" fill="#a9b1d6">Latin-1, Greek, Cyrillic, 2190-21FF, 2200-22FF, ...</text>
     <text x="104" y="544" font-size="22" fill="#565f89">built from font tables, never from a viewer</text>
   </g>
   <line x1="390" y1="580" x2="390" y2="660" stroke="#f7768e" stroke-width="1.5" marker-end="url(#arr-red)"/>

--- a/.0-pr-viz/001925.svg
+++ b/.0-pr-viz/001925.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#565f89"/></marker>
+    <marker id="arr-red" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#f7768e"/></marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/></marker>
+  </defs>
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1925 - Move the Visual PR check to meawoppl/visual-pr@v3</text>
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Under @v2 a PR visual could pass the check and still show reviewers empty boxes for arrows and math signs;</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">@v3 only admits ASCII + Latin-1, so a passing visual now draws every character on the reviewer's screen.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <!-- BEFORE -->
+  <g>
+    <rect x="80" y="250" width="620" height="130" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="104" y="290" font-size="26" fill="#7aa2f7">.github/workflows/visual-pr.yml</text>
+    <text x="104" y="328" font-size="23" fill="#a9b1d6">uses: meawoppl/visual-pr@v2</text>
+    <text x="104" y="362" font-size="22" fill="#565f89">style: .github/visual-pr/style.json (no "glyphs" key)</text>
+  </g>
+  <line x1="390" y1="380" x2="390" y2="425" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+  <g>
+    <rect x="80" y="430" width="620" height="150" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="104" y="470" font-size="26" fill="#c0caf5">v2 check_svg.py glyph allowlist</text>
+    <text x="104" y="508" font-size="23" fill="#a9b1d6">Latin-1 + Greek + Cyrillic + 2190-21FF + 2200-22FF + ...</text>
+    <text x="104" y="544" font-size="22" fill="#565f89">built from font tables, never from a viewer</text>
+  </g>
+  <line x1="390" y1="580" x2="390" y2="660" stroke="#f7768e" stroke-width="1.5" marker-end="url(#arr-red)"/>
+  <line x1="330" y1="675" x2="450" y2="675" stroke="#f7768e" stroke-width="3"/>
+  <text x="390" y="720" font-size="23" fill="#f7768e" text-anchor="middle">U+2192, U+2212, U+2248 pass, then draw as boxes</text>
+  <text x="390" y="752" font-size="22" fill="#565f89" text-anchor="middle">seen on a real PR in a sibling repo (visual-pr#10)</text>
+  <g>
+    <rect x="80" y="960" width="860" height="120" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="1006" font-size="26" fill="#c0caf5">"ok: 0 warning(s)" on a diagram with holes in it</text>
+    <text x="104" y="1046" font-size="23" fill="#f7768e">the check vouched for something the reviewer could not read</text>
+  </g>
+
+  <!-- AFTER -->
+  <g>
+    <rect x="1065" y="250" width="620" height="130" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1089" y="290" font-size="26" fill="#7aa2f7">.github/workflows/visual-pr.yml</text>
+    <text x="1089" y="328" font-size="23" fill="#9ece6a">uses: meawoppl/visual-pr@v3</text>
+    <text x="1089" y="362" font-size="22" fill="#565f89">the only line this PR changes</text>
+  </g>
+  <line x1="1375" y1="380" x2="1375" y2="425" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+  <g>
+    <rect x="1065" y="430" width="620" height="150" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1089" y="470" font-size="26" fill="#9ece6a">v3 allowlist: 0020-007E, 00A0-00FF</text>
+    <text x="1089" y="508" font-size="23" fill="#a9b1d6">anything else is an ERROR naming its stand-in</text>
+    <text x="1089" y="544" font-size="22" fill="#565f89">-> &lt;= ~ - ... + x  (write &lt; as &amp;lt; in SVG text)</text>
+  </g>
+  <g>
+    <rect x="1065" y="640" width="860" height="130" fill="#1e202e" stroke="#e0af68" stroke-width="1.5"/>
+    <text x="1089" y="680" font-size="24" fill="#e0af68">Merged visuals are never re-checked</text>
+    <text x="1089" y="716" font-size="22" fill="#a9b1d6">only new PRs feel this; existing .0-pr-viz files stay as they are</text>
+    <text x="1089" y="748" font-size="22" fill="#565f89">style.json unchanged: with no "glyphs" key it inherits the v3 default</text>
+  </g>
+  <g>
+    <rect x="1065" y="960" width="860" height="120" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="1006" font-size="26" fill="#c0caf5">A passing visual draws every character for the reviewer</text>
+    <text x="1089" y="1046" font-size="23" fill="#9ece6a">and a rejected one tells the author exactly what to type instead</text>
+  </g>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">Latin-1 is kept on the evidence of one viewer plus a DejaVu render; if this repo's reviewers see a box in it, the upstream list shrinks again.</text>
+</svg>

--- a/.0-pr-viz/001926.svg
+++ b/.0-pr-viz/001926.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2000" height="1200" viewBox="0 0 2000 1200" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <!-- Thesis -->
+  <text x="1000" y="64" text-anchor="middle" fill="#c0caf5" font-size="34" font-weight="bold">Every session header now names its model - codex and muse chats stop being anonymous</text>
+
+  <!-- BEFORE / AFTER labels -->
+  <text x="500" y="126" text-anchor="middle" fill="#f7768e" font-size="26" font-weight="bold" letter-spacing="4">BEFORE</text>
+  <text x="1500" y="126" text-anchor="middle" fill="#9ece6a" font-size="26" font-weight="bold" letter-spacing="4">AFTER</text>
+  <line x1="1000" y1="96" x2="1000" y2="1140" stroke="#565f89" stroke-width="2" stroke-dasharray="8 8"/>
+
+  <!-- BEFORE -->
+  <g>
+    <text x="180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">A codex session's chat header:</text>
+    <rect x="180" y="230" width="680" height="52" rx="10" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="200" y="262" fill="#c0caf5" font-size="16" font-weight="bold">rps-arena</text>
+    <text x="300" y="262" fill="#565f89" font-size="14">zeus</text>
+    <text x="352" y="262" fill="#565f89" font-size="13" font-family="monospace">~/repos/rps-arena</text>
+    <rect x="560" y="238" width="112" height="30" rx="5" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="616" y="258" text-anchor="middle" fill="#565f89" font-size="12" font-family="monospace">launcher v2.14</text>
+    <rect x="684" y="238" width="70" height="30" rx="15" fill="#1e202e" stroke="#9ece6a" stroke-width="1"/>
+    <text x="719" y="258" text-anchor="middle" fill="#9ece6a" font-size="12">active</text>
+    <text x="520" y="316" text-anchor="middle" fill="#f7768e" font-size="15" font-style="italic">gpt-5.4? gpt-5.4-sol? codex-mini? - the chat never says</text>
+
+    <text x="180" y="380" fill="#a9b1d6" font-size="19" font-weight="bold">Why claude sessions felt different:</text>
+    <rect x="150" y="410" width="700" height="260" rx="12" fill="#1e202e" stroke="#565f89" stroke-width="1.5"/>
+    <text x="180" y="448" fill="#c0caf5" font-size="16">- claude's wire carries `model` on every assistant message,</text>
+    <text x="180" y="476" fill="#c0caf5" font-size="16">  so each transcript badge names it (Opus 4.8, Fable 5, ...)</text>
+    <text x="180" y="504" fill="#c0caf5" font-size="16">- codex ThreadItems and muse journal records carry no</text>
+    <text x="180" y="532" fill="#c0caf5" font-size="16">  per-message model; muse's run.model.configured record is</text>
+    <text x="180" y="560" fill="#c0caf5" font-size="16">  deliberately screened from the transcript as setup noise</text>
+    <text x="180" y="588" fill="#c0caf5" font-size="16">- the rail pill has a model watermark, but the place you</text>
+    <text x="180" y="616" fill="#c0caf5" font-size="16">  actually read - the chat - said nothing</text>
+  </g>
+
+  <!-- AFTER -->
+  <g>
+    <text x="1180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">Same header, model chip for every agent:</text>
+    <rect x="1180" y="230" width="680" height="52" rx="10" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="1200" y="262" fill="#c0caf5" font-size="16" font-weight="bold">rps-arena</text>
+    <rect x="1296" y="238" width="120" height="30" rx="5" fill="#1e202e" stroke="#bb9af7" stroke-width="1.5"/>
+    <text x="1356" y="258" text-anchor="middle" fill="#bb9af7" font-size="12" font-family="monospace">gpt-5.4-sol</text>
+    <text x="1432" y="262" fill="#565f89" font-size="14">zeus</text>
+    <text x="1484" y="262" fill="#565f89" font-size="13" font-family="monospace">~/repos/rps-arena</text>
+    <rect x="1684" y="238" width="70" height="30" rx="15" fill="#1e202e" stroke="#9ece6a" stroke-width="1"/>
+    <text x="1719" y="258" text-anchor="middle" fill="#9ece6a" font-size="12">active</text>
+    <text x="1520" y="316" text-anchor="middle" fill="#9ece6a" font-size="15" font-style="italic">works for muse (llama4-maverick-mm) and claude alike</text>
+
+    <text x="1180" y="380" fill="#a9b1d6" font-size="19" font-weight="bold">Where the value comes from:</text>
+    <rect x="1150" y="410" width="700" height="260" rx="12" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1180" y="448" fill="#c0caf5" font-size="16">- sessions.last_model, written by the backend from turn</text>
+    <text x="1180" y="476" fill="#c0caf5" font-size="16">  metrics - which all three agents emit (muse since #1882)</text>
+    <text x="1180" y="504" fill="#c0caf5" font-size="16">- the page already overlays the live turn's model, so a</text>
+    <text x="1180" y="532" fill="#c0caf5" font-size="16">  mid-session model switch updates the chip immediately</text>
+    <text x="1180" y="560" fill="#c0caf5" font-size="16">- stays visible on phones: hostname and path are hidden</text>
+    <text x="1180" y="588" fill="#c0caf5" font-size="16">  there, but the model is the short, high-value datum</text>
+    <text x="1180" y="616" fill="#c0caf5" font-size="16">- no wire or backend change - the column already existed</text>
+  </g>
+
+  <!-- Footer limitation -->
+  <text x="1000" y="1190" text-anchor="middle" fill="#565f89" font-size="15" font-style="italic">Limitation: the chip is empty until a session's first completed turn reports metrics - a freshly launched session shows no model yet.</text>
+</svg>

--- a/.github/workflows/visual-pr.yml
+++ b/.github/workflows/visual-pr.yml
@@ -37,7 +37,7 @@ jobs:
           path: pr-head
           sparse-checkout: .0-pr-viz
 
-      - uses: meawoppl/visual-pr@v2
+      - uses: meawoppl/visual-pr@v3
         with:
           head-path: pr-head
           style: .github/visual-pr/style.json

--- a/frontend/src/pages/dashboard/session_view/component.rs
+++ b/frontend/src/pages/dashboard/session_view/component.rs
@@ -712,6 +712,17 @@ impl Component for SessionView {
             <div class={classes!("session-view", ctx.props().focused.then_some("focused"))}>
                 <div class="session-view-header">
                     <span class="session-name">{ &ctx.props().session.session_name }</span>
+                    // Which model this session is running — claude's transcript
+                    // badges carry it per-message, but codex and muse wire
+                    // events don't, so the header is the one place it reads
+                    // uniformly. `last_model` comes from turn metrics (all
+                    // three agents emit them) with the live-turn overlay from
+                    // the page, so it tracks mid-session model switches.
+                    if let Some(model) = ctx.props().session.last_model.as_deref() {
+                        <span class="session-model" title="Model this session last reported">
+                            { model }
+                        </span>
+                    }
                     <span class="session-hostname">{ &ctx.props().session.hostname }</span>
                     <span class="session-path">{ &ctx.props().session.working_directory }</span>
                     if let Some(version) = launcher_version {

--- a/frontend/styles/session-mobile.css
+++ b/frontend/styles/session-mobile.css
@@ -173,6 +173,11 @@
         display: none;
     }
 
+    .session-view-header .session-model {
+        font-size: 0.68rem;
+        padding: 0.15rem 0.35rem;
+    }
+
     .session-view-header .session-launcher-version {
         font-size: 0.7rem;
         padding: 0.15rem 0.35rem;

--- a/frontend/styles/session-terminal.css
+++ b/frontend/styles/session-terminal.css
@@ -78,6 +78,17 @@
     white-space: nowrap;
 }
 
+.session-view-header .session-model {
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+    font-family: monospace;
+    padding: 0.2rem 0.45rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: rgba(187, 154, 247, 0.08);
+    white-space: nowrap;
+}
+
 .session-view-header .session-launcher-version {
     font-size: 0.78rem;
     color: var(--text-secondary);


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/1c1d6571e12eb4bd8af5097b73363a1f428ae47b/.0-pr-viz/001926.svg)

Claude sessions reveal their model through the per-message assistant badge (claude's wire carries `model` on every assistant frame). Codex ThreadItems and muse journal records don't — and muse's `run.model.configured` record is deliberately screened from the transcript as setup noise — so their chats never said which model was running.

The session-view header now shows a **model chip for every agent**, sourced from `sessions.last_model`: written by the backend from turn metrics (all three agents emit them, muse since #1882) and already live-overlaid by the page with the current turn's model, so a mid-session model switch updates the chip immediately. It stays visible on phones, where hostname/path are hidden — the model is the short, high-value datum. No wire or backend change; the column already existed.

Known gap (footer of the visual): a freshly launched session shows no chip until its first turn reports metrics.
