### PR TITLE
Update codex-codes to 0.154.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,9 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.153.4"
+version = "0.154.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a298430bf650d7ea520f03d47337d1cbf8a6af19d20988e01ba349205fe503"
+checksum = "979562f06d068f103b81b3638dcb03912eb15bd589fb7ce69f8032730ebbb5d3"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ claude-codes = { version = "2.1.266", default-features = false, features = ["typ
 
 # Muse CLI integration
 muse-codes = { version = "1.0.3", default-features = false, features = ["types"] }
-codex-codes = { version = "0.153.4", default-features = false, features = ["types"] }
+codex-codes = { version = "0.154.0", default-features = false, features = ["types"] }
 
 # Web Push (VAPID + RFC8291 encryption). `default-features = false` drops the
 # bundled HTTP clients (isahc/libcurl and hyper) — we build the message here and


### PR DESCRIPTION
Update `codex-codes` from 0.153.4 to 0.154.0 in the workspace requirement and lockfile. The [upstream changes](https://github.com/meawoppl/rust-code-agent-sdks/blob/main/codex-codes/CHANGELOG.md#01535---2026-09-10) preserve partially read JSON frames when `AsyncClient::next_message()` or `request()` is cancelled. This fixes the SDK framing beneath the portal’s existing `tokio::select!` loop without an adapter workaround.

The new optional `FeedbackUploadResponse.prompt_hash` requires no changes: the portal does not use feedback upload. Version 0.154.0 re-baselines the tested CLI pin without further protocol changes.

Validation: all 38 Codex session tests passed; the frontend and shared types passed `cargo check -p frontend --target wasm32-unknown-unknown`; `cargo fmt` applied.

No visual: the portal diff contains only the dependency version and checksum.
