### PR TITLE
Share blank-string guard across claude-session-lib checks

### DIFF
--- a/.0-pr-viz/001939.svg
+++ b/.0-pr-viz/001939.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2000" height="1200" viewBox="0 0 2000 1200" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <!-- Thesis -->
+  <text x="1000" y="64" text-anchor="middle" fill="#c0caf5" font-size="34" font-weight="bold">Two inline blank checks in claude-session-lib share one is_non_blank home</text>
+
+  <!-- BEFORE / AFTER labels -->
+  <text x="500" y="126" text-anchor="middle" fill="#f7768e" font-size="26" font-weight="bold" letter-spacing="4">BEFORE</text>
+  <text x="1500" y="126" text-anchor="middle" fill="#9ece6a" font-size="26" font-weight="bold" letter-spacing="4">AFTER</text>
+  <line x1="1000" y1="96" x2="1000" y2="1140" stroke="#565f89" stroke-width="2" stroke-dasharray="8 8"/>
+
+  <!-- BEFORE -->
+  <g>
+    <text x="180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">claude-session-lib: the same shape twice</text>
+
+    <rect x="180" y="230" width="640" height="96" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="262" fill="#565f89" font-size="13">io_task.rs - synthetic-echo suppressor</text>
+    <text x="200" y="292" fill="#e6e9f5" font-size="15" font-family="monospace">text.trim().is_empty() || ...</text>
+
+    <rect x="180" y="346" width="640" height="96" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="378" fill="#565f89" font-size="13">io_task.rs - empty-echo transcript drop</text>
+    <text x="200" y="408" fill="#e6e9f5" font-size="15" font-family="monospace">if echoed_text.trim().is_empty() {</text>
+
+    <rect x="150" y="600" width="700" height="250" rx="12" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="180" y="638" fill="#f7768e" font-size="19" font-weight="bold">Same shape, no shared home:</text>
+    <text x="180" y="674" fill="#c0caf5" font-size="16">- each site re-spells !s.trim().is_empty()</text>
+    <text x="180" y="702" fill="#c0caf5" font-size="16">- continues the #1929 / #1936 / #1938</text>
+    <text x="180" y="730" fill="#c0caf5" font-size="16">  per-crate-helper series - this PR is next</text>
+    <text x="180" y="758" fill="#c0caf5" font-size="16">- the next blank check would copy the shape</text>
+    <text x="180" y="786" fill="#c0caf5" font-size="16">  a third time instead of reusing a name</text>
+  </g>
+
+  <!-- AFTER -->
+  <g>
+    <text x="1180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">One two-line helper, two call sites:</text>
+
+    <rect x="1180" y="230" width="640" height="180" rx="8" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1200" y="262" fill="#9ece6a" font-size="13">claude-session-lib/src/strings.rs (new)</text>
+    <text x="1200" y="294" fill="#e6e9f5" font-size="15" font-family="monospace">pub fn is_non_blank(s: &amp;str) -&gt; bool {</text>
+    <text x="1220" y="320" fill="#e6e9f5" font-size="15" font-family="monospace">!s.trim().is_empty()</text>
+    <text x="1200" y="346" fill="#e6e9f5" font-size="15" font-family="monospace">}</text>
+    <text x="1200" y="376" fill="#565f89" font-size="13" font-family="monospace">// + unit test: "", "   ", "  hi  "</text>
+
+    <rect x="1180" y="430" width="640" height="150" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="1200" y="462" fill="#565f89" font-size="13">the two call sites now</text>
+    <text x="1200" y="494" fill="#e6e9f5" font-size="15" font-family="monospace">!is_non_blank(text) || ...</text>
+    <text x="1200" y="520" fill="#e6e9f5" font-size="15" font-family="monospace">if !is_non_blank(&amp;echoed_text) {</text>
+
+    <rect x="1150" y="620" width="700" height="230" rx="12" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1180" y="658" fill="#9ece6a" font-size="19" font-weight="bold">Same behavior, single spelling:</text>
+    <text x="1180" y="694" fill="#c0caf5" font-size="16">- suppressor predicate and guard read as intent</text>
+    <text x="1180" y="722" fill="#c0caf5" font-size="16">- mirrors the #1936 / #1938 shape, including</text>
+    <text x="1180" y="750" fill="#c0caf5" font-size="16">  the per-crate-helper rationale in the docs</text>
+    <text x="1180" y="778" fill="#c0caf5" font-size="16">- the next blank check reuses the name</text>
+  </g>
+
+  <!-- bottom strip -->
+  <text x="500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">PR #1939 - no behavior change, DRY only</text>
+  <text x="1500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">cargo test -p claude-session-lib: 90 passed</text>
+
+  <!-- Footer limitation -->
+  <text x="1000" y="1190" text-anchor="middle" fill="#565f89" font-size="15" font-style="italic">Limitation: launcher and portal-stt keep their own copies; backend sites still inline.</text>
+</svg>

--- a/claude-session-lib/src/io_task.rs
+++ b/claude-session-lib/src/io_task.rs
@@ -24,6 +24,8 @@ use shared::PortalMessage;
 use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
 
+use crate::strings::is_non_blank;
+
 /// Build a Claude `ControlResponse` from a neutral [`PermissionDecision`].
 ///
 /// Mirrors the allow/deny/remember mapping the generic `Session` used to do
@@ -196,7 +198,7 @@ fn plain_input_text(input: &ClaudeInput) -> Option<String> {
 }
 
 fn should_suppress_synthetic_user_echo(text: &str) -> bool {
-    text.trim().is_empty() || is_system_reminder_text(text)
+    !is_non_blank(text) || is_system_reminder_text(text)
 }
 
 fn is_system_reminder_text(text: &str) -> bool {
@@ -454,7 +456,7 @@ impl ClaudeIoState {
             return true;
         }
 
-        if echoed_text.trim().is_empty() {
+        if !is_non_blank(&echoed_text) {
             tracing::debug!("Dropping empty user echo from transcript");
             return true;
         }

--- a/claude-session-lib/src/lib.rs
+++ b/claude-session-lib/src/lib.rs
@@ -16,6 +16,7 @@ pub mod io_task;
 pub mod login;
 pub mod proxy_session;
 mod spawn;
+pub mod strings;
 pub mod transcript;
 
 pub use agent::ClaudeAgent;

--- a/claude-session-lib/src/strings.rs
+++ b/claude-session-lib/src/strings.rs
@@ -1,0 +1,27 @@
+//! Small string guards shared across claude-session-lib checks.
+//!
+//! Claude-crate counterpart to the `is_non_blank` helpers in `session-lib`,
+//! `archive-format`, and the frontend utils (none is linkable from here
+//! without growing this crate's dependency surface for a two-line check, so
+//! it lives in each place instead).
+
+/// True when `s` holds non-whitespace text.
+///
+/// Single home for the repeated `!s.trim().is_empty()` shape in `if` guards
+/// and `||` predicates.
+pub fn is_non_blank(s: &str) -> bool {
+    !s.trim().is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_non_blank_rejects_empty_and_whitespace_only() {
+        assert!(!is_non_blank(""));
+        assert!(!is_non_blank("   "));
+        assert!(!is_non_blank("\t\n "));
+        assert!(is_non_blank("  hi  "));
+    }
+}


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/438d832b1c3b4b75fb15a73e6725ee53d2bfc068/.0-pr-viz/001939.svg)

claude-session-lib had the same hand-rolled trim().is_empty() shape in two places (synthetic user-echo suppressor, empty-echo transcript drop). New claude-session-lib/src/strings.rs owns is_non_blank once, with both sites adopting it - the same per-crate-helper pattern as #1929/#1936/#1938.

No behavior change: identical predicate at both sites.

Verified: cargo fmt clean, cargo test -p claude-session-lib (90 passed), clippy clean.