### PR TITLE
Update muse-codes to 1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4532,9 +4532,9 @@ dependencies = [
 
 [[package]]
 name = "muse-codes"
-version = "1.0.3"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "890f0e286ca5dda7256233fd8963f56d817aa6c1cc37a8811a301339a3c2d070"
+checksum = "159b7bb012640e31720c9c836c947bda31e53e75a5e820572afe6147e10190d3"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 claude-codes = { version = "2.1.267", default-features = false, features = ["types"] }
 
 # Muse CLI integration
-muse-codes = { version = "1.0.3", default-features = false, features = ["types"] }
+muse-codes = { version = "1.1.1", default-features = false, features = ["types"] }
 codex-codes = { version = "0.154.0", default-features = false, features = ["types"] }
 
 # Web Push (VAPID + RFC8291 encryption). `default-features = false` drops the


### PR DESCRIPTION
Update `muse-codes` from 1.0.3 to 1.1.1 in the workspace requirement and lockfile. The [upstream changelog](https://github.com/meawoppl/rust-code-agent-sdks/blob/main/muse-codes/CHANGELOG.md#111---2026-09-10) confirms unchanged protocol fingerprints and model catalog against Muse Code 1.1.1, so no portal adapter changes are required.

Validation on the combined latest SDK versions: all 348 Claude, Codex, Muse, and shared library tests passed (one existing live-binary Muse test remains ignored); the frontend and shared types passed `cargo check -p frontend --target wasm32-unknown-unknown`; `cargo fmt` applied.

No visual: this changes only a dependency version and checksum.
