### PR TITLE
Update claude-codes to 2.1.268

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,9 +1157,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-codes"
-version = "2.1.267"
+version = "2.1.268"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2929d2b9f0476f1662a0b53c29a050ccff9205c1e167954346a079bba68fef2"
+checksum = "eb3537279018607af7151057ac70678f3e1992cd00f420f59f56ea28298821e6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Claude Code integration
-claude-codes = { version = "2.1.267", default-features = false, features = ["types"] }
+claude-codes = { version = "2.1.268", default-features = false, features = ["types"] }
 
 # Muse CLI integration
 muse-codes = { version = "1.0.3", default-features = false, features = ["types"] }

--- a/claude-session-lib/src/proxy_session/wiggum.rs
+++ b/claude-session-lib/src/proxy_session/wiggum.rs
@@ -551,6 +551,9 @@ mod tests {
             user_message_uuids: Vec::new(),
             queued_turn_count: None,
             runner_exit: None,
+            resume_reason: None,
+            result_index: None,
+            local_command: None,
             fast_mode_disabled_reason: None,
         }
     }


### PR DESCRIPTION
Update `claude-codes` from 2.1.267 to 2.1.268. The SDK adds optional `resume_reason` metadata to reply frames and `result_index` / `local_command` to results; existing typed reply serialization carries these through. Update the Wiggum result fixture to initialize the new optional fields.

Reviewed the [upstream changelog](https://github.com/meawoppl/rust-code-agent-sdks/blob/main/claude-codes/CHANGELOG.md). No protocol migration is required.

Validation: `cargo test -p claude-session-lib --lib` (89 passed); `cargo check -p frontend --target wasm32-unknown-unknown`; `cargo fmt --all`. CI covers the full workspace and WASM build.

Visual omitted: dependency update with fixture compatibility only.
