### PR TITLE
Reuse shared blank-string guard in portal-stt probe

### DIFF
--- a/.0-pr-viz/001948.svg
+++ b/.0-pr-viz/001948.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200"
+     font-family="'Segoe UI', 'Noto Sans', 'DejaVu Sans', ui-sans-serif, system-ui, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <defs>
+    <marker id="arr-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#565f89"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <!-- Header -->
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1948 · Reuse shared blank-string guard in portal-stt probe</text>
+
+  <!-- Thesis -->
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">stt-probe kept the last inline blank check in shipped code;</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">now it calls shared::strings::is_non_blank.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <!-- Panel labels + center divider -->
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <!-- ==================== BEFORE ==================== -->
+  <g>
+    <rect x="80" y="250" width="860" height="150" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="104" y="290" font-size="26" fill="#7aa2f7">portal-stt/src/bin/stt-probe.rs</text>
+    <text x="104" y="330" font-size="23" fill="#a9b1d6">Ok(value) if !value.trim().is_empty()</text>
+    <text x="104" y="366" font-size="22" fill="#565f89">portal-stt never depended on shared</text>
+  </g>
+
+  <line x1="500" y1="400" x2="500" y2="490" stroke="#565f89" stroke-width="1.5" marker-end="url(#arr-dim)"/>
+  <text x="516" y="450" font-size="22" fill="#565f89">hand-rolled guard</text>
+
+  <g>
+    <rect x="80" y="510" width="860" height="150" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="104" y="550" font-size="26" fill="#7aa2f7">every other crate already converted</text>
+    <text x="104" y="590" font-size="23" fill="#a9b1d6">streak #1930 through #1947</text>
+    <text x="104" y="626" font-size="22" fill="#565f89">one spelling left in shipped code</text>
+  </g>
+
+  <line x1="440" y1="720" x2="560" y2="720" stroke="#f7768e" stroke-width="3"/>
+  <text x="500" y="760" font-size="23" fill="#f7768e" text-anchor="middle">one check, two spellings</text>
+  <text x="500" y="792" font-size="22" fill="#565f89" text-anchor="middle">a reader must prove them equal</text>
+
+  <g>
+    <rect x="80" y="960" width="860" height="120" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="104" y="1006" font-size="26" fill="#c0caf5">streak incomplete</text>
+    <text x="104" y="1046" font-size="23" fill="#f7768e">dedupe stops one crate short</text>
+  </g>
+
+  <!-- ==================== AFTER ==================== -->
+  <g>
+    <rect x="1065" y="250" width="860" height="150" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="1089" y="290" font-size="26" fill="#7aa2f7">same guard, shared spelling</text>
+    <text x="1089" y="330" font-size="23" fill="#a9b1d6">Ok(value) if shared::strings::is_non_blank(&amp;value)</text>
+    <text x="1089" y="366" font-size="22" fill="#565f89">matches launcher pastebin precedent</text>
+  </g>
+
+  <line x1="1495" y1="400" x2="1495" y2="490" stroke="#9ece6a" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <g>
+    <rect x="1065" y="510" width="860" height="160" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1089" y="550" font-size="26" fill="#9ece6a">one Cargo.toml line + lock edge</text>
+    <text x="1089" y="590" font-size="23" fill="#a9b1d6">shared = { path = "../shared" }</text>
+    <text x="1089" y="626" font-size="22" fill="#565f89">workspace version, no bump needed</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="700" width="860" height="100" fill="#1e202e" stroke="#e0af68" stroke-width="1.5"/>
+    <text x="1089" y="740" font-size="24" fill="#e0af68">clippy clean, 74 tests pass</text>
+    <text x="1089" y="776" font-size="22" fill="#a9b1d6">portal-stt, fmt included</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="960" width="860" height="120" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1089" y="1006" font-size="26" fill="#c0caf5">zero inline guards in shipped code</text>
+    <text x="1089" y="1046" font-size="23" fill="#9ece6a">same behavior, DRY only</text>
+  </g>
+
+  <!-- Footer -->
+  <text x="55" y="1172" font-size="22" fill="#565f89">No behavior change. Continues the blank-guard dedupe streak (#1930-#1947).</text>
+</svg>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5505,6 +5505,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "shared",
  "tokio",
  "tracing",
  "uuid",

--- a/portal-stt/Cargo.toml
+++ b/portal-stt/Cargo.toml
@@ -18,6 +18,7 @@ jsonwebtoken = "9.3"
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
+shared = { path = "../shared" }
 tokio.workspace = true
 tracing = { workspace = true }
 uuid.workspace = true

--- a/portal-stt/src/bin/stt-probe.rs
+++ b/portal-stt/src/bin/stt-probe.rs
@@ -24,7 +24,7 @@ async fn main() -> std::process::ExitCode {
     let audio_path = args.next();
 
     let backend = match std::env::var("PORTAL_STT_BACKEND") {
-        Ok(value) if !value.trim().is_empty() => value.trim().to_ascii_lowercase(),
+        Ok(value) if shared::strings::is_non_blank(&value) => value.trim().to_ascii_lowercase(),
         _ => {
             eprintln!(
                 "set PORTAL_STT_BACKEND to one of: {}\n\


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/d7e872fd278c3d935333db4ceb4246058011ef76/.0-pr-viz/001948.svg)

Follow-up to the blank-guard dedupe streak: stt-probe held the last inline `!value.trim().is_empty()` in shipped code. Adds the workspace `shared` path dep to portal-stt and uses `shared::strings::is_non_blank`; no behavior change.