### PR TITLE
Share is_non_blank guard across frontend checks

### DIFF
--- a/.0-pr-viz/001930.svg
+++ b/.0-pr-viz/001930.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200" font-family="'Segoe UI','Noto Sans','DejaVu Sans',ui-sans-serif,system-ui,sans-serif">
+<rect width="2000" height="1200" fill="#16161e"/>
+<text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1930 · share is_non_blank guard across frontend checks</text>
+<text x="55" y="100" font-size="34" fill="#e6e9f5">One bool helper answers every is-it-blank question.</text>
+<line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666"/>
+<text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+<text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+<line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+<rect x="80" y="270" width="840" height="300" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="325" font-size="26" fill="#c0caf5">28 hand-rolled blank checks in 20 files</text>
+<text x="108" y="380" font-size="23" fill="#a9b1d6">!s.trim().is_empty() in ifs, filters, disabled=</text>
+<text x="108" y="430" font-size="23" fill="#f7768e">one .map kept its stray negation: blank read</text>
+<text x="108" y="480" font-size="23" fill="#f7768e">as answered until the tests said otherwise</text>
+<rect x="80" y="650" width="840" height="245" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="705" font-size="26" fill="#c0caf5">only Option shapes had shared helpers</text>
+<text x="108" y="760" font-size="23" fill="#a9b1d6">non_blank / owned_non_blank return Options</text>
+<text x="108" y="810" font-size="23" fill="#f7768e">bool guards had nowhere to go, so they inlined</text>
+<rect x="1065" y="270" width="860" height="300" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="325" font-size="26" fill="#7aa2f7">utils::is_non_blank in utils.rs</text>
+<text x="1093" y="380" font-size="23" fill="#a9b1d6">single trim-and-check predicate, plus a test</text>
+<text x="1093" y="430" font-size="23" fill="#9ece6a">all 28 bool sites adopt it; non_blank builds on it</text>
+<text x="1093" y="480" font-size="23" fill="#9ece6a">error_body guard uses it too</text>
+<rect x="1065" y="650" width="860" height="245" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="705" font-size="26" fill="#7aa2f7">negation bug fixed, caught by existing tests</text>
+<text x="1093" y="760" font-size="23" fill="#a9b1d6">no trim().is_empty() left outside utils.rs</text>
+<text x="1093" y="810" font-size="23" fill="#9ece6a">699 frontend tests green, clippy and fmt clean</text>
+<text x="55" y="1172" font-size="22" fill="#565f89">Scope: frontend utils plus 20 call-site files; no protocol change.</text>
+</svg>

--- a/frontend/src/components/codex_renderer/lifecycle.rs
+++ b/frontend/src/components/codex_renderer/lifecycle.rs
@@ -1,10 +1,12 @@
 use super::events::{ContextCompactedParams, TurnPlanStep};
 use yew::prelude::*;
 
