### PR TITLE
Reuse shared blank-string guard in launcher pastebin

### DIFF
--- a/.0-pr-viz/001945.svg
+++ b/.0-pr-viz/001945.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <!-- Header -->
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1945 · Reuse shared blank-string guard in launcher pastebin</text>
+
+  <!-- Thesis -->
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">pastebin spelled the blank check inline at the journalctl site;</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">now it calls shared::strings::is_non_blank instead.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <!-- Panel labels + center divider -->
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <!-- ==================== BEFORE ==================== -->
+  <g>
+    <rect x="80" y="250" width="860" height="150" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="104" y="290" font-size="26" fill="#7aa2f7">launcher/src/pastebin.rs:151</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">if stdout.trim().is_empty()</text>
+    <text x="104" y="366" font-size="22" fill="#565f89">inline spelling in collect_logs</text>
+  </g>
+
+  <line x1="500" y1="400" x2="500" y2="490" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+  <text x="516" y="450" font-size="22" fill="#565f89">same two lines</text>
+
+  <g>
+    <rect x="80" y="510" width="860" height="150" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="104" y="550" font-size="26" fill="#7aa2f7">shared/src/strings.rs:9</text>
+    <text x="104" y="590" font-size="23" fill="#a9b1d6">pub fn is_non_blank(s: &amp;str) -&gt; bool</text>
+    <text x="104" y="626" font-size="22" fill="#565f89">the same two lines, plus #[must_use]</text>
+  </g>
+
+  <line x1="440" y1="720" x2="560" y2="720" stroke="#f7768e" stroke-width="3"/>
+  <text x="500" y="760" font-size="23" fill="#f7768e" text-anchor="middle">one check, two spellings</text>
+  <text x="500" y="792" font-size="22" fill="#565f89" text-anchor="middle">a fix must land twice to stay in sync</text>
+
+  <g>
+    <rect x="80" y="960" width="860" height="120" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="1006" font-size="26" fill="#c0caf5">last inline site in the streak</text>
+    <text x="104" y="1046" font-size="23" fill="#f7768e">drift risk on every future edit</text>
+  </g>
+
+  <!-- ==================== AFTER ==================== -->
+  <g>
+    <rect x="1065" y="250" width="860" height="150" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="1089" y="290" font-size="26" fill="#7aa2f7">collect_logs journalctl arm</text>
+    <text x="1089" y="330" font-size="23" fill="#a9b1d6">if shared::strings::is_non_blank(&amp;stdout)</text>
+    <text x="1089" y="366" font-size="22" fill="#565f89">branches flipped, same outcome</text>
+  </g>
+
+  <line x1="1495" y1="400" x2="1495" y2="490" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <g>
+    <rect x="1065" y="510" width="860" height="160" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1089" y="550" font-size="26" fill="#9ece6a">zero new dependencies</text>
+    <text x="1089" y="590" font-size="23" fill="#a9b1d6">shared is already a launcher dep</text>
+    <text x="1089" y="626" font-size="22" fill="#565f89">same file already uses shared::VERSION</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="700" width="860" height="100" fill="#1e202e" stroke="#e0af68" stroke-width="1.5"/>
+    <text x="1089" y="740" font-size="24" fill="#e0af68">clippy clean, 85 tests pass</text>
+    <text x="1089" y="776" font-size="22" fill="#a9b1d6">verified on the launcher package</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="960" width="860" height="120" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="1006" font-size="26" fill="#c0caf5">one spelling of the check</text>
+    <text x="1089" y="1046" font-size="23" fill="#9ece6a">same behavior, DRY only</text>
+  </g>
+
+  <!-- Footer -->
+  <text x="55" y="1172" font-size="22" fill="#565f89">No behavior change. Continues the blank-guard dedupe streak (#1930-#1944).</text>
+</svg>

--- a/launcher/src/pastebin.rs
+++ b/launcher/src/pastebin.rs
@@ -148,10 +148,10 @@ fn collect_logs() -> String {
             .output()
             .map(|o| {
                 let stdout = String::from_utf8_lossy(&o.stdout);
-                if stdout.trim().is_empty() {
-                    "No journal entries found for agent-portal.".into()
-                } else {
+                if shared::strings::is_non_blank(&stdout) {
                     stdout.to_string()
+                } else {
+                    "No journal entries found for agent-portal.".into()
                 }
             })
             .unwrap_or_else(|e| format!("Failed to read journalctl: {}", e))


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/25efb8abdccfe6dd4f2240ba14efbc833db8d5d6/.0-pr-viz/001945.svg)

Dedup: launcher/src/pastebin.rs spelled the blank check inline (stdout.trim().is_empty()) in collect_logs; now it calls shared::strings::is_non_blank (launcher already depends on shared; same file uses shared::VERSION). Branches flipped, same outcome. No behavior change. Verified: cargo check -p agent-portal, cargo clippy clean, cargo test -p agent-portal (85 passed). Continues the blank-guard streak (#1930-#1944).