### PR TITLE
Share blank-string guard across backend checks

### DIFF
--- a/.0-pr-viz/001932.svg
+++ b/.0-pr-viz/001932.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200" font-family="'Segoe UI','Noto Sans','DejaVu Sans',ui-sans-serif,system-ui,sans-serif">
+<rect width="2000" height="1200" fill="#16161e"/>
+<text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1932 · share blank-string guard across backend checks</text>
+<text x="55" y="100" font-size="34" fill="#e6e9f5">One trim-and-check helper for the whole backend.</text>
+<line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666"/>
+<text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+<text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+<line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+<rect x="80" y="270" width="840" height="300" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="325" font-size="26" fill="#c0caf5">8 hand-rolled blank checks in 7 files</text>
+<text x="108" y="380" font-size="23" fill="#a9b1d6">!s.trim().is_empty() in guards and filters</text>
+<text x="108" y="430" font-size="23" fill="#a9b1d6">match arms, .filter closures, if checks</text>
+<text x="108" y="480" font-size="23" fill="#f7768e">one edit means touching seven files</text>
+<rect x="80" y="650" width="840" height="245" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+<text x="108" y="705" font-size="26" fill="#c0caf5">no shared helper in the backend</text>
+<text x="108" y="760" font-size="23" fill="#a9b1d6">frontend solved this in #1930; backend lagged</text>
+<text x="108" y="810" font-size="23" fill="#f7768e">copied trim logic drifts between sites</text>
+<rect x="1065" y="270" width="860" height="300" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="325" font-size="26" fill="#7aa2f7">crate::strings::is_non_blank in strings.rs</text>
+<text x="1093" y="380" font-size="23" fill="#a9b1d6">single trim-and-check predicate, plus a test</text>
+<text x="1093" y="430" font-size="23" fill="#9ece6a">all 8 sites adopt it; no behavior change</text>
+<text x="1093" y="480" font-size="23" fill="#9ece6a">push, handlers, launchers, config covered</text>
+<rect x="1065" y="650" width="860" height="245" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+<text x="1093" y="705" font-size="26" fill="#7aa2f7">clippy, fmt, and unit tests green</text>
+<text x="1093" y="760" font-size="23" fill="#a9b1d6">new strings::tests covers blank and whitespace</text>
+<text x="1093" y="810" font-size="23" fill="#9ece6a">8 files, +42/-8, one focused commit</text>
+<text x="55" y="1172" font-size="22" fill="#565f89">Scope: bool guards only; value-building trim().to_string() arms keep their own trim.</text>
+</svg>

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -19,6 +19,7 @@ use std::str::FromStr;
 use tower_cookies::Key;
 
 use crate::handlers;
+use crate::strings::is_non_blank;
 
 pub type OAuthClient =
     BasicClient<EndpointSet, EndpointNotSet, EndpointNotSet, EndpointNotSet, EndpointSet>;
