### PR TITLE
Update claude-codes to 2.1.269

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,9 +1157,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claude-codes"
-version = "2.1.268"
+version = "2.1.269"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3537279018607af7151057ac70678f3e1992cd00f420f59f56ea28298821e6"
+checksum = "d89ac01c28b377738c26723bcb2b6c372d9e6b06c8249d7678cb574292b34065"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Claude Code integration
-claude-codes = { version = "2.1.268", default-features = false, features = ["types"] }
+claude-codes = { version = "2.1.269", default-features = false, features = ["types"] }
 
 # Muse CLI integration
 muse-codes = { version = "1.1.1", default-features = false, features = ["types"] }


### PR DESCRIPTION
Update `claude-codes` from 2.1.268 to 2.1.269 in the workspace manifest and lockfile.

The [upstream changelog](https://github.com/meawoppl/rust-code-agent-sdks/blob/main/claude-codes/CHANGELOG.md#21269---2026-09-12) reports no stream-JSON wire changes. Its clarification that `user_message_uuid` may appear on both the first stream event and first complete assistant message needs no portal adaptation: the portal does not deduplicate on that field.

Validation: `cargo fmt --all`; native `claude-session-lib` and `shared` unit tests; WASM check for `shared` and `frontend`. CI covers the full workspace and platform builds.

`no-visual`: dependency version/checksum update only.
