### PR TITLE
Keep browser voice session alive until final event

### DIFF
--- a/.0-pr-viz/001963.svg
+++ b/.0-pr-viz/001963.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1200" font-family="'Segoe UI','Noto Sans','DejaVu Sans',ui-sans-serif,system-ui,sans-serif">
+  <rect x="0" y="0" width="2000" height="1200" fill="#16161e"/>
+  <defs>
+    <marker id="arr-red" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#f7768e"/>
+    </marker>
+    <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <text x="55" y="52" font-size="24" letter-spacing="1" fill="#565f89">PR #1963 · Preserve browser voice text on stop</text>
+  <text x="55" y="100" font-size="34" fill="#e6e9f5">Stopping browser dictation used to detach the final callback;</text>
+  <text x="55" y="140" font-size="34" fill="#e6e9f5">now the session and visible preview survive teardown.</text>
+  <line x1="55" y1="165" x2="1945" y2="165" stroke="#3d4666" stroke-width="1"/>
+
+  <text x="55" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#f7768e">BEFORE</text>
+  <text x="1040" y="212" font-size="22" font-weight="700" letter-spacing="4" fill="#9ece6a">AFTER</text>
+  <line x1="1000" y1="190" x2="1000" y2="1135" stroke="#3d4666" stroke-width="1.5" stroke-dasharray="2 6"/>
+
+  <g>
+    <rect x="80" y="260" width="860" height="150" fill="#1e202e" stroke="#3d4666" stroke-width="1.5"/>
+    <text x="108" y="303" font-size="26" fill="#7aa2f7">stop_capture browser branch</text>
+    <text x="108" y="343" font-size="23" fill="#a9b1d6">capture.take() calls session.request_stop()</text>
+    <text x="108" y="377" font-size="22" fill="#f7768e">ActiveSession then drops immediately</text>
+  </g>
+
+  <line x1="510" y1="410" x2="510" y2="500" stroke="#f7768e" stroke-width="2" marker-end="url(#arr-red)"/>
+
+  <g>
+    <rect x="80" y="520" width="860" height="170" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+    <text x="108" y="563" font-size="26" fill="#c0caf5">Drop detaches onend and onresult</text>
+    <text x="108" y="603" font-size="23" fill="#f7768e">Final(text) may never reach VoiceInput</text>
+    <text x="108" y="637" font-size="22" fill="#565f89">InputBar clears interim on recording=false</text>
+  </g>
+
+  <g>
+    <rect x="80" y="800" width="860" height="150" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+    <text x="108" y="843" font-size="26" fill="#c0caf5">visible dictation disappears</text>
+    <text x="108" y="883" font-size="23" fill="#f7768e">nothing enters the message stream</text>
+    <text x="108" y="917" font-size="22" fill="#565f89">especially when only interim text existed</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="260" width="860" height="150" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1093" y="303" font-size="26" fill="#7aa2f7">stop_capture browser branch</text>
+    <text x="1093" y="343" font-size="23" fill="#a9b1d6">session.request_stop() then restores capture</text>
+    <text x="1093" y="377" font-size="22" fill="#9ece6a">onend remains attached until it fires</text>
+  </g>
+
+  <line x1="1495" y1="410" x2="1495" y2="500" stroke="#9ece6a" stroke-width="2" marker-end="url(#arr-green)"/>
+
+  <g>
+    <rect x="1065" y="520" width="860" height="170" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1093" y="563" font-size="26" fill="#c0caf5">Final or fallback text is delivered</text>
+    <text x="1093" y="603" font-size="23" fill="#9ece6a">flush_pending_browser_text uses carryover first</text>
+    <text x="1093" y="637" font-size="22" fill="#a9b1d6">latest_preview covers interim-only browsers</text>
+  </g>
+
+  <g>
+    <rect x="1065" y="800" width="860" height="150" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+    <text x="1093" y="843" font-size="26" fill="#c0caf5">server STT path unchanged</text>
+    <text x="1093" y="883" font-size="23" fill="#a9b1d6">MediaRecorder was already kept for onstop</text>
+    <text x="1093" y="917" font-size="22" fill="#9ece6a">both voice paths now preserve stop results</text>
+  </g>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">Scope: browser SpeechRecognition stop handling; server transcription and upload behavior are unchanged.</text>
+</svg>

--- a/frontend/src/components/voice_input.rs
+++ b/frontend/src/components/voice_input.rs
@@ -383,6 +383,11 @@ pub struct VoiceInput {
     hold_open_progress: usize,
     /// Consecutive restarts that added no transcript.
     no_progress_restarts: u8,
+    /// Last browser-recognition preview shown to the user. Some Web Speech
+    /// implementations do not promote an interim segment to final text when
+    /// `stop()` is called; if the user saw words and tapped stop, use this as
+    /// the teardown fallback rather than dropping the visible dictation.
+    latest_preview: String,
 }
 
 impl Component for VoiceInput {
@@ -410,6 +415,7 @@ impl Component for VoiceInput {
             carryover: String::new(),
             hold_open_progress: 0,
             no_progress_restarts: 0,
+            latest_preview: String::new(),
         }
     }
 
