### PR TITLE
Use response.ok() in launcher lifecycle check

### DIFF
--- a/frontend/src/pages/settings/launchers_panel.rs
+++ b/frontend/src/pages/settings/launchers_panel.rs
@@ -745,7 +745,7 @@ pub fn launchers_panel() -> Html {
             spawn_local(async move {
                 let url = utils::api_url(&format!("/api/launchers/{launcher_id}/{endpoint}"));
                 let failure = match Request::post(&url).send().await {
-                    Ok(resp) if resp.status() == 200 => None,
+                    Ok(resp) if resp.ok() => None,
                     Ok(resp) => {
                         let text = resp.text().await.unwrap_or_default();
                         Some(format!("{verb} failed: {} {}", resp.status(), text))


### PR DESCRIPTION
One-line consistency tidy: the launcher update/restart POST handler treats any 2xx as success via gloo Response::ok(), matching the delete checks converted in #1903. Backend returns EmptyResponse::OK (200) on success, so no behavior change in practice; this just drops the last remaining status() == 200 in frontend/src.