### PR TITLE
Share blank-string guard across session-lib checks

### DIFF
--- a/.0-pr-viz/001938.svg
+++ b/.0-pr-viz/001938.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2000" height="1200" viewBox="0 0 2000 1200" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <!-- Thesis -->
+  <text x="1000" y="64" text-anchor="middle" fill="#c0caf5" font-size="34" font-weight="bold">Two inline blank checks in session-lib share one is_non_blank home</text>
+
+  <!-- BEFORE / AFTER labels -->
+  <text x="500" y="126" text-anchor="middle" fill="#f7768e" font-size="26" font-weight="bold" letter-spacing="4">BEFORE</text>
+  <text x="1500" y="126" text-anchor="middle" fill="#9ece6a" font-size="26" font-weight="bold" letter-spacing="4">AFTER</text>
+  <line x1="1000" y1="96" x2="1000" y2="1140" stroke="#565f89" stroke-width="2" stroke-dasharray="8 8"/>
+
+  <!-- BEFORE -->
+  <g>
+    <text x="180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">session-lib: the same shape twice</text>
+
+    <rect x="180" y="230" width="640" height="96" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="262" fill="#565f89" font-size="13">install.rs - failure-detail guard</text>
+    <text x="200" y="292" fill="#e6e9f5" font-size="15" font-family="monospace">if stderr.trim().is_empty() {</text>
+
+    <rect x="180" y="346" width="640" height="96" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="378" fill="#565f89" font-size="13">probe.rs - Muse env-credential probe</text>
+    <text x="200" y="408" fill="#e6e9f5" font-size="15" font-family="monospace">.is_ok_and(|v| !v.trim().is_empty())</text>
+
+    <rect x="150" y="600" width="700" height="250" rx="12" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="180" y="638" fill="#f7768e" font-size="19" font-weight="bold">Same shape, no shared home:</text>
+    <text x="180" y="674" fill="#c0caf5" font-size="16">- each site re-spells !s.trim().is_empty()</text>
+    <text x="180" y="702" fill="#c0caf5" font-size="16">- #1936 left session-lib for a follow-up -</text>
+    <text x="180" y="730" fill="#c0caf5" font-size="16">  this PR is that follow-up</text>
+    <text x="180" y="758" fill="#c0caf5" font-size="16">- the next blank check would copy the shape</text>
+    <text x="180" y="786" fill="#c0caf5" font-size="16">  a third time instead of reusing a name</text>
+  </g>
+
+  <!-- AFTER -->
+  <g>
+    <text x="1180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">One two-line helper, two call sites:</text>
+
+    <rect x="1180" y="230" width="640" height="180" rx="8" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1200" y="262" fill="#9ece6a" font-size="13">session-lib/src/strings.rs (new)</text>
+    <text x="1200" y="294" fill="#e6e9f5" font-size="15" font-family="monospace">pub fn is_non_blank(s: &amp;str) -&gt; bool {</text>
+    <text x="1220" y="320" fill="#e6e9f5" font-size="15" font-family="monospace">!s.trim().is_empty()</text>
+    <text x="1200" y="346" fill="#e6e9f5" font-size="15" font-family="monospace">}</text>
+    <text x="1200" y="376" fill="#565f89" font-size="13" font-family="monospace">// + unit test: "", "   ", "  hi  "</text>
+
+    <rect x="1180" y="430" width="640" height="150" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="1200" y="462" fill="#565f89" font-size="13">the two call sites now</text>
+    <text x="1200" y="494" fill="#e6e9f5" font-size="15" font-family="monospace">if !is_non_blank(&amp;stderr) {</text>
+    <text x="1200" y="520" fill="#e6e9f5" font-size="15" font-family="monospace">.is_ok_and(|v| is_non_blank(&amp;v))</text>
+
+    <rect x="1150" y="620" width="700" height="230" rx="12" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1180" y="658" fill="#9ece6a" font-size="19" font-weight="bold">Same behavior, single spelling:</text>
+    <text x="1180" y="694" fill="#c0caf5" font-size="16">- if-guard and closure read as intent</text>
+    <text x="1180" y="722" fill="#c0caf5" font-size="16">- mirrors the #1932 / #1936 shape, including</text>
+    <text x="1180" y="750" fill="#c0caf5" font-size="16">  the per-crate-helper rationale in the docs</text>
+    <text x="1180" y="778" fill="#c0caf5" font-size="16">- the next blank check reuses the name</text>
+  </g>
+
+  <!-- bottom strip -->
+  <text x="500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">PR #1938 - no behavior change, DRY only</text>
+  <text x="1500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">cargo test -p session-lib: 63 passed</text>
+
+  <!-- Footer limitation -->
+  <text x="1000" y="1190" text-anchor="middle" fill="#565f89" font-size="15" font-style="italic">Limitation: install.rs keeps is_empty on the already-trimmed body; launcher and portal-stt keep their own copies.</text>
+</svg>

--- a/session-lib/src/install.rs
+++ b/session-lib/src/install.rs
@@ -10,6 +10,8 @@
 use shared::AgentType;
 use std::process::Command;
 
+use crate::strings::is_non_blank;
+
 /// Outcome of an install attempt.
 #[derive(Debug, Clone)]
 pub struct InstallResult {
@@ -51,7 +53,7 @@ pub fn install_agent(agent: AgentType) -> InstallResult {
 /// stdout, tail-truncated.
 fn failure_detail(output: &std::process::Output) -> String {
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let body = if stderr.trim().is_empty() {
+    let body = if !is_non_blank(&stderr) {
         String::from_utf8_lossy(&output.stdout)
     } else {
         stderr

--- a/session-lib/src/lib.rs
+++ b/session-lib/src/lib.rs
@@ -39,6 +39,7 @@ pub mod probe;
 pub mod proxy_session;
 pub mod session;
 pub mod snapshot;
+pub mod strings;
 pub mod tunnel;
 pub mod turn_tracker;
 

--- a/session-lib/src/probe.rs
+++ b/session-lib/src/probe.rs
@@ -7,6 +7,8 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::time::Duration;
 
+use crate::strings::is_non_blank;
+
 /// Result of probing one agent binary on the host.
 #[derive(Debug, Clone)]
 pub struct ProbeResult {
@@ -126,7 +128,7 @@ pub fn probe_muse_sandbox() -> Option<bool> {
 /// label instead of a name, annotated when the credential comes from the
 /// environment rather than the saved file.
 pub fn probe_muse_login() -> shared::AgentLoginStatus {
-    let via_env = std::env::var("META_API_KEY").is_ok_and(|v| !v.trim().is_empty());
+    let via_env = std::env::var("META_API_KEY").is_ok_and(|v| is_non_blank(&v));
     if via_env {
         return shared::AgentLoginStatus::LoggedIn {
             label: Some("meta".to_string()),

--- a/session-lib/src/strings.rs
+++ b/session-lib/src/strings.rs
@@ -1,0 +1,27 @@
+//! Small string guards shared across session-lib checks.
+//!
+//! Session-lib counterpart to the `is_non_blank` helpers in `backend`,
+//! `archive-format`, and the frontend utils (none is linkable from here
+//! without growing this crate's dependency surface for a two-line check, so
+//! it lives in each place instead).
+
+/// True when `s` holds non-whitespace text.
+///
+/// Single home for the repeated `!s.trim().is_empty()` shape in `if` guards
+/// and `is_ok_and` closures.
+pub fn is_non_blank(s: &str) -> bool {
+    !s.trim().is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_non_blank_rejects_empty_and_whitespace_only() {
+        assert!(!is_non_blank(""));
+        assert!(!is_non_blank("   "));
+        assert!(!is_non_blank("\t\n "));
+        assert!(is_non_blank("  hi  "));
+    }
+}


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/f7e1760d5ba3520e16f4047d81d23dd771ebd20b/.0-pr-viz/001938.svg)

session-lib had the same hand-rolled !s.trim().is_empty() shape in two places (install failure-detail guard, Muse env-credential probe). New session-lib/src/strings.rs owns is_non_blank once, with both sites adopting it - the same per-crate-helper pattern as #1929/#1932/#1936, and the crate #1936's footer explicitly left for a follow-up.

No behavior change: identical predicate at both sites. install.rs keeps its is_empty check on the already-trimmed body, which is the precise test there.

Verified: cargo fmt clean, cargo test -p session-lib (63 passed), clippy clean.