### PR TITLE
Reuse blank-string guard for trimmed checks

### DIFF
--- a/.0-pr-viz/001952.svg
+++ b/.0-pr-viz/001952.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2000" height="1200" viewBox="0 0 2000 1200" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <!-- Thesis -->
+  <text x="1000" y="64" text-anchor="middle" fill="#c0caf5" font-size="34" font-weight="bold">session-lib trimmed checks reuse the blank guard</text>
+
+  <!-- BEFORE / AFTER labels -->
+  <text x="500" y="126" text-anchor="middle" fill="#f7768e" font-size="26" font-weight="bold" letter-spacing="4">BEFORE</text>
+  <text x="1500" y="126" text-anchor="middle" fill="#9ece6a" font-size="26" font-weight="bold" letter-spacing="4">AFTER</text>
+  <line x1="1000" y1="96" x2="1000" y2="1140" stroke="#565f89" stroke-width="2" stroke-dasharray="8 8"/>
+
+  <!-- BEFORE -->
+  <g>
+    <text x="180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">two trimmed.is_empty() leftovers</text>
+
+    <rect x="180" y="230" width="640" height="150" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="262" fill="#565f89" font-size="13">session-lib/src/probe.rs:54</text>
+    <text x="200" y="294" fill="#e6e9f5" font-size="15" font-family="monospace">let trimmed = raw.trim();</text>
+    <text x="200" y="320" fill="#e6e9f5" font-size="15" font-family="monospace">if trimmed.is_empty() {</text>
+    <text x="200" y="346" fill="#565f89" font-size="13" font-family="monospace">version parse, guard imported above</text>
+
+    <rect x="180" y="400" width="640" height="150" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="432" fill="#565f89" font-size="13">session-lib/src/install.rs:61</text>
+    <text x="200" y="462" fill="#e6e9f5" font-size="15" font-family="monospace">let trimmed = body.trim();</text>
+    <text x="200" y="488" fill="#e6e9f5" font-size="15" font-family="monospace">if trimmed.is_empty() {</text>
+    <text x="200" y="514" fill="#565f89" font-size="13" font-family="monospace">failure detail, guard imported above</text>
+
+    <rect x="150" y="620" width="700" height="250" rx="12" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="180" y="658" fill="#f7768e" font-size="19" font-weight="bold">Same crate, two spellings:</text>
+    <text x="180" y="694" fill="#c0caf5" font-size="16">- #1943 converted the trim().is_empty()</text>
+    <text x="180" y="722" fill="#c0caf5" font-size="16">  sites but missed the trim-then-check pair</text>
+    <text x="180" y="750" fill="#c0caf5" font-size="16">- the guard is imported yet unused there</text>
+    <text x="180" y="778" fill="#c0caf5" font-size="16">- next reader meets both spellings again</text>
+  </g>
+
+  <!-- AFTER -->
+  <g>
+    <text x="1180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">Two one-line adoptions, zero new deps:</text>
+
+    <rect x="1180" y="230" width="640" height="150" rx="8" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1200" y="262" fill="#9ece6a" font-size="13">probe.rs + install.rs</text>
+    <text x="1200" y="294" fill="#e6e9f5" font-size="15" font-family="monospace">if !is_non_blank(trimmed) {</text>
+    <text x="1200" y="320" fill="#565f89" font-size="13" font-family="monospace">trimmed is already trimmed: exact same</text>
+    <text x="1200" y="346" fill="#565f89" font-size="13" font-family="monospace">meaning, imports already in place</text>
+
+    <rect x="1180" y="400" width="640" height="120" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="1200" y="432" fill="#565f89" font-size="13">no other files touched</text>
+    <text x="1200" y="464" fill="#e6e9f5" font-size="15" font-family="monospace">+2 / -2, Cargo.toml untouched</text>
+    <text x="1200" y="490" fill="#565f89" font-size="13" font-family="monospace">no behavior change possible</text>
+
+    <rect x="1150" y="620" width="700" height="250" rx="12" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1180" y="658" fill="#9ece6a" font-size="19" font-weight="bold">Same behavior, single spelling:</text>
+    <text x="1180" y="694" fill="#c0caf5" font-size="16">- every session-lib blank check now reads</text>
+    <text x="1180" y="722" fill="#c0caf5" font-size="16">  is_non_blank, no second shape left</text>
+    <text x="1180" y="750" fill="#c0caf5" font-size="16">- closes out the #1940-#1948 series tail</text>
+    <text x="1180" y="778" fill="#c0caf5" font-size="16">- the next check copies one name</text>
+  </g>
+
+  <!-- bottom strip -->
+  <text x="500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">PR #1952 - no behavior change, DRY only</text>
+  <text x="1500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">session-lib 62 passed, clippy + fmt clean</text>
+</svg>

--- a/session-lib/src/install.rs
+++ b/session-lib/src/install.rs
@@ -58,7 +58,7 @@ fn failure_detail(output: &std::process::Output) -> String {
         stderr
     };
     let trimmed = body.trim();
-    if trimmed.is_empty() {
+    if !is_non_blank(trimmed) {
         return format!("install command exited with {}", output.status);
     }
     tail(trimmed, MESSAGE_TAIL)

--- a/session-lib/src/probe.rs
+++ b/session-lib/src/probe.rs
@@ -51,7 +51,7 @@ pub fn probe_agent(agent: AgentType) -> ProbeResult {
         Ok(output) if output.status.success() => {
             let raw = String::from_utf8_lossy(&output.stdout);
             let trimmed = raw.trim();
-            if trimmed.is_empty() {
+            if !is_non_blank(trimmed) {
                 None
             } else {
                 Some(trimmed.to_string())


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/50d379183782770ba865a5cb47f1fd536393c669/.0-pr-viz/001952.svg)

Two leftover `trimmed.is_empty()` sites in session-lib (probe version parse, install failure detail) now reuse the already-imported `is_non_blank` guard from #1943. No behavior change — `trimmed` is already trimmed, so `trimmed.is_empty()` is exactly `!is_non_blank(trimmed)`.