### PR TITLE
Bind HTTP status once before success check

### DIFF
--- a/.0-pr-viz/001960.svg
+++ b/.0-pr-viz/001960.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2000" height="1200" viewBox="0 0 2000 1200" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+
+  <!-- Thesis -->
+  <text x="1000" y="64" text-anchor="middle" fill="#c0caf5" font-size="34" font-weight="bold">launcher binds HTTP status once before success check</text>
+
+  <!-- BEFORE / AFTER labels -->
+  <text x="500" y="126" text-anchor="middle" fill="#f7768e" font-size="26" font-weight="bold" letter-spacing="4">BEFORE</text>
+  <text x="1500" y="126" text-anchor="middle" fill="#9ece6a" font-size="26" font-weight="bold" letter-spacing="4">AFTER</text>
+  <line x1="1000" y1="96" x2="1000" y2="1140" stroke="#565f89" stroke-width="2" stroke-dasharray="8 8"/>
+
+  <!-- BEFORE -->
+  <g>
+    <text x="180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">three call sites query status() twice</text>
+
+    <rect x="180" y="230" width="640" height="250" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="262" fill="#565f89" font-size="13">forward.rs:209 (list) - seppuku.rs:22 - pastebin.rs:215</text>
+    <text x="200" y="294" fill="#e6e9f5" font-size="15" font-family="monospace">if !resp.status().is_success() {</text>
+    <text x="200" y="320" fill="#e6e9f5" font-size="15" font-family="monospace">  let status = resp.status();</text>
+    <text x="200" y="346" fill="#e6e9f5" font-size="15" font-family="monospace">  let body = resp.text().await...</text>
+    <text x="200" y="372" fill="#e6e9f5" font-size="15" font-family="monospace">  return Err(backend_http_error(</text>
+    <text x="200" y="398" fill="#e6e9f5" font-size="15" font-family="monospace">    status, &amp;body)); }</text>
+    <text x="200" y="428" fill="#565f89" font-size="13" font-family="monospace">two status() calls to say one thing</text>
+    <text x="200" y="454" fill="#565f89" font-size="13" font-family="monospace">StatusCode is Copy - no reason to re-ask</text>
+
+    <rect x="180" y="500" width="640" height="120" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="200" y="532" fill="#565f89" font-size="13">meanwhile, in the same crate</text>
+    <text x="200" y="564" fill="#e6e9f5" font-size="15" font-family="monospace">forward.rs open()/close(), media.rs</text>
+    <text x="200" y="590" fill="#e6e9f5" font-size="15" font-family="monospace">let status = resp.status(); if ...</text>
+
+    <rect x="150" y="660" width="700" height="250" rx="12" fill="#1e202e" stroke="#f7768e" stroke-width="1.5"/>
+    <text x="180" y="698" fill="#f7768e" font-size="19" font-weight="bold">Two spellings, one check:</text>
+    <text x="180" y="734" fill="#c0caf5" font-size="16">- same guard, same error mapping</text>
+    <text x="180" y="762" fill="#c0caf5" font-size="16">- three sites re-query in the branch</text>
+    <text x="180" y="790" fill="#c0caf5" font-size="16">- drift risk: edit one, miss the other</text>
+    <text x="180" y="818" fill="#c0caf5" font-size="16">- neighbors already bind it once</text>
+  </g>
+
+  <!-- AFTER -->
+  <g>
+    <text x="1180" y="200" fill="#a9b1d6" font-size="19" font-weight="bold">one binding for every success check</text>
+
+    <rect x="1180" y="230" width="640" height="250" rx="8" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1200" y="262" fill="#9ece6a" font-size="13">forward.rs - seppuku.rs - pastebin.rs</text>
+    <text x="1200" y="294" fill="#e6e9f5" font-size="15" font-family="monospace">let status = resp.status();</text>
+    <text x="1200" y="320" fill="#e6e9f5" font-size="15" font-family="monospace">if !status.is_success() {</text>
+    <text x="1200" y="346" fill="#e6e9f5" font-size="15" font-family="monospace">  let body = resp.text().await...</text>
+    <text x="1200" y="372" fill="#e6e9f5" font-size="15" font-family="monospace">  return Err(backend_http_error(</text>
+    <text x="1200" y="398" fill="#e6e9f5" font-size="15" font-family="monospace">    status, &amp;body)); }</text>
+    <text x="1200" y="428" fill="#565f89" font-size="13" font-family="monospace">identical behavior; no new branches</text>
+    <text x="1200" y="454" fill="#565f89" font-size="13" font-family="monospace">3 files, 6 insertions, 6 deletions</text>
+
+    <rect x="1180" y="500" width="640" height="120" rx="8" fill="#1e202e" stroke="#3d4666" stroke-width="1"/>
+    <text x="1200" y="532" fill="#565f89" font-size="13">matches the neighboring call sites</text>
+    <text x="1200" y="564" fill="#e6e9f5" font-size="15" font-family="monospace">forward open()/close(), media.rs</text>
+    <text x="1200" y="590" fill="#e6e9f5" font-size="15" font-family="monospace">one idiom across the launcher</text>
+
+    <rect x="1150" y="660" width="700" height="250" rx="12" fill="#1e202e" stroke="#9ece6a" stroke-width="1.5"/>
+    <text x="1180" y="698" fill="#9ece6a" font-size="19" font-weight="bold">Launcher converged:</text>
+    <text x="1180" y="734" fill="#c0caf5" font-size="16">- no double status() queries left</text>
+    <text x="1180" y="762" fill="#c0caf5" font-size="16">- error bodies + 404 path untouched</text>
+    <text x="1180" y="790" fill="#c0caf5" font-size="16">- 86 agent-portal tests green, fmt clean</text>
+  </g>
+
+  <!-- bottom strip -->
+  <text x="500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">PR #1960 - bind status once, drop the re-query</text>
+  <text x="1500" y="1160" text-anchor="middle" fill="#a9b1d6" font-size="16">same vein as #1953-#1959, launcher edition</text>
+</svg>

