### PR TITLE
Share blank-string guard across archive-format checks

### DIFF
--- a/.0-pr-viz/001936.svg
+++ b/.0-pr-viz/001936.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2000" height="1200" viewBox="0 0 2000 1200" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <!-- Thesis -->
+  <text x="1000" y="64" text-anchor="middle" fill="#c0caf5" font-size="34" font-weight="bold">Three inline blank checks in archive-format share one is_non_blank home</text>
+
+  <!-- BEFORE / AFTER labels -->
+  <text x="500" y="126" text-anchor="middle" fill="#f7768e" font-size="26" font-weight="bold" letter-spacing="4">BEFORE</text>
+  <text x="1500" y="126" text-anchor="middle" fill="#9ece6a" font-size="26" font-weight="bold" letter-spacing="4">AFTER</text>
+  <line x1="1000" y1="96" x2="1000" y2="1140" stroke="#565f89" stroke-width="2" stroke-dasharray="8 8"/>
+
+  <!-- BEFORE -->
+  <g>
+    <text x="180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">archive-format: the same shape three times</text>
+
+    <rect x="180" y="230" width="640" height="96" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="262" fill="#565f89" font-size="13">store.rs:72 - local-root env guard</text>
+    <text x="200" y="292" fill="#e6e9f5" font-size="15" font-family="monospace">if root.trim().is_empty() {</text>
+
+    <rect x="180" y="346" width="640" height="96" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="378" fill="#565f89" font-size="13">store.rs:85 - s3-bucket env guard</text>
+    <text x="200" y="408" fill="#e6e9f5" font-size="15" font-family="monospace">if bucket.trim().is_empty() {</text>
+
+    <rect x="180" y="462" width="640" height="96" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="494" fill="#565f89" font-size="13">lib.rs:369 - NDJSON transcript parse</text>
+    <text x="200" y="524" fill="#e6e9f5" font-size="15" font-family="monospace">.filter(|l| !l.trim().is_empty())</text>
+
+    <rect x="150" y="600" width="700" height="250" rx="12" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="180" y="638" fill="#f7768e" font-size="19" font-weight="bold">Three copies, zero shared home:</text>
+    <text x="180" y="674" fill="#c0caf5" font-size="16">- each site re-spells !s.trim().is_empty()</text>
+    <text x="180" y="702" fill="#c0caf5" font-size="16">- backend grew strings.rs in #1932, frontend</text>
+    <text x="180" y="730" fill="#c0caf5" font-size="16">  in #1929 - archive-format never got its own</text>
+    <text x="180" y="758" fill="#c0caf5" font-size="16">- the next blank check would copy the shape</text>
+    <text x="180" y="786" fill="#c0caf5" font-size="16">  a fourth time instead of reusing a name</text>
+  </g>
+
+  <!-- AFTER -->
+  <g>
+    <text x="1180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">One two-line helper, three call sites:</text>
+
+    <rect x="1180" y="230" width="640" height="180" rx="8" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1200" y="262" fill="#9ece6a" font-size="13">archive-format/src/strings.rs (new)</text>
+    <text x="1200" y="294" fill="#e6e9f5" font-size="15" font-family="monospace">pub fn is_non_blank(s: &amp;str) -&gt; bool {</text>
+    <text x="1220" y="320" fill="#e6e9f5" font-size="15" font-family="monospace">!s.trim().is_empty()</text>
+    <text x="1200" y="346" fill="#e6e9f5" font-size="15" font-family="monospace">}</text>
+    <text x="1200" y="376" fill="#565f89" font-size="13" font-family="monospace">// + unit test: "", "   ", "  hi  "</text>
+
+    <rect x="1180" y="430" width="640" height="150" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="1200" y="462" fill="#565f89" font-size="13">the three call sites now</text>
+    <text x="1200" y="494" fill="#e6e9f5" font-size="15" font-family="monospace">if !is_non_blank(&amp;root) {</text>
+    <text x="1200" y="520" fill="#e6e9f5" font-size="15" font-family="monospace">if !is_non_blank(&amp;bucket) {</text>
+    <text x="1200" y="546" fill="#e6e9f5" font-size="15" font-family="monospace">.filter(|l| strings::is_non_blank(l))</text>
+
+    <rect x="1150" y="620" width="700" height="230" rx="12" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1180" y="658" fill="#9ece6a" font-size="19" font-weight="bold">Same behavior, single spelling:</text>
+    <text x="1180" y="694" fill="#c0caf5" font-size="16">- filters and if-guards read as intent</text>
+    <text x="1180" y="722" fill="#c0caf5" font-size="16">- the next blank check reuses the name</text>
+    <text x="1180" y="750" fill="#c0caf5" font-size="16">- mirrors the #1929 / #1932 shape, including</text>
+    <text x="1180" y="778" fill="#c0caf5" font-size="16">  the per-crate-helper rationale in the docs</text>
+  </g>
+
+  <!-- bottom strip -->
+  <text x="500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">PR #1936 - no behavior change, DRY only</text>
+  <text x="1500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">cargo test -p archive-format: 18 passed</text>
+
+  <!-- Footer limitation -->
+  <text x="1000" y="1190" text-anchor="middle" fill="#565f89" font-size="15" font-style="italic">Limitation: session-lib, launcher and portal-stt keep their own copies - one crate per PR keeps the series reviewable.</text>
+</svg>

--- a/archive-format/src/lib.rs
+++ b/archive-format/src/lib.rs
@@ -39,6 +39,7 @@
 
 pub mod scan;
 pub mod store;
+pub mod strings;
 pub use store::*;
 
 use chrono::NaiveDateTime;
@@ -366,7 +367,7 @@ pub fn merge_transcript_lines(
 pub fn parse_transcript_ndjson(ndjson: &[u8]) -> std::io::Result<Vec<ArchiveMessageLine>> {
     String::from_utf8_lossy(ndjson)
         .lines()
-        .filter(|l| !l.trim().is_empty())
+        .filter(|l| strings::is_non_blank(l))
         .map(|l| {
             serde_json::from_str(l).map_err(|e| {
                 std::io::Error::new(std::io::ErrorKind::InvalidData, format!("bad line: {e}"))

--- a/archive-format/src/store.rs
+++ b/archive-format/src/store.rs
@@ -9,8 +9,8 @@ use uuid::Uuid;
 
 use crate::{
     decode_transcript, manifest_key, media_key, media_meta_key, parse_transcript_ndjson,
-    transcript_key, zstd_encode, ArchiveMessageLine, ArchivedMediaMeta, SessionArchiveBundle,
-    SessionArchiveManifest, TRANSCRIPT_COMPRESSION,
+    strings::is_non_blank, transcript_key, zstd_encode, ArchiveMessageLine, ArchivedMediaMeta,
+    SessionArchiveBundle, SessionArchiveManifest, TRANSCRIPT_COMPRESSION,
 };
 
 // ---------------------------------------------------------------------------
@@ -69,7 +69,7 @@ pub fn archive_config_from_env() -> Result<Option<ArchiveConfig>, String> {
                  PORTAL_SESSION_ARCHIVE_LOCAL_ROOT to be set"
                     .to_string()
             })?;
-            if root.trim().is_empty() {
+            if !is_non_blank(&root) {
                 return Err("PORTAL_SESSION_ARCHIVE_LOCAL_ROOT must not be empty".to_string());
             }
             ArchiveBackendConfig::Local {
@@ -82,7 +82,7 @@ pub fn archive_config_from_env() -> Result<Option<ArchiveConfig>, String> {
                  PORTAL_SESSION_ARCHIVE_S3_BUCKET to be set"
                     .to_string()
             })?;
-            if bucket.trim().is_empty() {
+            if !is_non_blank(&bucket) {
                 return Err("PORTAL_SESSION_ARCHIVE_S3_BUCKET must not be empty".to_string());
             }
             let prefix = match std::env::var("PORTAL_SESSION_ARCHIVE_S3_PREFIX") {

--- a/archive-format/src/strings.rs
+++ b/archive-format/src/strings.rs
@@ -1,0 +1,27 @@
+//! Small string guards shared across archive-format checks.
+//!
+//! Format-crate counterpart to the `is_non_blank` helpers in `backend` and
+//! the frontend utils (neither is linkable from here without growing this
+//! crate's dependency surface for a two-line check, so it lives in each
+//! place instead).
+
+/// True when `s` holds non-whitespace text.
+///
+/// Single home for the repeated `!s.trim().is_empty()` shape in `if` guards
+/// and `filter` closures.
+pub fn is_non_blank(s: &str) -> bool {
+    !s.trim().is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_non_blank_rejects_empty_and_whitespace_only() {
+        assert!(!is_non_blank(""));
+        assert!(!is_non_blank("   "));
+        assert!(!is_non_blank("\t\n "));
+        assert!(is_non_blank("  hi  "));
+    }
+}


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/06c6cd0274bdc33ca42f720cde07af27bdf1a6af/.0-pr-viz/001936.svg)

Follows #1932 (backend) and #1929 (frontend): adds a crate-local `is_non_blank` helper in `archive-format/src/strings.rs` and uses it at the three remaining inline `trim().is_empty()` sites (two env-config guards in `store.rs`, one NDJSON filter in `lib.rs`). No behavior change.