### PR TITLE
Dedupe non-empty string guard into frontend utils

### DIFF
--- a/.0-pr-viz/001927.svg
+++ b/.0-pr-viz/001927.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200" font-family="'Segoe UI','Noto Sans','DejaVu Sans',ui-sans-serif,system-ui,sans-serif">
+<rect width="2000" height="1200" fill="#16161e"/>
+<text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1927 · dedupe non-empty string guard into frontend utils</text>
+<text x="55" y="100" font-size="34" fill="#e6e9f5">One trim-aware non_empty in utils serves every call site.</text>
+<line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666"/>
+<text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+<text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+<line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+<rect x="80" y="270" width="840" height="300" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="325" font-size="26" fill="#c0caf5">two private non_empty helpers disagree</text>
+<text x="108" y="380" font-size="23" fill="#a9b1d6">types.rs skips trim; filters.rs trims first</text>
+<text x="108" y="430" font-size="23" fill="#f7768e">McpElicitation hand-rolls server_name.is_empty</text>
+<text x="108" y="480" font-size="23" fill="#f7768e">same blank-string rule lives in three places</text>
+<rect x="80" y="650" width="840" height="245" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="705" font-size="26" fill="#c0caf5">whitespace-only slips through dashboard</text>
+<text x="108" y="760" font-size="23" fill="#a9b1d6">reason "    " renders a blank Reason: line</text>
+<text x="108" y="810" font-size="23" fill="#f7768e">blank serverName renders backticked blanks</text>
+<rect x="1065" y="270" width="860" height="300" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="325" font-size="26" fill="#7aa2f7">pub fn non_empty lives in utils.rs</text>
+<text x="1093" y="380" font-size="23" fill="#a9b1d6">one fn: Option&lt;&amp;str&gt; trims, keeps non-blank</text>
+<text x="1093" y="430" font-size="23" fill="#9ece6a">types.rs plus filters.rs import and reuse it</text>
+<text x="1093" y="480" font-size="23" fill="#9ece6a">McpElicitation routes through it as well</text>
+<rect x="1065" y="650" width="860" height="245" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="705" font-size="26" fill="#7aa2f7">blank inputs treated as absent, with tests</text>
+<text x="1093" y="760" font-size="23" fill="#a9b1d6">whitespace reason and serverName omitted</text>
+<text x="1093" y="810" font-size="23" fill="#9ece6a">695 frontend tests green, clippy and fmt clean</text>
+<text x="55" y="1172" font-size="22" fill="#565f89">Scope: frontend utils, dashboard types, history filters; no protocol change.</text>
+</svg>

--- a/frontend/src/pages/dashboard/types.rs
+++ b/frontend/src/pages/dashboard/types.rs
@@ -1,6 +1,6 @@
 //! Shared types for the dashboard module
 
-use crate::utils::{storage_get, storage_set};
+use crate::utils::{non_empty, storage_get, storage_set};
 use serde::Deserialize;
 use shared::ToolInput;
 use std::collections::{HashMap, HashSet};
@@ -280,12 +280,6 @@ fn pretty_input<T: serde::Serialize + std::fmt::Debug + ?Sized>(input: &T) -> St
     serde_json::to_string_pretty(input).unwrap_or_else(|_| format!("{:?}", input))
 }
 
