### PR TITLE
Share blank-string guard via shared::strings

### DIFF
--- a/.0-pr-viz/001940.svg
+++ b/.0-pr-viz/001940.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2000" height="1200" viewBox="0 0 2000 1200" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <!-- Thesis -->
+  <text x="1000" y="64" text-anchor="middle" fill="#c0caf5" font-size="34" font-weight="bold">Nine inline blank checks share one shared::strings home</text>
+
+  <!-- BEFORE / AFTER labels -->
+  <text x="500" y="126" text-anchor="middle" fill="#f7768e" font-size="26" font-weight="bold" letter-spacing="4">BEFORE</text>
+  <text x="1500" y="126" text-anchor="middle" fill="#9ece6a" font-size="26" font-weight="bold" letter-spacing="4">AFTER</text>
+  <line x1="1000" y1="96" x2="1000" y2="1140" stroke="#565f89" stroke-width="2" stroke-dasharray="8 8"/>
+
+  <!-- BEFORE -->
+  <g>
+    <text x="180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">backend: the same shape seven times</text>
+
+    <rect x="180" y="230" width="640" height="96" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="262" fill="#565f89" font-size="13">push/mod.rs - permission snippet guard</text>
+    <text x="200" y="292" fill="#e6e9f5" font-size="15" font-family="monospace">Some(snippet) if !snippet.trim()...</text>
+
+    <rect x="180" y="346" width="640" height="96" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="378" fill="#565f89" font-size="13">config.rs / identity.rs - env + email guards</text>
+    <text x="200" y="408" fill="#e6e9f5" font-size="15" font-family="monospace">Ok(v) if !v.trim().is_empty()</text>
+
+    <rect x="180" y="462" width="640" height="96" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="494" fill="#565f89" font-size="13">files / launchers / history - filter closures</text>
+    <text x="200" y="524" fill="#e6e9f5" font-size="15" font-family="monospace">.filter(|s| !s.trim().is_empty())</text>
+
+    <rect x="150" y="600" width="700" height="250" rx="12" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="180" y="638" fill="#f7768e" font-size="19" font-weight="bold">Same shape, no shared home:</text>
+    <text x="180" y="674" fill="#c0caf5" font-size="16">- each site re-spells !s.trim().is_empty()</text>
+    <text x="180" y="702" fill="#c0caf5" font-size="16">- frontend / archive-format / claude-lib</text>
+    <text x="180" y="730" fill="#c0caf5" font-size="16">  already deduped (#1929-#1939) - backend</text>
+    <text x="180" y="758" fill="#c0caf5" font-size="16">  lagged behind with seven inline copies</text>
+    <text x="180" y="786" fill="#c0caf5" font-size="16">- the next blank check would copy it again</text>
+  </g>
+
+  <!-- AFTER -->
+  <g>
+    <text x="1180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">One two-line helper, nine call sites:</text>
+
+    <rect x="1180" y="230" width="640" height="180" rx="8" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1200" y="262" fill="#9ece6a" font-size="13">shared/src/strings.rs (new, WASM-safe)</text>
+    <text x="1200" y="294" fill="#e6e9f5" font-size="15" font-family="monospace">pub fn is_non_blank(s: &amp;str) -&gt; bool {</text>
+    <text x="1220" y="320" fill="#e6e9f5" font-size="15" font-family="monospace">!s.trim().is_empty()</text>
+    <text x="1200" y="346" fill="#e6e9f5" font-size="15" font-family="monospace">}</text>
+    <text x="1200" y="376" fill="#565f89" font-size="13" font-family="monospace">// + unit test: "", "   ", "  hi  "</text>
+
+    <rect x="1180" y="430" width="640" height="150" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="1200" y="462" fill="#565f89" font-size="13">the nine call sites now</text>
+    <text x="1200" y="494" fill="#e6e9f5" font-size="15" font-family="monospace">shared::strings::is_non_blank(...)</text>
+    <text x="1200" y="520" fill="#565f89" font-size="13" font-family="monospace">guards, filters, and match arms unchanged</text>
+
+    <rect x="1150" y="620" width="700" height="230" rx="12" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1180" y="658" fill="#9ece6a" font-size="19" font-weight="bold">Same behavior, single spelling:</text>
+    <text x="1180" y="694" fill="#c0caf5" font-size="16">- backend reuses shared (already a dep),</text>
+    <text x="1180" y="722" fill="#c0caf5" font-size="16">  no dependency surface grows</text>
+    <text x="1180" y="750" fill="#c0caf5" font-size="16">- shared-internal sites use crate::strings</text>
+    <text x="1180" y="778" fill="#c0caf5" font-size="16">- the next blank check reuses the name</text>
+  </g>
+
+  <!-- bottom strip -->
+  <text x="500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">PR #1940 - no behavior change, DRY only</text>
+  <text x="1500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">shared 203 passed, clippy + WASM clean</text>
+</svg>

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -491,7 +491,7 @@ impl ServerConfig {
         // read by the Web Push sender, never by this endpoint. Unset = push
         // disabled (the vapid-key endpoint 404s).
         let vapid_public_key = match env::var("PORTAL_VAPID_PUBLIC_KEY") {
-            Ok(v) if !v.trim().is_empty() => {
+            Ok(v) if shared::strings::is_non_blank(&v) => {
                 log_source("PORTAL_VAPID_PUBLIC_KEY", true);
                 Some(v)
             }

--- a/backend/src/handlers/auth/identity.rs
+++ b/backend/src/handlers/auth/identity.rs
@@ -91,7 +91,7 @@ pub fn resolve_user(
 
     // Everything below needs a trustworthy address.
     let email = match (&identity.email, identity.email_verified) {
-        (Some(email), true) if !email.trim().is_empty() => email.trim().to_string(),
+        (Some(email), true) if shared::strings::is_non_blank(email) => email.trim().to_string(),
         _ => {
             warn!(
                 target: "auth_audit",

--- a/backend/src/handlers/files.rs
+++ b/backend/src/handlers/files.rs
@@ -33,7 +33,7 @@ pub async fn pull_session_file(
     Path(session_id): Path<Uuid>,
     Query(query): Query<PullFileQuery>,
 ) -> Result<impl IntoResponse, AppError> {
-    if query.path.trim().is_empty() {
+    if !shared::strings::is_non_blank(&query.path) {
         return Err(AppError::BadRequest("path is required"));
     }
 
@@ -90,7 +90,7 @@ pub async fn pull_session_file(
         .unwrap_or_else(|| "download".to_string());
     let content_type = response
         .media_type
-        .filter(|s| !s.trim().is_empty())
+        .filter(|s| shared::strings::is_non_blank(s))
         .unwrap_or_else(|| "application/octet-stream".to_string());
 
     Ok((

--- a/backend/src/handlers/history.rs
+++ b/backend/src/handlers/history.rs
@@ -510,7 +510,7 @@ pub async fn get_history_media(
     // last resort for bytes we don't recognize.
     let content_type = meta
         .map(|m| m.content_type)
-        .filter(|ct| !ct.trim().is_empty())
+        .filter(|ct| shared::strings::is_non_blank(ct))
         .or_else(|| shared::media::sniff_content_type(&bytes).map(str::to_string))
         .unwrap_or_else(|| "application/octet-stream".to_string());
 

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -305,7 +305,7 @@ pub async fn fork_session(
         ForkDirectoryMode::Worktree | ForkDirectoryMode::Same => source.working_directory.clone(),
         ForkDirectoryMode::Other => req
             .working_directory
-            .filter(|path| !path.trim().is_empty())
+            .filter(|path| shared::strings::is_non_blank(path))
             .ok_or(AppError::BadRequest(
                 "working_directory is required for other-directory forks",
             ))?,
@@ -313,7 +313,10 @@ pub async fn fork_session(
     let name = normalize_custom_name(Some(&req.name))
         .unwrap_or_else(|| format!("{} (fork)", source.session_name));
     let mut claude_args: Vec<String> = jsonb_string_vec(&source.claude_args);
-    if let Some(model) = req.model.filter(|model| !model.trim().is_empty()) {
+    if let Some(model) = req
+        .model
+        .filter(|model| shared::strings::is_non_blank(model))
+    {
         claude_args = apply_model_override(claude_args, agent_type, model);
     }
 

--- a/backend/src/push/mod.rs
+++ b/backend/src/push/mod.rs
@@ -253,10 +253,12 @@ impl NotificationEvent {
                 NotificationContentDetail::Generic => "Permission needed".to_string(),
                 NotificationContentDetail::ToolName => format!("Permission needed: {tool_name}"),
                 NotificationContentDetail::Snippet => match input_snippet {
-                    Some(snippet) if !snippet.trim().is_empty() => cap_snippet(&format!(
-                        "Permission needed: {tool_name} — {}",
-                        snippet.trim()
-                    )),
+                    Some(snippet) if shared::strings::is_non_blank(snippet.as_str()) => {
+                        cap_snippet(&format!(
+                            "Permission needed: {tool_name} — {}",
+                            snippet.trim()
+                        ))
+                    }
                     // No excerpt available: degrade to the tool-name body
                     // rather than an empty tease.
                     _ => format!("Permission needed: {tool_name}"),

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -127,6 +127,9 @@ pub mod protocol;
 // String/number formatting helpers shared between frontend and native crates
 pub mod fmt;
 
+// Blank-string guard shared between frontend and native crates
+pub mod strings;
+
 // Timezone canonicalization (abbreviation -> IANA) shared across crates
 pub mod timezone;
 

--- a/shared/src/strings.rs
+++ b/shared/src/strings.rs
@@ -1,0 +1,24 @@
+//! Small blank-string guard shared across crates.
+//!
+//! Single home for the repeated `!s.trim().is_empty()` shape in `if` guards
+//! and `filter` closures. Everything here is std-only so the crate keeps
+//! compiling for `wasm32-unknown-unknown`.
+
+/// True when `s` holds non-whitespace text.
+#[must_use]
+pub fn is_non_blank(s: &str) -> bool {
+    !s.trim().is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_non_blank_rejects_empty_and_whitespace_only() {
+        assert!(!is_non_blank(""));
+        assert!(!is_non_blank("   "));
+        assert!(!is_non_blank("\t\n "));
+        assert!(is_non_blank("  hi  "));
+    }
+}

--- a/shared/src/system_reminder.rs
+++ b/shared/src/system_reminder.rs
@@ -85,7 +85,7 @@ pub fn split_collapsible_notices(text: &str) -> Vec<Segment> {
 /// whitespace-only run between blocks adds no segment, while the whitespace
 /// inside a kept segment is preserved verbatim.
 fn push_text_segment(segments: &mut Vec<Segment>, s: &str) {
-    if !s.trim().is_empty() {
+    if crate::strings::is_non_blank(s) {
         segments.push(Segment::Text(s.to_string()));
     }
 }

--- a/shared/src/user_messages.rs
+++ b/shared/src/user_messages.rs
@@ -69,7 +69,7 @@ fn blocks_text(content: &serde_json::Value) -> String {
 /// task-complete `<task-notification>`, a standalone `<system-reminder>`)
 /// is not a user message in any sense the history viewer cares about.
 pub fn is_substantive_user_text(text: &str) -> bool {
-    !strip_collapsible_notices(text).trim().is_empty()
+    crate::strings::is_non_blank(&strip_collapsible_notices(text))
 }
 
 /// [`user_visible_text`] + [`is_substantive_user_text`] over a stored record.


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/f40c57ba159cfe051b2bcbffbf99231f9a5d02fb/.0-pr-viz/001940.svg)

Adds a WASM-safe `shared::strings::is_non_blank` helper (mirroring the per-crate guards in frontend/archive-format/claude-session-lib) and switches the 7 inline `trim().is_empty()` sites in backend plus 2 shared-internal sites to it. No behavior change; pure DRY.