@@ -491,7 +492,7 @@ impl ServerConfig {
         // read by the Web Push sender, never by this endpoint. Unset = push
         // disabled (the vapid-key endpoint 404s).
         let vapid_public_key = match env::var("PORTAL_VAPID_PUBLIC_KEY") {
-            Ok(v) if !v.trim().is_empty() => {
+            Ok(v) if is_non_blank(&v) => {
                 log_source("PORTAL_VAPID_PUBLIC_KEY", true);
                 Some(v)
             }

--- a/backend/src/handlers/auth/identity.rs
+++ b/backend/src/handlers/auth/identity.rs
@@ -34,6 +34,7 @@ use tracing::{info, warn};
 
 use crate::db::DbConnection;
 use crate::models::{NewUser, NewUserIdentity, User, UserIdentity};
+use crate::strings::is_non_blank;
 
 /// Provider key for Google logins, as stored in `user_identities.provider`.
 pub const PROVIDER_GOOGLE: &str = "google";
@@ -91,7 +92,7 @@ pub fn resolve_user(
 
     // Everything below needs a trustworthy address.
     let email = match (&identity.email, identity.email_verified) {
-        (Some(email), true) if !email.trim().is_empty() => email.trim().to_string(),
+        (Some(email), true) if is_non_blank(email) => email.trim().to_string(),
         _ => {
             warn!(
                 target: "auth_audit",

--- a/backend/src/handlers/files.rs
+++ b/backend/src/handlers/files.rs
@@ -1,5 +1,6 @@
 use crate::auth::CurrentUserId;
 use crate::errors::AppError;
+use crate::strings::is_non_blank;
 use crate::AppState;
 use axum::{
     extract::{Path, Query, State},
@@ -33,7 +34,7 @@ pub async fn pull_session_file(
     Path(session_id): Path<Uuid>,
     Query(query): Query<PullFileQuery>,
 ) -> Result<impl IntoResponse, AppError> {
-    if query.path.trim().is_empty() {
+    if !is_non_blank(&query.path) {
         return Err(AppError::BadRequest("path is required"));
     }
 
@@ -90,7 +91,7 @@ pub async fn pull_session_file(
         .unwrap_or_else(|| "download".to_string());
     let content_type = response
         .media_type
-        .filter(|s| !s.trim().is_empty())
+        .filter(|s| is_non_blank(s))
         .unwrap_or_else(|| "application/octet-stream".to_string());
 
     Ok((

--- a/backend/src/handlers/history.rs
+++ b/backend/src/handlers/history.rs
@@ -48,6 +48,7 @@ use crate::auth::extract_user;
 use crate::errors::AppError;
 use crate::handlers::media_store::{parse_range, RangeOutcome};
 use crate::models::User;
+use crate::strings::is_non_blank;
 use crate::AppState;
 
 fn archive_runtime(app_state: &AppState) -> Result<Arc<ArchiveRuntime>, AppError> {
@@ -510,7 +511,7 @@ pub async fn get_history_media(
     // last resort for bytes we don't recognize.
     let content_type = meta
         .map(|m| m.content_type)
-        .filter(|ct| !ct.trim().is_empty())
+        .filter(|ct| is_non_blank(ct))
         .or_else(|| shared::media::sniff_content_type(&bytes).map(str::to_string))
         .unwrap_or_else(|| "application/octet-stream".to_string());
 

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -22,6 +22,7 @@ use crate::errors::AppError;
 use crate::handlers::responses::EmptyResponse;
 use crate::handlers::websocket::SessionManager;
 use crate::models::{jsonb_string_vec, NewSessionMember, NewSessionWithId};
+use crate::strings::is_non_blank;
 use crate::AppState;
 
 /// GET /api/launchers - List connected launchers for the current user
@@ -305,7 +306,7 @@ pub async fn fork_session(
         ForkDirectoryMode::Worktree | ForkDirectoryMode::Same => source.working_directory.clone(),
         ForkDirectoryMode::Other => req
             .working_directory
-            .filter(|path| !path.trim().is_empty())
+            .filter(|path| is_non_blank(path))
             .ok_or(AppError::BadRequest(
                 "working_directory is required for other-directory forks",
             ))?,
@@ -313,7 +314,7 @@ pub async fn fork_session(
     let name = normalize_custom_name(Some(&req.name))
         .unwrap_or_else(|| format!("{} (fork)", source.session_name));
     let mut claude_args: Vec<String> = jsonb_string_vec(&source.claude_args);
-    if let Some(model) = req.model.filter(|model| !model.trim().is_empty()) {
+    if let Some(model) = req.model.filter(|model| is_non_blank(model)) {
         claude_args = apply_model_override(claude_args, agent_type, model);
     }
 

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -18,6 +18,7 @@ pub mod models;
 pub mod push;
 pub mod routes;
 pub mod schema;
+pub mod strings;
 
 // Visible to the crate's own `#[cfg(test)]` modules AND to the separate
 // integration-test binaries (e.g. `tests/harness.rs`), which link the lib

--- a/backend/src/push/mod.rs
+++ b/backend/src/push/mod.rs
@@ -23,6 +23,7 @@ pub use transport::{LogTransport, PushError, PushTransport, SendOutcome};
 pub use webpush::WebPushTransport;
 
 use crate::models::PushSubscription;
+use crate::strings::is_non_blank;
 use shared::api::{NotificationContentDetail, NotificationPrefs, PushPlatform};
 use std::path::PathBuf;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
@@ -253,7 +254,7 @@ impl NotificationEvent {
                 NotificationContentDetail::Generic => "Permission needed".to_string(),
                 NotificationContentDetail::ToolName => format!("Permission needed: {tool_name}"),
                 NotificationContentDetail::Snippet => match input_snippet {
-                    Some(snippet) if !snippet.trim().is_empty() => cap_snippet(&format!(
+                    Some(snippet) if is_non_blank(&snippet) => cap_snippet(&format!(
                         "Permission needed: {tool_name} — {}",
                         snippet.trim()
                     )),

--- a/backend/src/strings.rs
+++ b/backend/src/strings.rs
@@ -1,0 +1,27 @@
+//! Small string guards shared across backend checks.
+//!
+//! Backend counterpart to the `is_non_blank` family in `frontend/src/utils.rs`
+//! (the frontend cannot share this crate, and the helper is two lines, so it
+//! lives in both places rather than growing `shared/` for backend
+//! convenience).
+
+/// True when `s` holds non-whitespace text.
+///
+/// Single home for the repeated `!s.trim().is_empty()` shape in `if` guards,
+/// match guards, and `filter` closures.
+pub fn is_non_blank(s: &str) -> bool {
+    !s.trim().is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_non_blank_rejects_empty_and_whitespace_only() {
+        assert!(!is_non_blank(""));
+        assert!(!is_non_blank("   "));
+        assert!(!is_non_blank("\t\n "));
+        assert!(is_non_blank("  hi  "));
+    }
+}


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/2373e9d5c9cf28385108f51d6bc49057a54d9beb/.0-pr-viz/001932.svg)

Follows the frontend dedupe (#1927, #1929, #1930) into the backend: adds a single `crate::strings::is_non_blank` guard and converts the 8 scattered `!s.trim().is_empty()` /`s.trim().is_empty()` sites (push snippet, history content-type, identity email, files path/media-type, launchers workdir/model, VAPID config) to it. No behavior change.

Verified locally: `cargo fmt --check`, `cargo clippy -p backend --all-targets` clean, new `strings::tests` unit test passes.