-/// Keep an optional string only when it is present and non-empty, so empty
-/// `reason`/`grant_root` fields are omitted instead of rendering blank lines.
-fn non_empty(opt: Option<&str>) -> Option<&str> {
-    opt.filter(|s| !s.is_empty())
-}
-
 /// Render a Claude-side permission tool input from the SDK's named,
 /// typed `ToolInput` parser.
 fn format_claude_permission_input(tool_name: &str, input: &serde_json::Value) -> String {
@@ -344,13 +338,9 @@ fn format_codex_permission_input(input: &shared::CodexPermissionInput) -> String
         C::Permissions { reason, .. } => non_empty(reason.as_deref())
             .map(|s| s.to_string())
             .unwrap_or_else(|| pretty_input(input)),
-        C::McpElicitation { server_name } => {
-            if server_name.is_empty() {
-                "MCP server is asking for input".to_string()
-            } else {
-                format!("MCP server `{}` is asking for input", server_name)
-            }
-        }
+        C::McpElicitation { server_name } => non_empty(Some(server_name.as_str()))
+            .map(|s| format!("MCP server `{}` is asking for input", s))
+            .unwrap_or_else(|| "MCP server is asking for input".to_string()),
         C::AskUserQuestion { .. } => {
             // The AskUserQuestion renderer is invoked elsewhere in the
             // permission dialog; this code path is only hit for the
@@ -423,6 +413,43 @@ mod tests {
         assert_eq!(
             format_permission_input("FileChange", &input),
             "File change 2 file(s):\n  src/main.rs\n  tests/app.rs\nReason: needs approval"
+        );
+    }
+
+    #[test]
+    fn format_codex_file_change_omits_whitespace_only_reason_and_grant_root() {
+        let input = serde_json::json!({
+            "tool": "fileChange",
+            "itemId": "fc1",
+            "paths": ["src/main.rs"],
+            "reason": "   ",
+            "grantRoot": "  "
+        });
+
+        assert_eq!(
+            format_permission_input("FileChange", &input),
+            "File change 1 file(s):\n  src/main.rs"
+        );
+    }
+
+    #[test]
+    fn format_mcp_elicitation_omits_blank_server_name() {
+        let blank = serde_json::json!({
+            "tool": "mcpElicitation",
+            "serverName": "   "
+        });
+        assert_eq!(
+            format_permission_input("McpElicitation", &blank),
+            "MCP server is asking for input"
+        );
+
+        let named = serde_json::json!({
+            "tool": "mcpElicitation",
+            "serverName": "github"
+        });
+        assert_eq!(
+            format_permission_input("McpElicitation", &named),
+            "MCP server `github` is asking for input"
         );
     }
 

--- a/frontend/src/pages/history/filters.rs
+++ b/frontend/src/pages/history/filters.rs
@@ -7,6 +7,8 @@
 //! ever holds a single page and filtering that would silently narrow one page
 //! instead of the archive.
 
+use crate::utils::non_empty;
+
 /// Active filter selections from the browser controls. Empty/`None` fields
 /// are "no constraint".
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -41,16 +43,12 @@ impl SessionFilter {
             ("to", &self.to),
             ("q", &self.query),
         ] {
-            if let Some(v) = non_empty(value) {
+            if let Some(v) = non_empty(value.as_deref()) {
                 parts.push(format!("{key}={}", encode_component(v)));
             }
         }
         parts.join("&")
     }
-}
-
-fn non_empty(opt: &Option<String>) -> Option<&str> {
-    opt.as_deref().map(str::trim).filter(|s| !s.is_empty())
 }
 
 /// Percent-encode everything outside the unreserved set. Hand-rolled to keep

--- a/frontend/src/utils.rs
+++ b/frontend/src/utils.rs
@@ -218,6 +218,14 @@ pub fn storage_set(key: &str, value: &str) {
     }
 }
 
+/// Keep a string only when it is present and non-blank.
+///
+/// Trims leading/trailing whitespace so whitespace-only values are treated as
+/// absent instead of rendering blank lines or being sent as empty constraints.
+pub fn non_empty(opt: Option<&str>) -> Option<&str> {
+    opt.map(str::trim).filter(|s| !s.is_empty())
+}
+
 /// Remove a key from browser localStorage, silently doing nothing when
 /// storage is unavailable.
 pub fn storage_remove(key: &str) {
@@ -252,6 +260,14 @@ mod tests {
         assert_eq!(calculate_backoff(2), 4000);
         assert_eq!(calculate_backoff(5), 30000);
         assert_eq!(calculate_backoff(99), 30000);
+    }
+
+    #[test]
+    fn non_empty_treats_missing_empty_and_blank_as_absent() {
+        assert_eq!(non_empty(None), None);
+        assert_eq!(non_empty(Some("")), None);
+        assert_eq!(non_empty(Some("   ")), None);
+        assert_eq!(non_empty(Some("  hi  ")), Some("hi"));
     }
 
     #[test]


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/4c3b41a7d08a12f1514e2f57af3206ca56b63322/.0-pr-viz/001927.svg)

Two private non_empty helpers (dashboard/types.rs without trim, history/filters.rs with trim) plus an inline server_name.is_empty check. Hoists one trim-aware pub fn non_empty into frontend utils and reuses it at all three sites, so whitespace-only reason/grant_root/serverName and filter fields are treated as absent. No core behavior change.
