### PR TITLE
Hide Claude command lifecycle bookkeeping

### DIFF
--- a/.0-pr-viz/001928.svg
+++ b/.0-pr-viz/001928.svg
@@ -27,11 +27,11 @@
   <g>
     <text x="1150" y="220" fill="#a9b1d6" font-size="20" font-weight="bold">The same frame follows an explicit typed path:</text>
     <rect x="1150" y="255" width="700" height="360" rx="14" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
-    <rect x="1200" y="305" width="600" height="70" rx="10" fill="#24283b" stroke="#7aa2f7" stroke-width="1.5"/>
+    <rect x="1200" y="305" width="600" height="70" rx="10" fill="#1e202e" stroke="#7aa2f7" stroke-width="1.5"/>
     <text x="1500" y="348" text-anchor="middle" fill="#7aa2f7" font-size="18" font-family="monospace">ClaudeOutput::CommandLifecycle</text>
     <line x1="1500" y1="375" x2="1500" y2="425" stroke="#565f89" stroke-width="3"/>
     <polygon points="1490,420 1510,420 1500,438" fill="#565f89"/>
-    <rect x="1200" y="445" width="600" height="105" rx="10" fill="#24283b" stroke="#9ece6a" stroke-width="1.5"/>
+    <rect x="1200" y="445" width="600" height="105" rx="10" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
     <text x="1500" y="487" text-anchor="middle" fill="#9ece6a" font-size="18" font-weight="bold">Recognized and suppressed</text>
     <text x="1500" y="522" text-anchor="middle" fill="#a9b1d6" font-size="15">no raw fallback and no empty transcript row</text>
     <text x="1500" y="585" text-anchor="middle" fill="#9ece6a" font-size="15">conversation stays focused on user and agent content</text>
@@ -43,6 +43,5 @@
     <text x="1185" y="855" fill="#a9b1d6" font-size="16">The reported completed-frame shape is pinned by tests.</text>
   </g>
 
-  <text x="1000" y="1050" text-anchor="middle" fill="#bb9af7" font-size="20" font-weight="bold">Typed control signal in; zero transcript cards out</text>
-  <text x="1000" y="1110" text-anchor="middle" fill="#565f89" font-size="15">Scope: #1913 removes the incorrect raw rendering; richer queued/running UI needs an end-to-end UUID correlation contract.</text>
+  <text x="1000" y="1170" text-anchor="middle" fill="#565f89" font-size="15">Scope: #1913 removes raw rendering; richer queued/running UI needs an end-to-end UUID correlation contract.</text>
 </svg>