--- a/launcher/src/forward.rs
+++ b/launcher/src/forward.rs
@@ -206,8 +206,8 @@ pub async fn list() -> Result<()> {
         .send()
         .await
         .context("request to backend failed")?;
-    if !resp.status().is_success() {
-        let status = resp.status();
+    let status = resp.status();
+    if !status.is_success() {
         let body = resp.text().await.unwrap_or_default();
         return Err(crate::message::backend_http_error(status, &body));
     }

--- a/launcher/src/pastebin.rs
+++ b/launcher/src/pastebin.rs
@@ -212,8 +212,8 @@ async fn upload_to_dpaste(content: &str) -> Result<String> {
         .await
         .context("Failed to upload to dpaste.org")?;
 
-    if !resp.status().is_success() {
-        let status = resp.status();
+    let status = resp.status();
+    if !status.is_success() {
         let body = resp.text().await.unwrap_or_default();
         anyhow::bail!("dpaste.org returned {}: {}", status, body);
     }

--- a/launcher/src/seppuku.rs
+++ b/launcher/src/seppuku.rs
@@ -19,8 +19,8 @@ pub async fn run() -> Result<()> {
         .await
         .context("could not reach the portal backend")?;
 
-    if !response.status().is_success() {
-        let status = response.status();
+    let status = response.status();
+    if !status.is_success() {
         let body = response.text().await.unwrap_or_default();
         return Err(crate::message::backend_http_error(status, &body));
     }


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/b6c7f6dc78774ff0b3555fbf1ce2ec17bb77d0f8/.0-pr-viz/001960.svg)

Three launcher call sites checked resp.status().is_success() then called resp.status() again inside the error branch. Bind status once first, matching open()/close()/media.rs. No behavior change (StatusCode is Copy).