### PR TITLE
Reuse message api_base in forward

### DIFF
--- a/.0-pr-viz/001953.svg
+++ b/.0-pr-viz/001953.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2000" height="1200" viewBox="0 0 2000 1200" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <!-- Thesis -->
+  <text x="1000" y="64" text-anchor="middle" fill="#c0caf5" font-size="34" font-weight="bold">launcher backend errors share one helper</text>
+
+  <!-- BEFORE / AFTER labels -->
+  <text x="500" y="126" text-anchor="middle" fill="#f7768e" font-size="26" font-weight="bold" letter-spacing="4">BEFORE</text>
+  <text x="1500" y="126" text-anchor="middle" fill="#9ece6a" font-size="26" font-weight="bold" letter-spacing="4">AFTER</text>
+  <line x1="1000" y1="96" x2="1000" y2="1140" stroke="#565f89" stroke-width="2" stroke-dasharray="8 8"/>
+
+  <!-- BEFORE -->
+  <g>
+    <text x="180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">five copies of one format string</text>
+
+    <rect x="180" y="230" width="640" height="180" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="262" fill="#565f89" font-size="13">message.rs:183 / forward.rs:194,266</text>
+    <text x="200" y="294" fill="#565f89" font-size="13">media.rs:184 / seppuku.rs:25</text>
+    <text x="200" y="326" fill="#e6e9f5" font-size="15" font-family="monospace">anyhow!("backend returned</text>
+    <text x="200" y="352" fill="#e6e9f5" font-size="15" font-family="monospace">  {status}: {}", body.trim())</text>
+
+    <rect x="180" y="430" width="640" height="150" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="462" fill="#565f89" font-size="13">two more look-alikes, intentionally kept</text>
+    <text x="200" y="494" fill="#e6e9f5" font-size="15" font-family="monospace">...after {attempt} attempts: ...</text>
+    <text x="200" y="520" fill="#e6e9f5" font-size="15" font-family="monospace">"backend returned {}" (no body)</text>
+    <text x="200" y="546" fill="#565f89" font-size="13" font-family="monospace">different shapes: out of scope</text>
+
+    <rect x="150" y="640" width="700" height="250" rx="12" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="180" y="678" fill="#f7768e" font-size="19" font-weight="bold">One crate, five spellings:</text>
+    <text x="180" y="714" fill="#c0caf5" font-size="16">- same message typed out five times</text>
+    <text x="180" y="742" fill="#c0caf5" font-size="16">- mixed {} vs {status} capture styles</text>
+    <text x="180" y="770" fill="#c0caf5" font-size="16">- a wording tweak needs five edits</text>
+    <text x="180" y="798" fill="#c0caf5" font-size="16">- next site copies whichever it saw</text>
+  </g>
+
+  <!-- AFTER -->
+  <g>
+    <text x="1180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">One helper, five callers:</text>
+
+    <rect x="1180" y="230" width="640" height="180" rx="8" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1200" y="262" fill="#9ece6a" font-size="13">message.rs: backend_http_error</text>
+    <text x="1200" y="294" fill="#e6e9f5" font-size="15" font-family="monospace">pub(crate) fn backend_http_error(</text>
+    <text x="1200" y="320" fill="#e6e9f5" font-size="15" font-family="monospace">  status, body) -&gt; anyhow::Error</text>
+    <text x="1200" y="346" fill="#565f89" font-size="13" font-family="monospace">permanent_error falls through to it</text>
+    <text x="1200" y="372" fill="#565f89" font-size="13" font-family="monospace">forward x2, media, seppuku call it</text>
+
+    <rect x="1180" y="430" width="640" height="150" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="1200" y="462" fill="#565f89" font-size="13">format locked by a unit test</text>
+    <text x="1200" y="494" fill="#e6e9f5" font-size="15" font-family="monospace">backend_http_error_reports_</text>
+    <text x="1200" y="520" fill="#e6e9f5" font-size="15" font-family="monospace">  status_with_trimmed_body</text>
+    <text x="1200" y="546" fill="#565f89" font-size="13" font-family="monospace">rendered strings byte-identical</text>
+
+    <rect x="1150" y="640" width="700" height="250" rx="12" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1180" y="678" fill="#9ece6a" font-size="19" font-weight="bold">Same behavior, single spelling:</text>
+    <text x="1180" y="714" fill="#c0caf5" font-size="16">- every backend HTTP error reads</text>
+    <text x="1180" y="742" fill="#c0caf5" font-size="16">  backend_http_error, one edit point</text>
+    <text x="1180" y="770" fill="#c0caf5" font-size="16">- odd-shaped variants left alone</text>
+    <text x="1180" y="798" fill="#c0caf5" font-size="16">- the next site copies one name</text>
+  </g>
+
+  <!-- bottom strip -->
+  <text x="500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">PR #1953 - no behavior change, DRY only</text>
+  <text x="1500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">agent-portal 86 passed, clippy + fmt clean</text>
+</svg>

--- a/.0-pr-viz/001955.svg
+++ b/.0-pr-viz/001955.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2000" height="1200" viewBox="0 0 2000 1200" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <!-- Thesis -->
+  <text x="1000" y="64" text-anchor="middle" fill="#c0caf5" font-size="34" font-weight="bold">forward list stops swallowing the error body</text>
+
+  <!-- BEFORE / AFTER labels -->
+  <text x="500" y="126" text-anchor="middle" fill="#f7768e" font-size="26" font-weight="bold" letter-spacing="4">BEFORE</text>
+  <text x="1500" y="126" text-anchor="middle" fill="#9ece6a" font-size="26" font-weight="bold" letter-spacing="4">AFTER</text>
+  <line x1="1000" y1="96" x2="1000" y2="1140" stroke="#565f89" stroke-width="2" stroke-dasharray="8 8"/>
+
+  <!-- BEFORE -->
+  <g>
+    <text x="180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">last call site outside the helper</text>
+
+    <rect x="180" y="230" width="640" height="180" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="262" fill="#565f89" font-size="13">forward.rs: list() (open/close converted in #1953)</text>
+    <text x="200" y="294" fill="#e6e9f5" font-size="15" font-family="monospace">if !resp.status().is_success() {</text>
+    <text x="200" y="320" fill="#e6e9f5" font-size="15" font-family="monospace">  return Err(anyhow!(</text>
+    <text x="200" y="346" fill="#e6e9f5" font-size="15" font-family="monospace">    "backend returned {}",</text>
+    <text x="200" y="372" fill="#e6e9f5" font-size="15" font-family="monospace">    resp.status()));</text>
+
+    <rect x="180" y="430" width="640" height="150" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="462" fill="#565f89" font-size="13">failure output, e.g. a 500 with a reason</text>
+    <text x="200" y="494" fill="#e6e9f5" font-size="15" font-family="monospace">backend returned</text>
+    <text x="200" y="520" fill="#e6e9f5" font-size="15" font-family="monospace">  500 Internal Server Error</text>
+    <text x="200" y="546" fill="#565f89" font-size="13" font-family="monospace">body never read: reason lost</text>
+
+    <rect x="150" y="640" width="700" height="250" rx="12" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="180" y="678" fill="#f7768e" font-size="19" font-weight="bold">One subcommand, thinner errors:</text>
+    <text x="180" y="714" fill="#c0caf5" font-size="16">- list failed with status only</text>
+    <text x="180" y="742" fill="#c0caf5" font-size="16">- open/close/seppuku already</text>
+    <text x="180" y="770" fill="#c0caf5" font-size="16">  included the trimmed body</text>
+    <text x="180" y="798" fill="#c0caf5" font-size="16">- same outage, less to go on</text>
+  </g>
+
+  <!-- AFTER -->
+  <g>
+    <text x="1180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">Same three lines as its siblings:</text>
+
+    <rect x="1180" y="230" width="640" height="180" rx="8" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1200" y="262" fill="#9ece6a" font-size="13">forward.rs: list()</text>
+    <text x="1200" y="294" fill="#e6e9f5" font-size="15" font-family="monospace">let status = resp.status();</text>
+    <text x="1200" y="320" fill="#e6e9f5" font-size="15" font-family="monospace">let body = resp.text().await</text>
+    <text x="1200" y="346" fill="#e6e9f5" font-size="15" font-family="monospace">  .unwrap_or_default();</text>
+    <text x="1200" y="372" fill="#e6e9f5" font-size="15" font-family="monospace">backend_http_error(status, &amp;body)</text>
+
+    <rect x="1180" y="430" width="640" height="150" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="1200" y="462" fill="#565f89" font-size="13">failure output now</text>
+    <text x="1200" y="494" fill="#e6e9f5" font-size="15" font-family="monospace">backend returned 500</text>
+    <text x="1200" y="520" fill="#e6e9f5" font-size="15" font-family="monospace">  Internal Server Error: boom</text>
+    <text x="1200" y="546" fill="#565f89" font-size="13" font-family="monospace">format locked by the helper unit test</text>
+
+    <rect x="1150" y="640" width="700" height="250" rx="12" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1180" y="678" fill="#9ece6a" font-size="19" font-weight="bold">Every launcher site converged:</text>
+    <text x="1180" y="714" fill="#c0caf5" font-size="16">- no remaining backend call site</text>
+    <text x="1180" y="742" fill="#c0caf5" font-size="16">  formats this error by hand</text>
+    <text x="1180" y="770" fill="#c0caf5" font-size="16">- retry-count and dpaste shapes</text>
+    <text x="1180" y="798" fill="#c0caf5" font-size="16">  intentionally untouched</text>
+  </g>
+
+  <!-- bottom strip -->
+  <text x="500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">PR #1955 - richer list errors, DRY finish</text>
+  <text x="1500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">agent-portal helper test passed, clippy + fmt clean</text>
+</svg>

--- a/.0-pr-viz/001956.svg
+++ b/.0-pr-viz/001956.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2000" height="1200" viewBox="0 0 2000 1200" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <!-- Thesis -->
+  <text x="1000" y="64" text-anchor="middle" fill="#c0caf5" font-size="34" font-weight="bold">forward.rs reuses message::api_base()</text>
+
+  <!-- BEFORE / AFTER labels -->
+  <text x="500" y="126" text-anchor="middle" fill="#f7768e" font-size="26" font-weight="bold" letter-spacing="4">BEFORE</text>
+  <text x="1500" y="126" text-anchor="middle" fill="#9ece6a" font-size="26" font-weight="bold" letter-spacing="4">AFTER</text>
+  <line x1="1000" y1="96" x2="1000" y2="1140" stroke="#565f89" stroke-width="2" stroke-dasharray="8 8"/>
+
+  <!-- BEFORE -->
+  <g>
+    <text x="180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">private copy, verbatim duplicate</text>
+
+    <rect x="180" y="230" width="640" height="210" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="262" fill="#565f89" font-size="13">launcher/src/forward.rs:14 api_base()</text>
+    <text x="200" y="294" fill="#e6e9f5" font-size="15" font-family="monospace">fn api_base() -&gt; Result&lt;(String,</text>
+    <text x="200" y="320" fill="#e6e9f5" font-size="15" font-family="monospace">  String)&gt; {</text>
+    <text x="200" y="346" fill="#e6e9f5" font-size="15" font-family="monospace">  load_config / token guard /</text>
+    <text x="200" y="372" fill="#e6e9f5" font-size="15" font-family="monospace">  ws-&gt;http rewrite ... }</text>
+    <text x="200" y="398" fill="#565f89" font-size="13" font-family="monospace">identical body to message::api_base</text>
+
+    <rect x="180" y="460" width="640" height="150" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="492" fill="#565f89" font-size="13">three local call sites</text>
+    <text x="200" y="524" fill="#e6e9f5" font-size="15" font-family="monospace">open / list / close:</text>
+    <text x="200" y="550" fill="#e6e9f5" font-size="15" font-family="monospace">  api_base()?</text>
+    <text x="200" y="576" fill="#565f89" font-size="13" font-family="monospace">media.rs + seppuku.rs already shared</text>
+
+    <rect x="150" y="650" width="700" height="250" rx="12" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="180" y="688" fill="#f7768e" font-size="19" font-weight="bold">Two spellings, one resolver:</text>
+    <text x="180" y="724" fill="#c0caf5" font-size="16">- same config load, same auth guard</text>
+    <text x="180" y="752" fill="#c0caf5" font-size="16">- same wss/ws to https/http rewrite</text>
+    <text x="180" y="780" fill="#c0caf5" font-size="16">- drift risk: fix one, miss the other</text>
+    <text x="180" y="808" fill="#c0caf5" font-size="16">- comment even said shared with message</text>
+  </g>
+
+  <!-- AFTER -->
+  <g>
+    <text x="1180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">single home in message.rs</text>
+
+    <rect x="1180" y="230" width="640" height="210" rx="8" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1200" y="262" fill="#9ece6a" font-size="13">launcher/src/message.rs:110 api_base()</text>
+    <text x="1200" y="294" fill="#e6e9f5" font-size="15" font-family="monospace">pub(crate) fn api_base()</text>
+    <text x="1200" y="320" fill="#e6e9f5" font-size="15" font-family="monospace">  -&gt; Result&lt;(String, String)&gt;</text>
+    <text x="1200" y="346" fill="#565f89" font-size="13" font-family="monospace">unchanged; now the only copy</text>
+    <text x="1200" y="372" fill="#565f89" font-size="13" font-family="monospace">open/list/close + media + seppuku</text>
+
+    <rect x="1180" y="460" width="640" height="150" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="1200" y="492" fill="#565f89" font-size="13">forward.rs: open / list / close</text>
+    <text x="1200" y="524" fill="#e6e9f5" font-size="15" font-family="monospace">crate::message::api_base()?</text>
+    <text x="1200" y="550" fill="#565f89" font-size="13" font-family="monospace">private duplicate deleted (-20/+3)</text>
+
+    <rect x="1150" y="650" width="700" height="250" rx="12" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1180" y="688" fill="#9ece6a" font-size="19" font-weight="bold">Launcher converged:</text>
+    <text x="1180" y="724" fill="#c0caf5" font-size="16">- one resolver for every subcommand</text>
+    <text x="1180" y="752" fill="#c0caf5" font-size="16">- auth + URL rewrite fix in one place</text>
+    <text x="1180" y="780" fill="#c0caf5" font-size="16">- no behavior change, pure DRY</text>
+  </g>
+
+  <!-- bottom strip -->
+  <text x="500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">PR #1956 - share api_base, delete the copy</text>
+  <text x="1500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">agent-portal tests passed, clippy + fmt clean</text>
+</svg>

--- a/launcher/src/forward.rs
+++ b/launcher/src/forward.rs
@@ -224,7 +224,9 @@ pub async fn list() -> Result<()> {
         .await
         .context("request to backend failed")?;
     if !resp.status().is_success() {
-        return Err(anyhow!("backend returned {}", resp.status()));
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(crate::message::backend_http_error(status, &body));
     }
     let data: SessionForwardsResponse = resp.json().await.context("malformed response")?;
     if data.forwards.is_empty() {

--- a/launcher/src/forward.rs
+++ b/launcher/src/forward.rs
@@ -191,7 +191,7 @@ pub async fn open(port: u16) -> Result<()> {
     let status = resp.status();
     if !status.is_success() {
         let body = resp.text().await.unwrap_or_default();
-        return Err(anyhow!("backend returned {}: {}", status, body.trim()));
+        return Err(crate::message::backend_http_error(status, &body));
     }
     let data: CreateForwardResponse = resp.json().await.context("malformed response")?;
 
@@ -263,7 +263,7 @@ pub async fn close() -> Result<()> {
     }
     if !status.is_success() {
         let body = resp.text().await.unwrap_or_default();
-        return Err(anyhow!("backend returned {}: {}", status, body.trim()));
+        return Err(crate::message::backend_http_error(status, &body));
     }
     println!("Forward closed.");
     Ok(())

--- a/launcher/src/forward.rs
+++ b/launcher/src/forward.rs
@@ -9,23 +9,6 @@ use anyhow::{anyhow, Context, Result};
 
 use shared::api::{CreateForwardRequest, CreateForwardResponse, SessionForwardsResponse};
 
-/// Resolve the API base URL and auth token from launcher config (shared with
-/// `message`).
-fn api_base() -> Result<(String, String)> {
-    let config = crate::config::load_config();
-    let token = config
-        .auth_token
-        .filter(|t| !t.is_empty())
-        .ok_or_else(|| anyhow!("Not authenticated — run `agent-portal login` first"))?;
-    let ws_url = config
-        .backend_url
-        .unwrap_or_else(|| shared::default_backend_url().to_string());
-    let http = ws_url
-        .replacen("wss://", "https://", 1)
-        .replacen("ws://", "http://", 1);
-    Ok((http.trim_end_matches('/').to_string(), token))
-}
-
 /// The calling agent's own portal session id (reuses `message`'s resolver, so
 /// Claude / Codex / explicit-override all work).
 async fn session_id(client: &reqwest::Client, base: &str, token: &str) -> Result<String> {
@@ -173,7 +156,7 @@ pub async fn open(port: u16) -> Result<()> {
     if port == 0 {
         return Err(anyhow!("port must be 1-65535"));
     }
-    let (base, token) = api_base()?;
+    let (base, token) = crate::message::api_base()?;
     let client = reqwest::Client::new();
     let session = session_id(&client, &base, &token).await?;
 
@@ -213,7 +196,7 @@ pub async fn open(port: u16) -> Result<()> {
 
 /// `agent-portal forward list` — active forwards for this session.
 pub async fn list() -> Result<()> {
-    let (base, token) = api_base()?;
+    let (base, token) = crate::message::api_base()?;
     let client = reqwest::Client::new();
     let session = session_id(&client, &base, &token).await?;
 
@@ -249,7 +232,7 @@ pub async fn list() -> Result<()> {
 
 /// `agent-portal forward close` — revoke the session's forward.
 pub async fn close() -> Result<()> {
-    let (base, token) = api_base()?;
+    let (base, token) = crate::message::api_base()?;
     let client = reqwest::Client::new();
     let session = session_id(&client, &base, &token).await?;
 

--- a/launcher/src/media.rs
+++ b/launcher/src/media.rs
@@ -181,7 +181,7 @@ pub(crate) async fn upload_media(
     let status = resp.status();
     if !status.is_success() {
         let body = resp.text().await.unwrap_or_default();
-        return Err(anyhow!("backend returned {}: {}", status, body.trim()));
+        return Err(crate::message::backend_http_error(status, &body));
     }
 
     let data: ShowMediaResponse = resp.json().await.context("malformed response")?;

--- a/launcher/src/message.rs
+++ b/launcher/src/message.rs
@@ -172,6 +172,12 @@ fn jitter_ms(max: u64) -> u64 {
     nanos % (max + 1)
 }
 
+/// User-facing error for a non-success backend HTTP response: the status plus
+/// the trimmed response body.
+pub(crate) fn backend_http_error(status: reqwest::StatusCode, body: &str) -> anyhow::Error {
+    anyhow!("backend returned {status}: {}", body.trim())
+}
+
 /// Turn a permanent (non-retried) HTTP status into a user-facing error, with
 /// login/permission guidance for auth failures.
 fn permanent_error(status: reqwest::StatusCode, body: &str) -> anyhow::Error {
@@ -180,7 +186,7 @@ fn permanent_error(status: reqwest::StatusCode, body: &str) -> anyhow::Error {
         StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => anyhow!(
             "not authorized ({status}) — run `agent-portal login`, or check you own the target session"
         ),
-        _ => anyhow!("backend returned {status}: {}", body.trim()),
+        _ => backend_http_error(status, body),
     }
 }
 
@@ -700,6 +706,15 @@ mod tests {
         assert!(session_is_connected(&old_wire));
         old_wire.status = "disconnected".to_string();
         assert!(!session_is_connected(&old_wire));
+    }
+
+    #[test]
+    fn backend_http_error_reports_status_with_trimmed_body() {
+        let err = backend_http_error(reqwest::StatusCode::INTERNAL_SERVER_ERROR, "  boom\n");
+        assert_eq!(
+            err.to_string(),
+            "backend returned 500 Internal Server Error: boom"
+        );
     }
 
     #[test]

--- a/launcher/src/seppuku.rs
+++ b/launcher/src/seppuku.rs
@@ -22,7 +22,7 @@ pub async fn run() -> Result<()> {
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
-        anyhow::bail!("backend returned {status}: {}", body.trim());
+        return Err(crate::message::backend_http_error(status, &body));
     }
 
     println!("Session termination requested.");


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/ca366d9300b52520cc45505233d111dc5a25f7ac/.0-pr-viz/001956.svg)

forward.rs duplicated message::api_base() verbatim (same config load, token guard, ws->http rewrite). media.rs and seppuku.rs already reuse crate::message::api_base(); point forward's open/list/close at it and delete the copy. No behavior change.