### PR TITLE
Share blank-string guard in session-lib

### DIFF
--- a/.0-pr-viz/001943.svg
+++ b/.0-pr-viz/001943.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2000" height="1200" viewBox="0 0 2000 1200" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <!-- Thesis -->
+  <text x="1000" y="64" text-anchor="middle" fill="#c0caf5" font-size="34" font-weight="bold">session-lib adopts the shared blank-string guard</text>
+
+  <!-- BEFORE / AFTER labels -->
+  <text x="500" y="126" text-anchor="middle" fill="#f7768e" font-size="26" font-weight="bold" letter-spacing="4">BEFORE</text>
+  <text x="1500" y="126" text-anchor="middle" fill="#9ece6a" font-size="26" font-weight="bold" letter-spacing="4">AFTER</text>
+  <line x1="1000" y1="96" x2="1000" y2="1140" stroke="#565f89" stroke-width="2" stroke-dasharray="8 8"/>
+
+  <!-- BEFORE -->
+  <g>
+    <text x="180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">two raw trim().is_empty() call sites</text>
+
+    <rect x="180" y="230" width="640" height="150" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="262" fill="#565f89" font-size="13">session-lib/src/probe.rs:129</text>
+    <text x="200" y="294" fill="#e6e9f5" font-size="15" font-family="monospace">.is_ok_and(|v| !v.trim().is_empty())</text>
+    <text x="200" y="320" fill="#e6e9f5" font-size="15" font-family="monospace">META_API_KEY presence probe</text>
+    <text x="200" y="346" fill="#565f89" font-size="13" font-family="monospace">inline two-line shape</text>
+
+    <rect x="180" y="400" width="640" height="120" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="432" fill="#565f89" font-size="13">session-lib/src/install.rs:54</text>
+    <text x="200" y="462" fill="#e6e9f5" font-size="15" font-family="monospace">if stderr.trim().is_empty() {</text>
+    <text x="200" y="488" fill="#565f89" font-size="13" font-family="monospace">same shape, stderr/stdout fallback</text>
+
+    <rect x="180" y="540" width="640" height="96" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="572" fill="#565f89" font-size="13">no strings.rs in session-lib</text>
+    <text x="200" y="602" fill="#e6e9f5" font-size="15" font-family="monospace">last native holdout, shared unused</text>
+
+    <rect x="150" y="680" width="700" height="220" rx="12" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="180" y="718" fill="#f7768e" font-size="19" font-weight="bold">Same check, three spellings:</text>
+    <text x="180" y="754" fill="#c0caf5" font-size="16">- shared, claude-session-lib, and inline</text>
+    <text x="180" y="782" fill="#c0caf5" font-size="16">- a behavior fix needs every spelling</text>
+    <text x="180" y="810" fill="#c0caf5" font-size="16">- consolidation stops at session-lib</text>
+  </g>
+
+  <!-- AFTER -->
+  <g>
+    <text x="1180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">One re-export, two one-line adoptions:</text>
+
+    <rect x="1180" y="230" width="640" height="150" rx="8" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1200" y="262" fill="#9ece6a" font-size="13">session-lib/src/strings.rs (new)</text>
+    <text x="1200" y="294" fill="#e6e9f5" font-size="15" font-family="monospace">pub use shared::strings::is_non_blank;</text>
+    <text x="1200" y="324" fill="#565f89" font-size="13" font-family="monospace">mirrors claude-session-lib exactly</text>
+    <text x="1200" y="350" fill="#565f89" font-size="13" font-family="monospace">tests already live in shared</text>
+
+    <rect x="1180" y="400" width="640" height="120" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="1200" y="432" fill="#565f89" font-size="13">probe.rs + install.rs</text>
+    <text x="1200" y="464" fill="#e6e9f5" font-size="15" font-family="monospace">use crate::strings::is_non_blank;</text>
+    <text x="1200" y="490" fill="#565f89" font-size="13" font-family="monospace">is_ok_and(|v| is_non_blank(&amp;v))</text>
+
+    <rect x="1180" y="540" width="640" height="96" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="1200" y="572" fill="#565f89" font-size="13">Cargo.toml untouched (line 2)</text>
+    <text x="1200" y="602" fill="#e6e9f5" font-size="15" font-family="monospace">shared = { path = "../shared" }</text>
+
+    <rect x="1150" y="680" width="700" height="220" rx="12" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1180" y="718" fill="#9ece6a" font-size="19" font-weight="bold">Same behavior, smaller surface:</text>
+    <text x="1180" y="754" fill="#c0caf5" font-size="16">- one spelling of the blank check</text>
+    <text x="1180" y="782" fill="#c0caf5" font-size="16">- no new dependency, +11 / -2</text>
+    <text x="1180" y="810" fill="#c0caf5" font-size="16">- native code fully consolidated</text>
+  </g>
+
+  <!-- bottom strip -->
+  <text x="500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">PR #1943 - no behavior change, DRY only</text>
+  <text x="1500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">session-lib + shared pass, clippy clean</text>
+</svg>

--- a/session-lib/src/install.rs
+++ b/session-lib/src/install.rs
@@ -7,6 +7,7 @@
 //! The launcher invokes this under `spawn_blocking`, exactly like
 //! [`crate::probe`].
 
+use crate::strings::is_non_blank;
 use shared::AgentType;
 use std::process::Command;
 
@@ -51,7 +52,7 @@ pub fn install_agent(agent: AgentType) -> InstallResult {
 /// stdout, tail-truncated.
 fn failure_detail(output: &std::process::Output) -> String {
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let body = if stderr.trim().is_empty() {
+    let body = if !is_non_blank(&stderr) {
         String::from_utf8_lossy(&output.stdout)
     } else {
         stderr

--- a/session-lib/src/lib.rs
+++ b/session-lib/src/lib.rs
@@ -39,6 +39,7 @@ pub mod probe;
 pub mod proxy_session;
 pub mod session;
 pub mod snapshot;
+pub mod strings;
 pub mod tunnel;
 pub mod turn_tracker;
 

--- a/session-lib/src/probe.rs
+++ b/session-lib/src/probe.rs
@@ -2,6 +2,7 @@
 //! the launcher can spawn. Used at launcher startup (sent in the register
 //! envelope) and on demand (refreshed when the user opens the launch dialog).
 
+use crate::strings::is_non_blank;
 use shared::AgentType;
 use std::path::PathBuf;
 use std::process::Command;
@@ -126,7 +127,7 @@ pub fn probe_muse_sandbox() -> Option<bool> {
 /// label instead of a name, annotated when the credential comes from the
 /// environment rather than the saved file.
 pub fn probe_muse_login() -> shared::AgentLoginStatus {
-    let via_env = std::env::var("META_API_KEY").is_ok_and(|v| !v.trim().is_empty());
+    let via_env = std::env::var("META_API_KEY").is_ok_and(|v| is_non_blank(&v));
     if via_env {
         return shared::AgentLoginStatus::LoggedIn {
             label: Some("meta".to_string()),

--- a/session-lib/src/strings.rs
+++ b/session-lib/src/strings.rs
@@ -1,0 +1,6 @@
+//! Blank-string guard re-exported from `shared`.
+//!
+//! This crate already depends on `shared`, so the check lives there instead
+//! of in a local copy (covered by `shared::strings` tests).
+
+pub use shared::strings::is_non_blank;


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/e389d03337538807d519e6a28f5439fb401048d0/.0-pr-viz/001943.svg)

Continues the blank-guard consolidation (#1936-#1941): session-lib had the last two raw trim().is_empty() call sites in native code. Adds session-lib/src/strings.rs as a re-export of shared::strings::is_non_blank (same pattern as claude-session-lib) and adopts it in probe.rs and install.rs. No behavior change.