@@ -453,6 +459,7 @@ impl Component for VoiceInput {
                     self.carryover.clear();
                     self.hold_open_progress = 0;
                     self.no_progress_restarts = 0;
+                    self.latest_preview.clear();
                     let hold_open = self.hold_open;
                     spawn_local(async move {
                         match start_session_async(link.clone(), String::new(), hold_open).await {
@@ -476,7 +483,7 @@ impl Component for VoiceInput {
                     // deliver any keep-alive carryover rather than losing
                     // dictation to the race.
                     drop(session);
-                    self.flush_carryover(ctx);
+                    self.flush_pending_browser_text(ctx);
                     return true;
                 }
                 self.capture = Some(Capture::Browser(session));
@@ -546,7 +553,7 @@ impl Component for VoiceInput {
                 ctx.props().on_recording_change.emit(false);
                 // A failed keep-alive restart must not lose what was already
                 // dictated: deliver the accumulated text as the message.
-                self.flush_carryover(ctx);
+                self.flush_pending_browser_text(ctx);
                 match failure {
                     StartFailure::PermissionDenied => {
                         self.show_hint(ctx, MIC_DENIED_HINT);
@@ -568,10 +575,12 @@ impl Component for VoiceInput {
                     if let Some(cb) = ctx.props().on_interim_transcription.as_ref() {
                         cb.emit(text.clone());
                     }
+                    self.latest_preview = text.clone();
                     self.carryover = text;
                     return false;
                 }
                 self.carryover.clear();
+                self.latest_preview.clear();
                 let trimmed = text.trim();
                 if !trimmed.is_empty() {
                     ctx.props().on_transcription.emit(trimmed.to_string());
@@ -579,6 +588,7 @@ impl Component for VoiceInput {
                 false
             }
             VoiceInputMsg::Interim(text) => {
+                self.latest_preview = text.clone();
                 if let Some(cb) = ctx.props().on_interim_transcription.as_ref() {
                     cb.emit(text);
                 }
@@ -660,7 +670,7 @@ impl Component for VoiceInput {
 
                 self.max_duration_timer = None;
                 // Give-up (or default-mode end): deliver whatever accumulated.
-                self.flush_carryover(ctx);
+                self.flush_pending_browser_text(ctx);
                 if self.is_recording {
                     self.is_recording = false;
                     ctx.props().on_recording_change.emit(false);
@@ -693,6 +703,7 @@ impl Component for VoiceInput {
                     self.pending_stop = false;
                     self.capture = None;
                     self.max_duration_timer = None;
+                    self.flush_pending_browser_text(ctx);
                     true
                 } else {
                     false
@@ -807,12 +818,18 @@ impl VoiceInput {
                     link.send_message(VoiceInputMsg::StopWatchdog);
                 }));
             }
-            // Browser path: the recognizer's `onend` clears `pending_stop`.
-            // iOS sometimes never fires it, hence the watchdog.
-            other => {
-                if let Some(Capture::Browser(session)) = &other {
-                    session.request_stop();
-                }
+            Some(Capture::Browser(session)) => {
+                // Ask for the final result and put the session back: the
+                // recognizer still has to fire `onend`, and dropping now would
+                // detach the handler that emits `Final`.
+                session.request_stop();
+                self.capture = Some(Capture::Browser(session));
+                self.pending_stop = true;
+                self.stop_watchdog = Some(Timeout::new(STOP_WATCHDOG_MS, move || {
+                    link.send_message(VoiceInputMsg::StopWatchdog);
+                }));
+            }
+            None => {
                 self.pending_stop = true;
                 self.stop_watchdog = Some(Timeout::new(STOP_WATCHDOG_MS, move || {
                     link.send_message(VoiceInputMsg::StopWatchdog);
@@ -824,10 +841,17 @@ impl VoiceInput {
         ctx.props().on_recording_change.emit(false);
     }
 
-    /// Deliver (and clear) any keep-alive carryover as the final transcription.
+    /// Deliver (and clear) any pending browser-recognition text as the final
+    /// transcription.
     /// No-op when empty, so it is safe to call on every teardown path.
-    fn flush_carryover(&mut self, ctx: &Context<Self>) {
-        let text = std::mem::take(&mut self.carryover);
+    fn flush_pending_browser_text(&mut self, ctx: &Context<Self>) {
+        let text = if utils::is_non_blank(&self.carryover) {
+            std::mem::take(&mut self.carryover)
+        } else {
+            std::mem::take(&mut self.latest_preview)
+        };
+        self.carryover.clear();
+        self.latest_preview.clear();
         let trimmed = text.trim();
         if !trimmed.is_empty() {
             ctx.props().on_transcription.emit(trimmed.to_string());


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/3bfd7bc10cb5fc53d1873615d63a676317d80a7f/.0-pr-viz/001963.svg)

## Summary
- keep the browser SpeechRecognition session stored after the user taps stop
- allow the pending onend handler to emit Final instead of being detached by Drop
- fall back to the latest visible interim preview when a browser never promotes it to final text
- preserve the existing watchdog path for browsers that never deliver onend

## Validation
- cargo fmt --check
- cargo check -p frontend --target wasm32-unknown-unknown
- python3 check_svg.py --style .github/visual-pr/style.json .0-pr-viz/001963.svg