--- a/.0-pr-viz/001928.svg
+++ b/.0-pr-viz/001928.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2000" height="1200" viewBox="0 0 2000 1200" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+  <text x="1000" y="72" text-anchor="middle" fill="#c0caf5" font-size="34" font-weight="bold">Claude command lifecycle bookkeeping no longer becomes transcript noise</text>
+  <text x="500" y="142" text-anchor="middle" fill="#f7768e" font-size="26" font-weight="bold" letter-spacing="4">BEFORE</text>
+  <text x="1500" y="142" text-anchor="middle" fill="#9ece6a" font-size="26" font-weight="bold" letter-spacing="4">AFTER</text>
+  <line x1="1000" y1="110" x2="1000" y2="1110" stroke="#565f89" stroke-width="2" stroke-dasharray="8 8"/>
+
+  <g>
+    <text x="150" y="220" fill="#a9b1d6" font-size="20" font-weight="bold">A normal completed command emits:</text>
+    <rect x="150" y="255" width="700" height="360" rx="14" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+    <text x="185" y="305" fill="#f7768e" font-size="17" font-weight="bold">Unrecognized Message</text>
+    <text x="185" y="355" fill="#c0caf5" font-size="16" font-family="monospace">{</text>
+    <text x="215" y="390" fill="#c0caf5" font-size="16" font-family="monospace">"type": "command_lifecycle",</text>
+    <text x="215" y="425" fill="#c0caf5" font-size="16" font-family="monospace">"state": "completed",</text>
+    <text x="215" y="460" fill="#c0caf5" font-size="16" font-family="monospace">"command_uuid": "8823a584...",</text>
+    <text x="215" y="495" fill="#c0caf5" font-size="16" font-family="monospace">"session_id": "041ddc00..."</text>
+    <text x="185" y="530" fill="#c0caf5" font-size="16" font-family="monospace">}</text>
+    <text x="500" y="575" text-anchor="middle" fill="#f7768e" font-size="15">transport bookkeeping looked like conversation</text>
+
+    <rect x="150" y="690" width="700" height="205" rx="14" fill="#1e202e" stroke="#565f89" stroke-width="1.5"/>
+    <text x="185" y="740" fill="#c0caf5" font-size="18" font-weight="bold">Render budget impact</text>
+    <text x="185" y="785" fill="#a9b1d6" font-size="16">Each queued / started / completed record counted as</text>
+    <text x="185" y="820" fill="#a9b1d6" font-size="16">one visible history item, pushing useful messages out</text>
+    <text x="185" y="855" fill="#a9b1d6" font-size="16">of both backend hydration and the live client buffer.</text>
+  </g>
+
+  <g>
+    <text x="1150" y="220" fill="#a9b1d6" font-size="20" font-weight="bold">The same frame follows an explicit typed path:</text>
+    <rect x="1150" y="255" width="700" height="360" rx="14" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <rect x="1200" y="305" width="600" height="70" rx="10" fill="#24283b" stroke="#7aa2f7" stroke-width="1.5"/>
+    <text x="1500" y="348" text-anchor="middle" fill="#7aa2f7" font-size="18" font-family="monospace">ClaudeOutput::CommandLifecycle</text>
+    <line x1="1500" y1="375" x2="1500" y2="425" stroke="#565f89" stroke-width="3"/>
+    <polygon points="1490,420 1510,420 1500,438" fill="#565f89"/>
+    <rect x="1200" y="445" width="600" height="105" rx="10" fill="#24283b" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1500" y="487" text-anchor="middle" fill="#9ece6a" font-size="18" font-weight="bold">Recognized and suppressed</text>
+    <text x="1500" y="522" text-anchor="middle" fill="#a9b1d6" font-size="15">no raw fallback and no empty transcript row</text>
+    <text x="1500" y="585" text-anchor="middle" fill="#9ece6a" font-size="15">conversation stays focused on user and agent content</text>
+
+    <rect x="1150" y="690" width="700" height="205" rx="14" fill="#1e202e" stroke="#7aa2f7" stroke-width="1.5"/>
+    <text x="1185" y="740" fill="#c0caf5" font-size="18" font-weight="bold">One shared accounting rule</text>
+    <text x="1185" y="785" fill="#a9b1d6" font-size="16">counts_toward_render_limit returns false for lifecycle</text>
+    <text x="1185" y="820" fill="#a9b1d6" font-size="16">records, so backend pages and frontend trimming agree.</text>
+    <text x="1185" y="855" fill="#a9b1d6" font-size="16">The reported completed-frame shape is pinned by tests.</text>
+  </g>
+
+  <text x="1000" y="1050" text-anchor="middle" fill="#bb9af7" font-size="20" font-weight="bold">Typed control signal in; zero transcript cards out</text>
+  <text x="1000" y="1110" text-anchor="middle" fill="#565f89" font-size="15">Scope: #1913 removes the incorrect raw rendering; richer queued/running UI needs an end-to-end UUID correlation contract.</text>
+</svg>