+use crate::utils;
+
 pub(super) fn render_turn_plan(plan: Option<&[TurnPlanStep]>, explanation: Option<&str>) -> Html {
     let plan = plan.unwrap_or(&[]);
     let explanation = explanation.unwrap_or("");
-    if plan.is_empty() && explanation.trim().is_empty() {
+    if plan.is_empty() && !utils::is_non_blank(explanation) {
         return html! {};
     }
     html! {
@@ -16,7 +18,7 @@ pub(super) fn render_turn_plan(plan: Option<&[TurnPlanStep]>, explanation: Optio
                         <span class="tool-name">{ "Plan" }</span>
                     </div>
                     {
-                        if !explanation.trim().is_empty() {
+                        if utils::is_non_blank(explanation) {
                             html! { <div class="assistant-text">{ explanation }</div> }
                         } else {
                             html! {}

--- a/frontend/src/components/codex_renderer/patch.rs
+++ b/frontend/src/components/codex_renderer/patch.rs
@@ -1,5 +1,6 @@
 use super::tool_card::tool_card;
 use crate::components::diff::{DiffCard, DiffSource};
+use crate::utils;
 use codex_codes::io::items::{FileChangeItem, FileUpdateChange, PatchApplyStatus, PatchChangeKind};
 use yew::prelude::*;
 
@@ -49,7 +50,7 @@ pub(super) fn render_file_change_patch(changes: Option<&[FileUpdateChange]>) -> 
     let changes = changes.unwrap_or(&[]);
     let cards: Vec<Html> = changes
         .iter()
-        .filter(|c| !c.diff.trim().is_empty())
+        .filter(|c| utils::is_non_blank(&c.diff))
         .map(render_diff_card)
         .collect();
     if cards.is_empty() {
@@ -71,7 +72,7 @@ pub(super) fn render_file_change_patch(changes: Option<&[FileUpdateChange]>) -> 
 fn render_diff_card(c: &FileUpdateChange) -> Html {
     let kind_css = AttrValue::from(patch_kind_css(&c.kind));
     let path = AttrValue::from(c.path.clone());
-    if c.diff.trim().is_empty() {
+    if !utils::is_non_blank(&c.diff) {
         return html! {
             <div class="diff-card">
                 <div class="diff-card-header">

--- a/frontend/src/components/fork_dialog.rs
+++ b/frontend/src/components/fork_dialog.rs
@@ -64,11 +64,11 @@ pub fn fork_dialog(props: &ForkDialogProps) -> Html {
         let on_close = props.on_close.clone();
         let on_forked = props.on_forked.clone();
         Callback::from(move |_| {
-            if name.trim().is_empty() {
+            if !utils::is_non_blank(&name) {
                 error.set(Some("Name is required".into()));
                 return;
             }
-            if *mode == ForkDirectoryMode::Other && other_directory.trim().is_empty() {
+            if *mode == ForkDirectoryMode::Other && !utils::is_non_blank(&other_directory) {
                 error.set(Some("Choose the other working directory".into()));
                 return;
             }

--- a/frontend/src/components/launch_dialog.rs
+++ b/frontend/src/components/launch_dialog.rs
@@ -914,7 +914,7 @@ pub fn launch_dialog(props: &LaunchDialogProps) -> Html {
                     if *create_worktree {
                         <div class="launch-note">
                             {
-                                if session_name.trim().is_empty() {
+                                if !utils::is_non_blank(&session_name) {
                                     "Worktree branch will be named session-<timestamp> (set a session name above to name it)".to_string()
                                 } else {
                                     format!("Worktree branch will be named {}", session_name.trim())

--- a/frontend/src/components/message_renderer/renderers/assistant.rs
+++ b/frontend/src/components/message_renderer/renderers/assistant.rs
@@ -9,6 +9,7 @@ use crate::components::copy_button::CopyButton;
 use crate::components::expandable::ExpandableText;
 use crate::components::markdown::render_markdown_for_session;
 use crate::components::tool_renderers::render_tool_use;
+use crate::utils;
 use shared::{AssistantMessage, AssistantUsage as UsageInfo};
 use shared::{Citation, ContentBlock, ToolResultContent};
 use uuid::Uuid;
@@ -291,7 +292,7 @@ fn render_block(block: &ContentBlock, session_id: Uuid) -> Option<Html> {
             html! {
                 <div class="thinking-block">
                     <span class="thinking-label" title={sig_title}>{ "thinking" }</span>
-                    if th.thinking.trim().is_empty() {
+                    if !utils::is_non_blank(&th.thinking) {
                         <div class="thinking-content muted" title="Thinking text was omitted by the model; the encrypted signature is preserved in the raw message.">
                             { "thinking omitted" }
                         </div>

--- a/frontend/src/components/message_renderer/renderers/user.rs
+++ b/frontend/src/components/message_renderer/renderers/user.rs
@@ -10,6 +10,7 @@ use crate::components::tool_renderers::{
     has_askuserquestion_answers, render_askuserquestion_result,
 };
 use crate::components::{split_upload_notice, UploadNotice};
+use crate::utils;
 use shared::UserFrame as OptimisticUserMessage;
 use uuid::Uuid;
 use yew::prelude::*;
@@ -129,7 +130,7 @@ pub fn render_optimistic_user_message_content(
     msg: &OptimisticUserMessage,
     session_id: Uuid,
 ) -> Option<Html> {
-    if msg.content.trim().is_empty() {
+    if !utils::is_non_blank(&msg.content) {
         return None;
     }
     if let Some(notice) = split_upload_notice(&msg.content) {

--- a/frontend/src/components/muse_renderer.rs
+++ b/frontend/src/components/muse_renderer.rs
@@ -12,6 +12,8 @@
 use muse_codes::CommandResult;
 use yew::prelude::*;
 
+use crate::utils;
+
 use super::expandable::ExpandableText;
 use super::tool_renderers::OUTPUT_PREVIEW_CHARS;
 
@@ -30,7 +32,7 @@ fn parse_command_result(text: &str) -> Option<CommandResult> {
     }
     serde_json::from_str::<CommandResult>(trimmed)
         .ok()
-        .filter(|c| !c.command.trim().is_empty())
+        .filter(|c| utils::is_non_blank(&c.command))
 }
 
 /// Render a muse command result via the shared [`CommandResultCard`] — the same
@@ -465,7 +467,7 @@ mod tests {
 
     fn bash_tree() -> TaskTree {
         let mut tree = TaskTree::default();
-        for line in BASH_FIXTURE.lines().filter(|l| !l.trim().is_empty()) {
+        for line in BASH_FIXTURE.lines().filter(|l| utils::is_non_blank(l)) {
             tree.apply(&serde_json::from_str(line).expect("fixture line is JSON"));
         }
         tree

--- a/frontend/src/components/muse_renderer/task_tree.rs
+++ b/frontend/src/components/muse_renderer/task_tree.rs
@@ -23,6 +23,8 @@
 
 use std::collections::BTreeMap;
 
+use crate::utils;
+
 /// Where a task sits in its lifecycle. Ordered by progression so a node can
 /// only advance, never regress on an out-of-order record.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
@@ -226,8 +228,8 @@ impl TaskTree {
             // answer (better a stale reply than a blank card) — deliberate.
             t if t.starts_with("run.terminal.") => {
                 let answer = str_field(payload, "text")
-                    .filter(|t| !t.trim().is_empty())
-                    .or_else(|| str_field(payload, "reason").filter(|r| !r.trim().is_empty()));
+                    .filter(|t| utils::is_non_blank(t))
+                    .or_else(|| str_field(payload, "reason").filter(|r| utils::is_non_blank(r)));
                 if answer.is_some() {
                     self.answer = answer;
                     self.answer_is_terminal = true;
@@ -374,7 +376,7 @@ mod tests {
     fn events(capture: &str) -> Vec<serde_json::Value> {
         capture
             .lines()
-            .filter(|l| !l.trim().is_empty())
+            .filter(|l| utils::is_non_blank(l))
             .map(|l| {
                 let r: serde_json::Value = serde_json::from_str(l).expect("capture parses");
                 json!({

--- a/frontend/src/components/schedule_dialog.rs
+++ b/frontend/src/components/schedule_dialog.rs
@@ -226,7 +226,7 @@ pub fn schedule_dialog(props: &ScheduleDialogProps) -> Html {
             let host = host.clone();
             let agent_type = agent_type;
 
-            if data.name.trim().is_empty() || data.cron_expression.trim().is_empty() {
+            if !utils::is_non_blank(&data.name) || !utils::is_non_blank(&data.cron_expression) {
                 return;
             }
 

--- a/frontend/src/components/share_dialog.rs
+++ b/frontend/src/components/share_dialog.rs
@@ -103,7 +103,7 @@ impl Component for ShareDialog {
                 true
             }
             ShareDialogMsg::AddMember => {
-                if self.email_input.trim().is_empty() {
+                if !utils::is_non_blank(&self.email_input) {
                     return false;
                 }
                 let session_id = ctx.props().session_id;

--- a/frontend/src/components/tool_renderers/command_result.rs
+++ b/frontend/src/components/tool_renderers/command_result.rs
@@ -6,6 +6,7 @@
 
 use super::super::expandable::ExpandableText;
 use crate::components::markdown::linkify_urls;
+use crate::utils;
 use yew::prelude::*;
 
 /// How much output to show before the `ExpandableText` toggle collapses it —
@@ -37,7 +38,7 @@ pub fn command_result_card(props: &CommandResultCardProps) -> Html {
 
     html! {
         <div class={card_class}>
-            if let Some(desc) = props.description.as_ref().filter(|d| !d.trim().is_empty()) {
+            if let Some(desc) = props.description.as_ref().filter(|d| utils::is_non_blank(d)) {
                 <div class="command-result-intent">{ desc }</div>
             }
             <div class="command-result-command">

--- a/frontend/src/components/turn_metrics_display.rs
+++ b/frontend/src/components/turn_metrics_display.rs
@@ -1,5 +1,6 @@
 //! Shared display helpers for turn-metrics UI surfaces.
 
+use crate::utils;
 use shared::AgentType;
 
 /// Compact integer for `"2.1k in / 547 out"` chips.
@@ -40,7 +41,7 @@ pub(crate) fn compact_model_label(model: &str) -> String {
 }
 
 pub(crate) fn is_displayable_model(model: &str) -> bool {
-    !model.trim().is_empty() && model != "<synthetic>"
+    utils::is_non_blank(model) && model != "<synthetic>"
 }
 
 /// Build the compact dashboard label for a model/tier pair.

--- a/frontend/src/components/upload_notice.rs
+++ b/frontend/src/components/upload_notice.rs
@@ -11,6 +11,7 @@
 //! compact attachment chips instead of the prose. They live in one module with
 //! a round-trip test so the builder and parser cannot drift.
 
+use crate::utils;
 use shared::fmt::format_file_size;
 
 /// The fixed header line of the agent-facing notice. The wire format is
@@ -71,7 +72,7 @@ pub fn split_upload_notice(text: &str) -> Option<UploadNotice<'_>> {
         return None;
     }
     Some(UploadNotice {
-        user_text: user_text.filter(|t| !t.trim().is_empty()),
+        user_text: user_text.filter(|t| utils::is_non_blank(t)),
         files,
     })
 }

--- a/frontend/src/components/voice_input.rs
+++ b/frontend/src/components/voice_input.rs
@@ -1085,7 +1085,7 @@ async fn start_session_async(
     let final_for_end = final_acc.clone();
     let on_end = Closure::wrap(Box::new(move |_event: JsValue| {
         let text = std::mem::take(&mut *final_for_end.borrow_mut());
-        if !text.trim().is_empty() {
+        if utils::is_non_blank(&text) {
             link_for_end.send_message(VoiceInputMsg::Final(text));
         }
         link_for_end.send_message(VoiceInputMsg::Ended);

--- a/frontend/src/pages/dashboard/session_view/input_bar.rs
+++ b/frontend/src/pages/dashboard/session_view/input_bar.rs
@@ -1171,7 +1171,7 @@ mod tests {
         // The bar's only normalisation is `.trim()` — see
         // `dispatch_text_send`. We mirror it here so the test is a real
         // contract pin and not a tautology.
-        !s.trim().is_empty()
+        crate::utils::is_non_blank(s)
     }
 
     #[test]

--- a/frontend/src/pages/dashboard/session_view/permission_handler.rs
+++ b/frontend/src/pages/dashboard/session_view/permission_handler.rs
@@ -16,6 +16,7 @@ use crate::pages::dashboard::types::{
     parse_ask_user_question, AskUserQuestion, AskUserQuestionInput, PendingPermission,
     QuestionAnswers,
 };
+use crate::utils;
 
 /// Typed answer the handler emits to the parent. The parent translates each
 /// variant into a `ClientToServer::PermissionResponse` frame; keeping the
@@ -201,7 +202,7 @@ impl Component for PermissionHandler {
                 // A blank answer (e.g. a cleared "something else" field)
                 // un-answers the question rather than counting an empty string
                 // as a valid answer.
-                if answer.trim().is_empty() {
+                if !utils::is_non_blank(&answer) {
                     self.question_answers.remove(&question_idx);
                 } else {
                     self.question_answers.insert(question_idx, answer);
@@ -507,7 +508,7 @@ fn assemble_answers(
             let joined = joined_ticks(question, ticks.get(&q_idx));
             if !joined.is_empty() {
                 out.insert(q_idx, joined);
-            } else if let Some(custom) = answers.get(&q_idx).filter(|a| !a.trim().is_empty()) {
+            } else if let Some(custom) = answers.get(&q_idx).filter(|a| utils::is_non_blank(a)) {
                 out.insert(q_idx, custom.clone());
             } else {
                 out.insert(q_idx, String::new());
@@ -531,7 +532,7 @@ fn empty_multi_select_questions(
     for (q_idx, question) in parsed.questions.iter().enumerate() {
         let has_custom = answers
             .get(&q_idx)
-            .map(|a| !a.trim().is_empty())
+            .map(|a| utils::is_non_blank(a))
             .unwrap_or(false);
         if question.multi_select
             && joined_ticks(question, ticks.get(&q_idx)).is_empty()

--- a/frontend/src/pages/history/browser.rs
+++ b/frontend/src/pages/history/browser.rs
@@ -11,6 +11,7 @@ use shared::api::{HistorySessionSummary, HistorySessionsResponse, DEFAULT_HISTOR
 use super::fetch::{fetch_json, Load};
 use super::filters::SessionFilter;
 use crate::components::turn_metrics_display::is_displayable_model;
+use crate::utils;
 use crate::Route;
 
 /// Rows requested per page. Must not exceed `MAX_HISTORY_PAGE_SIZE`, which the
@@ -139,7 +140,7 @@ fn stats_strip(resp: &HistorySessionsResponse, filter: &UseStateHandle<SessionFi
     // `owners` covers every filter *except* `user`, so when a user is selected
     // narrow it here — that keeps the tiles agreeing with the table while the
     // dropdown above still lists everyone.
-    let selected = filter.user_id.as_deref().filter(|s| !s.trim().is_empty());
+    let selected = filter.user_id.as_deref().filter(|s| utils::is_non_blank(s));
     let user_tiles = if resp.is_admin {
         resp.owners
             .iter()

--- a/frontend/src/pages/settings/agent_install.rs
+++ b/frontend/src/pages/settings/agent_install.rs
@@ -131,7 +131,7 @@ fn install_status(resp: &InstallAgentResponse) -> (&'static str, String) {
         let detail = resp
             .message
             .as_deref()
-            .filter(|m| !m.trim().is_empty())
+            .filter(|m| utils::is_non_blank(m))
             .unwrap_or("the install command failed");
         ("error", format!("Install failed: {detail}"))
     }

--- a/frontend/src/pages/settings/agent_login.rs
+++ b/frontend/src/pages/settings/agent_login.rs
@@ -292,7 +292,7 @@ impl AgentLoginModal {
                             <button
                                 class="agent-login-submit"
                                 onclick={on_submit}
-                                disabled={self.submitting || self.code_input.trim().is_empty()}
+                                disabled={self.submitting || !utils::is_non_blank(&self.code_input)}
                             >
                                 { if self.submitting { "Signing in…" } else { "Submit" } }
                             </button>
@@ -339,7 +339,7 @@ fn outcome_status(outcome: &AgentLoginOutcome) -> (&'static str, String) {
         let detail = outcome
             .message
             .as_deref()
-            .filter(|m| !m.trim().is_empty())
+            .filter(|m| utils::is_non_blank(m))
             .unwrap_or("sign-in did not complete");
         ("error", format!("Sign-in failed: {detail}"))
     }

--- a/frontend/src/pages/settings/tokens_panel.rs
+++ b/frontend/src/pages/settings/tokens_panel.rs
@@ -303,7 +303,7 @@ pub fn tokens_panel(props: &TokensPanelProps) -> Html {
             let created_token = created_token.clone();
             let fetch_tokens = fetch_tokens.clone();
 
-            if form_data.name.trim().is_empty() {
+            if !utils::is_non_blank(&form_data.name) {
                 return;
             }
 

--- a/frontend/src/utils.rs
+++ b/frontend/src/utils.rs
@@ -123,7 +123,7 @@ pub async fn send_json(
 pub async fn error_body(resp: gloo_net::http::Response) -> String {
     let status = resp.status();
     match resp.text().await {
-        Ok(t) if !t.trim().is_empty() => t,
+        Ok(t) if is_non_blank(&t) => t,
         _ => format!("HTTP {status}"),
     }
 }
@@ -226,13 +226,22 @@ pub fn non_empty(opt: Option<&str>) -> Option<&str> {
     opt.map(str::trim).filter(|s| !s.is_empty())
 }
 
+/// True when `s` holds non-whitespace text.
+///
+/// Bool counterpart to [`non_blank`] for `if` guards, `disabled=` flags, and
+/// `filter` closures that only need the check, sparing them the repeated
+/// `!s.trim().is_empty()` shape.
+pub fn is_non_blank(s: &str) -> bool {
+    !s.trim().is_empty()
+}
+
 /// Keep a borrowed string only when it is non-blank.
 ///
 /// Borrowed counterpart to [`non_empty`] for call sites that already hold a
 /// `&str`/`String` instead of an `Option`. Trims before checking so
 /// whitespace-only input is treated as absent.
 pub fn non_blank(s: &str) -> Option<&str> {
-    non_empty(Some(s))
+    is_non_blank(s).then(|| s.trim())
 }
 
 /// Keep a trimmed owned copy of `s` only when it is non-blank.
@@ -286,6 +295,13 @@ mod tests {
         assert_eq!(non_empty(Some("")), None);
         assert_eq!(non_empty(Some("   ")), None);
         assert_eq!(non_empty(Some("  hi  ")), Some("hi"));
+    }
+
+    #[test]
+    fn is_non_blank_rejects_empty_and_whitespace_only() {
+        assert!(!is_non_blank(""));
+        assert!(!is_non_blank("   "));
+        assert!(is_non_blank("  hi  "));
     }
 
     #[test]


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/3d7ca54f88daf6bd3114d39d4df75505a6bfe5fc/.0-pr-viz/001930.svg)

Follow-up to #1927/#1929: those added the Option-shaped blank-string helpers (`non_empty`/`non_blank`/`owned_non_blank`). The bool-shaped checks (`if`, `disabled=`, `filter`) had no shared home, so 28 copies of `!s.trim().is_empty()` survived across 20 files. This adds `utils::is_non_blank` and adopts it everywhere; `non_blank` now builds on it.

Behavior is unchanged — pure predicate extraction. The existing permission-handler tests caught one stray negation in my first pass (fixed).
