### PR TITLE
Reuse shared blank-string guard in muse tests

### DIFF
--- a/.0-pr-viz/001947.svg
+++ b/.0-pr-viz/001947.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <!-- Header -->
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1947 · Reuse shared blank-string guard in muse tests</text>
+
+  <!-- Thesis -->
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">The corpus-replay test kept the last inline blank check;</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">now it calls shared::strings::is_non_blank.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <!-- Panel labels + center divider -->
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <!-- ==================== BEFORE ==================== -->
+  <g>
+    <rect x="80" y="250" width="860" height="150" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="104" y="290" font-size="26" fill="#7aa2f7">muse-session-lib/tests/corpus_replay.rs</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">.filter(|l| !l.trim().is_empty())</text>
+    <text x="104" y="366" font-size="22" fill="#565f89">last inline spelling left in the repo</text>
+  </g>
+
+  <line x1="500" y1="400" x2="500" y2="490" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+  <text x="516" y="450" font-size="22" fill="#565f89">hand-rolled guard</text>
+
+  <g>
+    <rect x="80" y="510" width="860" height="150" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="104" y="550" font-size="26" fill="#7aa2f7">every other crate already converted</text>
+    <text x="104" y="590" font-size="23" fill="#a9b1d6">streak #1930 through #1946</text>
+    <text x="104" y="626" font-size="22" fill="#565f89">one spelling left behind</text>
+  </g>
+
+  <line x1="440" y1="720" x2="560" y2="720" stroke="#f7768e" stroke-width="3"/>
+  <text x="500" y="760" font-size="23" fill="#f7768e" text-anchor="middle">one check, two spellings</text>
+  <text x="500" y="792" font-size="22" fill="#565f89" text-anchor="middle">a reader must prove them equal</text>
+
+  <g>
+    <rect x="80" y="960" width="860" height="120" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="1006" font-size="26" fill="#c0caf5">streak incomplete</text>
+    <text x="104" y="1046" font-size="23" fill="#f7768e">dedupe stops one file short</text>
+  </g>
+
+  <!-- ==================== AFTER ==================== -->
+  <g>
+    <rect x="1065" y="250" width="860" height="150" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="1089" y="290" font-size="26" fill="#7aa2f7">same filter, shared guard</text>
+    <text x="1089" y="330" font-size="23" fill="#a9b1d6">.filter(|l| shared::strings::is_non_blank(l))</text>
+    <text x="1089" y="366" font-size="22" fill="#565f89">shared already a dependency, no Cargo change</text>
+  </g>
+
+  <line x1="1495" y1="400" x2="1495" y2="490" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <g>
+    <rect x="1065" y="510" width="860" height="160" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1089" y="550" font-size="26" fill="#9ece6a">call sites consistent</text>
+    <text x="1089" y="590" font-size="23" fill="#a9b1d6">integration tests can use shared directly</text>
+    <text x="1089" y="626" font-size="22" fill="#565f89">same precedent as backend/tests/harness.rs</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="700" width="860" height="100" fill="#1e202e" stroke="#e0af68" stroke-width="1.5"/>
+    <text x="1089" y="740" font-size="24" fill="#e0af68">clippy clean, 7 tests pass</text>
+    <text x="1089" y="776" font-size="22" fill="#a9b1d6">muse-session-lib, fmt included</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="960" width="860" height="120" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="1006" font-size="26" fill="#c0caf5">zero inline guards remain</text>
+    <text x="1089" y="1046" font-size="23" fill="#9ece6a">same behavior, DRY only</text>
+  </g>
+
+  <!-- Footer -->
+  <text x="55" y="1172" font-size="22" fill="#565f89">No behavior change. Closes out the blank-guard dedupe streak (#1930-#1946).</text>
+</svg>

--- a/muse-session-lib/tests/corpus_replay.rs
+++ b/muse-session-lib/tests/corpus_replay.rs
@@ -29,7 +29,7 @@ fn load(name: &str) -> Vec<MuseRecord> {
     std::fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("{}: {e}", path.display()))
         .lines()
-        .filter(|l| !l.trim().is_empty())
+        .filter(|l| shared::strings::is_non_blank(l))
         .map(|l| match serde_json::from_str(l) {
             Ok(r) => r,
             Err(e) => panic!("{name}: captured line failed to parse: {e}\n{l}"),


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/31dab0a64ddadfa70bf7f8e0349e798975b567f9/.0-pr-viz/001947.svg)

One-line DRY follow-up to the blank-guard dedupe streak: the corpus-replay test filter was the last inline `!l.trim().is_empty()` in the repo. Now uses `shared::strings::is_non_blank`; no behavior change.