### PR TITLE
Update codex-codes to 0.154.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.154.0"
+version = "0.154.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "979562f06d068f103b81b3638dcb03912eb15bd589fb7ce69f8032730ebbb5d3"
+checksum = "6957243f4c350be5a1b0aece041a83f5e3dc1d24bd85f0642bbb307aacef5be0"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ claude-codes = { version = "2.1.267", default-features = false, features = ["typ
 
 # Muse CLI integration
 muse-codes = { version = "1.0.3", default-features = false, features = ["types"] }
-codex-codes = { version = "0.154.0", default-features = false, features = ["types"] }
+codex-codes = { version = "0.154.1", default-features = false, features = ["types"] }
 
 # Web Push (VAPID + RFC8291 encryption). `default-features = false` drops the
 # bundled HTTP clients (isahc/libcurl and hyper) — we build the message here and


### PR DESCRIPTION
Update `codex-codes` from 0.154.0 to 0.154.1, keeping the existing types-only WASM features.

Reviewed the [upstream changelog](https://github.com/meawoppl/rust-code-agent-sdks/blob/main/codex-codes/CHANGELOG.md): this adds thread attachment RPC/notification types and optional managed-provider configuration fields. The portal does not issue attachment RPCs or consume those policy fields; attachment state notifications fit the existing non-display notification handling. No portal code changes are required.

Validation: `cargo test -p codex-session-lib --lib` (38 passed); `cargo check -p frontend --target wasm32-unknown-unknown`; `cargo fmt --all`.

Visual omitted: dependency-only update.
