### PR TITLE
Update claude-codes to 2.1.267

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,9 +1156,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-codes"
-version = "2.1.266"
+version = "2.1.267"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd76756862e148c4bd0595a5d6979397b665ff6a56648d0f872ff4bdd8556ab2"
+checksum = "e2929d2b9f0476f1662a0b53c29a050ccff9205c1e167954346a079bba68fef2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Claude Code integration
-claude-codes = { version = "2.1.266", default-features = false, features = ["types"] }
+claude-codes = { version = "2.1.267", default-features = false, features = ["types"] }
 
 # Muse CLI integration
 muse-codes = { version = "1.0.3", default-features = false, features = ["types"] }


### PR DESCRIPTION
Update `claude-codes` from 2.1.266 to 2.1.267 in the workspace requirement and lockfile. The [upstream changelog](https://github.com/meawoppl/rust-code-agent-sdks/blob/main/claude-codes/CHANGELOG.md#21267---2026-09-10) confirms a tested CLI pin update with no stream-JSON protocol drift, so no portal adapter changes are required.

Validation: 89 Claude session tests and 202 shared tests passed; the frontend and shared types passed `cargo check -p frontend --target wasm32-unknown-unknown`; `cargo fmt` applied.

No visual: this changes only a dependency version and checksum.
