### PR TITLE
Reuse shared blank-string guard in frontend utils

### DIFF
--- a/.0-pr-viz/001943.svg
+++ b/.0-pr-viz/001943.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2000" height="1200" viewBox="0 0 2000 1200" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <!-- Thesis -->
+  <text x="1000" y="64" text-anchor="middle" fill="#c0caf5" font-size="34" font-weight="bold">session-lib adopts the shared blank-string guard</text>
+
+  <!-- BEFORE / AFTER labels -->
+  <text x="500" y="126" text-anchor="middle" fill="#f7768e" font-size="26" font-weight="bold" letter-spacing="4">BEFORE</text>
+  <text x="1500" y="126" text-anchor="middle" fill="#9ece6a" font-size="26" font-weight="bold" letter-spacing="4">AFTER</text>
+  <line x1="1000" y1="96" x2="1000" y2="1140" stroke="#565f89" stroke-width="2" stroke-dasharray="8 8"/>
+
+  <!-- BEFORE -->
+  <g>
+    <text x="180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">two raw trim().is_empty() call sites</text>
+
+    <rect x="180" y="230" width="640" height="150" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="262" fill="#565f89" font-size="13">session-lib/src/probe.rs:129</text>
+    <text x="200" y="294" fill="#e6e9f5" font-size="15" font-family="monospace">.is_ok_and(|v| !v.trim().is_empty())</text>
+    <text x="200" y="320" fill="#e6e9f5" font-size="15" font-family="monospace">META_API_KEY presence probe</text>
+    <text x="200" y="346" fill="#565f89" font-size="13" font-family="monospace">inline two-line shape</text>
+
+    <rect x="180" y="400" width="640" height="120" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="432" fill="#565f89" font-size="13">session-lib/src/install.rs:54</text>
+    <text x="200" y="462" fill="#e6e9f5" font-size="15" font-family="monospace">if stderr.trim().is_empty() {</text>
+    <text x="200" y="488" fill="#565f89" font-size="13" font-family="monospace">same shape, stderr/stdout fallback</text>
+
+    <rect x="180" y="540" width="640" height="96" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="572" fill="#565f89" font-size="13">no strings.rs in session-lib</text>
+    <text x="200" y="602" fill="#e6e9f5" font-size="15" font-family="monospace">last native holdout, shared unused</text>
+
+    <rect x="150" y="680" width="700" height="220" rx="12" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="180" y="718" fill="#f7768e" font-size="19" font-weight="bold">Same check, three spellings:</text>
+    <text x="180" y="754" fill="#c0caf5" font-size="16">- shared, claude-session-lib, and inline</text>
+    <text x="180" y="782" fill="#c0caf5" font-size="16">- a behavior fix needs every spelling</text>
+    <text x="180" y="810" fill="#c0caf5" font-size="16">- consolidation stops at session-lib</text>
+  </g>
+
+  <!-- AFTER -->
+  <g>
+    <text x="1180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">One re-export, two one-line adoptions:</text>
+
+    <rect x="1180" y="230" width="640" height="150" rx="8" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1200" y="262" fill="#9ece6a" font-size="13">session-lib/src/strings.rs (new)</text>
+    <text x="1200" y="294" fill="#e6e9f5" font-size="15" font-family="monospace">pub use shared::strings::is_non_blank;</text>
+    <text x="1200" y="324" fill="#565f89" font-size="13" font-family="monospace">mirrors claude-session-lib exactly</text>
+    <text x="1200" y="350" fill="#565f89" font-size="13" font-family="monospace">tests already live in shared</text>
+
+    <rect x="1180" y="400" width="640" height="120" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="1200" y="432" fill="#565f89" font-size="13">probe.rs + install.rs</text>
+    <text x="1200" y="464" fill="#e6e9f5" font-size="15" font-family="monospace">use crate::strings::is_non_blank;</text>
+    <text x="1200" y="490" fill="#565f89" font-size="13" font-family="monospace">is_ok_and(|v| is_non_blank(&amp;v))</text>
+
+    <rect x="1180" y="540" width="640" height="96" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="1200" y="572" fill="#565f89" font-size="13">Cargo.toml untouched (line 2)</text>
+    <text x="1200" y="602" fill="#e6e9f5" font-size="15" font-family="monospace">shared = { path = "../shared" }</text>
+
+    <rect x="1150" y="680" width="700" height="220" rx="12" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1180" y="718" fill="#9ece6a" font-size="19" font-weight="bold">Same behavior, smaller surface:</text>
+    <text x="1180" y="754" fill="#c0caf5" font-size="16">- one spelling of the blank check</text>
+    <text x="1180" y="782" fill="#c0caf5" font-size="16">- no new dependency, +11 / -2</text>
+    <text x="1180" y="810" fill="#c0caf5" font-size="16">- native code fully consolidated</text>
+  </g>
+
+  <!-- bottom strip -->
+  <text x="500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">PR #1943 - no behavior change, DRY only</text>
+  <text x="1500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">session-lib + shared pass, clippy clean</text>
+</svg>

--- a/.0-pr-viz/001944.svg
+++ b/.0-pr-viz/001944.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <!-- Header -->
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1944 · Reuse shared blank-string guard in frontend utils</text>
+
+  <!-- Thesis -->
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">frontend/src/utils.rs carried its own is_non_blank, line for line</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">identical to shared::strings; now it re-exports the shared one.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <!-- Panel labels + center divider -->
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <!-- ==================== BEFORE ==================== -->
+  <g>
+    <rect x="80" y="250" width="860" height="150" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="104" y="290" font-size="26" fill="#7aa2f7">frontend/src/utils.rs:234</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">pub fn is_non_blank(s: &amp;str) -&gt; bool</text>
+    <text x="104" y="366" font-size="22" fill="#565f89">!s.trim().is_empty() - a local copy</text>
+  </g>
+
+  <line x1="500" y1="400" x2="500" y2="490" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+  <text x="516" y="450" font-size="22" fill="#565f89">same two lines</text>
+
+  <g>
+    <rect x="80" y="510" width="860" height="150" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="104" y="550" font-size="26" fill="#7aa2f7">shared/src/strings.rs:9</text>
+    <text x="104" y="590" font-size="23" fill="#a9b1d6">pub fn is_non_blank(s: &amp;str) -&gt; bool</text>
+    <text x="104" y="626" font-size="22" fill="#565f89">the same two lines, plus #[must_use]</text>
+  </g>
+
+  <line x1="440" y1="720" x2="560" y2="720" stroke="#f7768e" stroke-width="3"/>
+  <text x="500" y="760" font-size="23" fill="#f7768e" text-anchor="middle">two spellings of one check</text>
+  <text x="500" y="792" font-size="22" fill="#565f89" text-anchor="middle">a fix must land twice to stay in sync</text>
+
+  <g>
+    <rect x="80" y="960" width="860" height="120" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="1006" font-size="26" fill="#c0caf5">two copies ship in one build</text>
+    <text x="104" y="1046" font-size="23" fill="#f7768e">drift risk on every future edit</text>
+  </g>
+
+  <!-- ==================== AFTER ==================== -->
+  <g>
+    <rect x="1065" y="250" width="860" height="150" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="1089" y="290" font-size="26" fill="#7aa2f7">utils::is_non_blank callers</text>
+    <text x="1089" y="330" font-size="23" fill="#a9b1d6">guards, disabled= flags, filters</text>
+    <text x="1089" y="366" font-size="22" fill="#565f89">untouched - the path still resolves</text>
+  </g>
+
+  <line x1="1495" y1="400" x2="1495" y2="490" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <g>
+    <rect x="1065" y="510" width="860" height="160" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1089" y="550" font-size="26" fill="#9ece6a">one-line re-export</text>
+    <text x="1089" y="590" font-size="23" fill="#a9b1d6">pub use shared::strings::is_non_blank;</text>
+    <text x="1089" y="626" font-size="22" fill="#565f89">shared is already a frontend dep</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="700" width="860" height="100" fill="#1e202e" stroke="#e0af68" stroke-width="1.5"/>
+    <text x="1089" y="740" font-size="24" fill="#e0af68">non_blank + owned_non_blank stay</text>
+    <text x="1089" y="776" font-size="22" fill="#a9b1d6">local helpers now ride on the re-export</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="960" width="860" height="120" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="1006" font-size="26" fill="#c0caf5">one spelling of the check</text>
+    <text x="1089" y="1046" font-size="23" fill="#9ece6a">same behavior, DRY only</text>
+  </g>
+
+  <!-- Footer -->
+  <text x="55" y="1172" font-size="22" fill="#565f89">Leaves archive-format's own copy: a native-only crate that avoids the shared dep. No behavior change.</text>
+</svg>

--- a/frontend/src/utils.rs
+++ b/frontend/src/utils.rs
@@ -228,12 +228,10 @@ pub fn non_empty(opt: Option<&str>) -> Option<&str> {
 
 /// True when `s` holds non-whitespace text.
 ///
-/// Bool counterpart to [`non_blank`] for `if` guards, `disabled=` flags, and
-/// `filter` closures that only need the check, sparing them the repeated
-/// `!s.trim().is_empty()` shape.
-pub fn is_non_blank(s: &str) -> bool {
-    !s.trim().is_empty()
-}
+/// Re-export of the shared blank-string guard so `if` guards, `disabled=`
+/// flags, and `filter` closures keep calling `utils::is_non_blank` without a
+/// second copy of the check to drift.
+pub use shared::strings::is_non_blank;
 
 /// Keep a borrowed string only when it is non-blank.
 ///

--- a/session-lib/src/install.rs
+++ b/session-lib/src/install.rs
@@ -7,6 +7,7 @@
 //! The launcher invokes this under `spawn_blocking`, exactly like
 //! [`crate::probe`].
 
+use crate::strings::is_non_blank;
 use shared::AgentType;
 use std::process::Command;
 
@@ -51,7 +52,7 @@ pub fn install_agent(agent: AgentType) -> InstallResult {
 /// stdout, tail-truncated.
 fn failure_detail(output: &std::process::Output) -> String {
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let body = if stderr.trim().is_empty() {
+    let body = if !is_non_blank(&stderr) {
         String::from_utf8_lossy(&output.stdout)
     } else {
         stderr

--- a/session-lib/src/lib.rs
+++ b/session-lib/src/lib.rs
@@ -39,6 +39,7 @@ pub mod probe;
 pub mod proxy_session;
 pub mod session;
 pub mod snapshot;
+pub mod strings;
 pub mod tunnel;
 pub mod turn_tracker;
 

--- a/session-lib/src/probe.rs
+++ b/session-lib/src/probe.rs
@@ -2,6 +2,7 @@
 //! the launcher can spawn. Used at launcher startup (sent in the register
 //! envelope) and on demand (refreshed when the user opens the launch dialog).
 
+use crate::strings::is_non_blank;
 use shared::AgentType;
 use std::path::PathBuf;
 use std::process::Command;
@@ -126,7 +127,7 @@ pub fn probe_muse_sandbox() -> Option<bool> {
 /// label instead of a name, annotated when the credential comes from the
 /// environment rather than the saved file.
 pub fn probe_muse_login() -> shared::AgentLoginStatus {
-    let via_env = std::env::var("META_API_KEY").is_ok_and(|v| !v.trim().is_empty());
+    let via_env = std::env::var("META_API_KEY").is_ok_and(|v| is_non_blank(&v));
     if via_env {
         return shared::AgentLoginStatus::LoggedIn {
             label: Some("meta".to_string()),

--- a/session-lib/src/strings.rs
+++ b/session-lib/src/strings.rs
@@ -1,0 +1,6 @@
+//! Blank-string guard re-exported from `shared`.
+//!
+//! This crate already depends on `shared`, so the check lives there instead
+//! of in a local copy (covered by `shared::strings` tests).
+
+pub use shared::strings::is_non_blank;


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/2390f235c6528b11dc7c7b377b3507b122e986eb/.0-pr-viz/001944.svg)

Dedup: frontend/src/utils.rs defined its own is_non_blank identical to shared::strings::is_non_blank (frontend already depends on shared). Now a re-export, so all utils::is_non_blank call sites keep working with one copy of the check. No behavior change. Verified: cargo check -p frontend, cargo test -p frontend utils:: (8 passed), cargo clippy -p frontend clean.