### PR TITLE
Update codex-codes to 0.154.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.154.1"
+version = "0.154.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6957243f4c350be5a1b0aece041a83f5e3dc1d24bd85f0642bbb307aacef5be0"
+checksum = "f3f3cbb10b295dbc38f3ab105029e8515d73c6d4fe7ba1d9ef61b1f3edce09b9"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ claude-codes = { version = "2.1.268", default-features = false, features = ["typ
 
 # Muse CLI integration
 muse-codes = { version = "1.1.1", default-features = false, features = ["types"] }
-codex-codes = { version = "0.154.1", default-features = false, features = ["types"] }
+codex-codes = { version = "0.154.2", default-features = false, features = ["types"] }
 
 # Web Push (VAPID + RFC8291 encryption). `default-features = false` drops the
 # bundled HTTP clients (isahc/libcurl and hyper) — we build the message here and


### PR DESCRIPTION
Update `codex-codes` from 0.154.1 to 0.154.2 in the workspace manifest and lockfile.

Reviewed the [upstream changelog](https://github.com/meawoppl/rust-code-agent-sdks/blob/main/codex-codes/CHANGELOG.md#01542---2026-09-12): model access programs, MCP server capabilities, and disabled-plugin lists are additive optional/defaulted fields. Portal turn requests already use `TurnStartParams::default()`, preserving existing disabled-plugin settings. The portal does not use the removed `thread/rollback` API. No consumer changes are required.

Validation: `cargo fmt --all`; native `codex-session-lib` and `shared` unit tests; WASM check for `shared` and `frontend`. CI covers the full workspace and platform builds.

`no-visual`: dependency version/checksum update only.