--- a/frontend/src/components/agent_frame.rs
+++ b/frontend/src/components/agent_frame.rs
@@ -34,6 +34,9 @@ pub enum AgentFrameKind {
     ClaudeUser,
     ClaudeError,
     ClaudeRateLimitEvent,
+    /// Command transport bookkeeping. Recognized but omitted from the
+    /// transcript; see the grouping filter for #1913.
+    ClaudeCommandLifecycle,
     Portal,
     OptimisticUser,
     CodexThreadStarted,
@@ -158,6 +161,7 @@ impl FrameRenderer {
             | AgentFrameKind::ClaudeUser
             | AgentFrameKind::ClaudeError
             | AgentFrameKind::ClaudeRateLimitEvent
+            | AgentFrameKind::ClaudeCommandLifecycle
             | AgentFrameKind::Portal
             | AgentFrameKind::OptimisticUser => Self::Claude,
             AgentFrameKind::CodexThreadStarted
@@ -193,6 +197,7 @@ impl ClaudeMessage {
             Self::Error(_) => AgentFrameKind::ClaudeError,
             Self::Portal(_) => AgentFrameKind::Portal,
             Self::RateLimitEvent(_) => AgentFrameKind::ClaudeRateLimitEvent,
+            Self::CommandLifecycle(_) => AgentFrameKind::ClaudeCommandLifecycle,
             // A `/clear` seam is a session-level event, so it routes and groups
             // with system frames; `dispatch` still selects its own renderer off
             // the message variant, not this kind.

--- a/frontend/src/components/message_renderer/dispatch.rs
+++ b/frontend/src/components/message_renderer/dispatch.rs
@@ -81,6 +81,10 @@ pub(crate) fn render_frame(ctx: FrameRenderContext<'_>) -> Html {
             AgentFrame::Claude(ClaudeMessage::RateLimitEvent(msg)) => {
                 renderers::render_rate_limit_event(&msg, ctx.timestamp)
             }
+            // Transport bookkeeping is intentionally not a transcript row.
+            // `group_messages` normally removes it before dispatch; retain an
+            // empty direct-render fallback for callers rendering one frame.
+            AgentFrame::Claude(ClaudeMessage::CommandLifecycle(_)) => html! {},
             AgentFrame::Claude(ClaudeMessage::LocalError(msg)) => {
                 renderers::render_local_error(&msg, ctx.timestamp)
             }

--- a/frontend/src/components/message_renderer/grouping.rs
+++ b/frontend/src/components/message_renderer/grouping.rs
@@ -525,16 +525,22 @@ pub fn group_messages(
     }
 
     for message in messages {
+        let kind = AgentFrameRegistry::parse(&message.content, agent_type).kind();
+
+        // Claude command lifecycle frames are transport bookkeeping, not
+        // conversation. Recognize and omit them rather than surfacing raw JSON
+        // or leaving empty keyed rows in the transcript (#1913).
+        if kind == AgentFrameKind::ClaudeCommandLifecycle {
+            continue;
+        }
+
         // Cumulative `turn/diff/updated` events are dropped entirely — Codex
         // re-sends the whole-turn diff on every edit tick, so they pile up
         // O(ticks) redundant cards (each the size of the full turn) on top of
         // the per-file diffs that already show the same edits. Skipping here
         // rather than in `classify` keeps the surrounding Codex events in one
         // run instead of fragmenting the group around each dropped diff.
-        if matches!(
-            AgentFrameRegistry::parse(&message.content, agent_type).kind(),
-            AgentFrameKind::CodexTurnDiffUpdated
-        ) {
+        if matches!(kind, AgentFrameKind::CodexTurnDiffUpdated) {
             continue;
         }
         match classify(message, agent_type, current_user_id) {

--- a/frontend/src/components/message_renderer/tests/classifier.rs
+++ b/frontend/src/components/message_renderer/tests/classifier.rs
@@ -1,12 +1,16 @@
 //! Cross-family classifier contracts: turn-terminator detection and the
 //! one-row-per-realistic-message-kind sweep that guards every category.
 
-use super::super::grouping::{classify, group_is_turn_terminator, GroupCategory, MessageGroup};
+use super::super::grouping::{
+    classify, group_is_turn_terminator, group_messages, GroupCategory, MessageGroup,
+};
+use super::super::types::ClaudeMessage;
 use super::fixtures::{
     assistant_with_tool_use, codex_item_started_agent_message, plain_user_text,
     portal_text_message, read_tool_result_user_message, rendered, result_message,
     thinking_tokens_message,
 };
+use crate::components::agent_frame::{AgentFrameKind, AgentFrameRegistry};
 
 #[test]
 fn turn_terminator_detection_covers_claude_and_codex() {
@@ -243,4 +247,29 @@ fn every_local_frame_the_portal_can_author_renders() {
         let _parsed = ClaudeMessage::parse(&json)
             .unwrap_or_else(|e| panic!("{tag} frame must parse: {e} ({json})"));
     }
+}
+
+#[test]
+fn claude_command_lifecycle_is_typed_not_raw_json() {
+    let json = r#"{"command_uuid":"8823a584-c752-4981-957b-fa5e23a053c0","session_id":"041ddc00-ff2f-4281-99da-b66bebcf78e6","state":"completed","type":"command_lifecycle","uuid":"132c02dc-453c-4d5a-a8ff-03f4b1579c89"}"#;
+
+    assert!(matches!(
+        ClaudeMessage::parse(json),
+        Ok(ClaudeMessage::CommandLifecycle(message))
+            if message.state == shared::CommandLifecycleState::Completed
+    ));
+    assert_eq!(
+        AgentFrameRegistry::parse(json, shared::AgentType::Claude).kind(),
+        AgentFrameKind::ClaudeCommandLifecycle
+    );
+
+    let groups = group_messages(
+        &[rendered(json.to_string())],
+        shared::AgentType::Claude,
+        None,
+    );
+    assert!(
+        groups.is_empty(),
+        "command lifecycle bookkeeping must not create a transcript row"
+    );
 }

--- a/frontend/src/components/message_renderer/types.rs
+++ b/frontend/src/components/message_renderer/types.rs
@@ -58,6 +58,11 @@ pub enum ClaudeMessage {
     Error(shared::AnthropicError),
     Portal(shared::PortalMessage),
     RateLimitEvent(shared::RateLimitEvent),
+    /// Claude's delivery bookkeeping for an input carrying a client-supplied
+    /// UUID. It is typed so it never falls through to the raw-JSON renderer,
+    /// but it has no transcript body: queued/started/terminal states describe
+    /// command transport, not conversation content (#1913).
+    CommandLifecycle(shared::CommandLifecycleMessage),
     /// `/clear`. Worth its own variant rather than falling to `Unknown`: it is
     /// the visible seam between two conversations in one session, and it also
     /// marks where claude's conversation id rotates (see the render).
@@ -103,6 +108,7 @@ impl ClaudeMessage {
             shared::ClaudeOutput::Result(msg) => Some(Self::Result(msg)),
             shared::ClaudeOutput::Error(msg) => Some(Self::Error(msg)),
             shared::ClaudeOutput::RateLimitEvent(msg) => Some(Self::RateLimitEvent(msg)),
+            shared::ClaudeOutput::CommandLifecycle(msg) => Some(Self::CommandLifecycle(msg)),
             shared::ClaudeOutput::ConversationReset(msg) => Some(Self::ConversationReset(msg)),
             // Wildcard: control frames plus the 2.1.160 wire additions
             // (stream_event, tool_progress, transcript variants, …) that

--- a/frontend/src/pages/dashboard/session_view/helpers.rs
+++ b/frontend/src/pages/dashboard/session_view/helpers.rs
@@ -242,6 +242,7 @@ pub(super) fn message_type_tag(m: &ClaudeMessage) -> ActivityTag {
         ClaudeMessage::Error(_) => ActivityTag::Error,
         ClaudeMessage::Portal(_) => ActivityTag::Portal,
         ClaudeMessage::RateLimitEvent(_) => ActivityTag::RateLimit,
+        ClaudeMessage::CommandLifecycle(_) => ActivityTag::Suppressed,
         ClaudeMessage::ConversationReset(_) => ActivityTag::System,
         ClaudeMessage::LocalError(_) => ActivityTag::Error,
     }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -175,10 +175,10 @@ pub use claude_codes::io::{
 
 // Re-export claude-codes output types for typed parsing.
 pub use claude_codes::io::{
-    AnthropicError, AssistantMessage, AssistantUsage, ConversationResetMessage, MessageContent,
-    RateLimitEvent, ResultMessage, ServerToolUse, SystemMessage, SystemSubtype,
-    TaskNotificationMessage, TaskProgressMessage, TaskStartedMessage, TaskStatus, TaskType,
-    TaskUsage, UserMessage,
+    AnthropicError, AssistantMessage, AssistantUsage, CommandLifecycleMessage,
+    CommandLifecycleState, ConversationResetMessage, MessageContent, RateLimitEvent, ResultMessage,
+    ServerToolUse, SystemMessage, SystemSubtype, TaskNotificationMessage, TaskProgressMessage,
+    TaskStartedMessage, TaskStatus, TaskType, TaskUsage, UserMessage,
 };
 pub use claude_codes::CacheCreationDetails;
 pub use claude_codes::ClaudeOutput;

--- a/shared/src/render_budget.rs
+++ b/shared/src/render_budget.rs
@@ -16,12 +16,15 @@
 /// Whether one stored wire frame counts against the render budget.
 ///
 /// Claude's cumulative thinking-token system markers are free: many arrive per
-/// turn and the frontend collapses them into a single chip.
+/// turn and the frontend collapses them into a single chip. Command-lifecycle
+/// records are also free because they are transport bookkeeping omitted from
+/// the transcript (#1913).
 pub fn counts_toward_render_limit(content: &str) -> bool {
-    !matches!(
-        serde_json::from_str::<crate::ClaudeOutput>(content),
-        Ok(crate::ClaudeOutput::System(message)) if message.is_thinking_tokens()
-    )
+    match serde_json::from_str::<crate::ClaudeOutput>(content) {
+        Ok(crate::ClaudeOutput::System(message)) => !message.is_thinking_tokens(),
+        Ok(crate::ClaudeOutput::CommandLifecycle(_)) => false,
+        _ => true,
+    }
 }
 
 /// Trim `items` (chronological, oldest first) to the newest window containing
@@ -91,10 +94,12 @@ mod tests {
 
     const THINKING: &str = r#"{"type":"system","subtype":"thinking_tokens","session_id":"s","cumulative_thinking_tokens":42}"#;
     const TEXTISH: &str = r#"{"type":"user","content":"hello"}"#;
+    const COMMAND_LIFECYCLE: &str = r#"{"type":"command_lifecycle","command_uuid":"cmd-1","state":"completed","uuid":"frame-1","session_id":"session-1"}"#;
 
     #[test]
     fn thinking_token_markers_ride_free() {
         assert!(!counts_toward_render_limit(THINKING));
+        assert!(!counts_toward_render_limit(COMMAND_LIFECYCLE));
         assert!(counts_toward_render_limit(TEXTISH));
         assert!(counts_toward_render_limit("not json at all"));
     }


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/f45539a273a2d57aabe5cf10a54fa6d4a41f1915/.0-pr-viz/001928.svg)\n\nCloses #1913.\n\nRecognizes the typed `ClaudeOutput::CommandLifecycle` frame, suppresses it from transcript rendering, and excludes these non-rendered bookkeeping records from the shared frontend/backend render budget. Includes a regression over the reported wire shape.