### PR TITLE
Add iOS simulator mobile build lane

### DIFF
--- a/.0-pr-viz/001968.svg
+++ b/.0-pr-viz/001968.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2000" height="1200" viewBox="0 0 2000 1200" role="img" aria-labelledby="title desc">
+  <title id="title">PR 1968 iOS simulator build lane</title>
+  <desc id="desc">Before, mobile CI covered Android only and Linux could not run Tauri iOS commands. After, an additive macOS workflow initializes and builds the iOS simulator app without signing.</desc>
+  <rect width="2000" height="1200" fill="#16161e"/>
+
+  <text x="55" y="70" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="24" letter-spacing="1">PR #1968 · Add iOS simulator mobile build lane</text>
+  <text x="55" y="124" fill="#e6e9f5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="34" font-weight="700">iOS builds used to be invisible until a Mac tried them;</text>
+  <text x="55" y="166" fill="#e6e9f5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="34" font-weight="700">now CI runs the unsigned simulator build on macOS.</text>
+  <line x1="55" y1="190" x2="1945" y2="190" stroke="#3d4666" stroke-width="2"/>
+  <line x1="1000" y1="225" x2="1000" y2="1088" stroke="#3d4666" stroke-width="2" stroke-dasharray="12 14"/>
+
+  <text x="70" y="260" fill="#f7768e" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="700" letter-spacing="4">BEFORE</text>
+  <text x="1070" y="260" fill="#9ece6a" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="700" letter-spacing="4">AFTER</text>
+
+  <rect x="80" y="320" width="820" height="250" rx="8" fill="#1e202e" stroke="#565f89" stroke-width="2"/>
+  <text x="120" y="372" fill="#c0caf5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="26" font-weight="700">Mobile CI surface</text>
+  <text x="120" y="425" fill="#7aa2f7" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">mobile-android.yml</text>
+  <text x="120" y="472" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">Android debug APK was covered.</text>
+  <text x="120" y="516" fill="#f7768e" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">iOS had no macOS/Xcode build lane.</text>
+
+  <rect x="1100" y="320" width="820" height="250" rx="8" fill="#1e202e" stroke="#565f89" stroke-width="2"/>
+  <text x="1140" y="372" fill="#c0caf5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="26" font-weight="700">Mobile CI surface</text>
+  <text x="1140" y="425" fill="#7aa2f7" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">mobile-ios.yml</text>
+  <text x="1140" y="472" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">macos-latest installs Rust + Tauri CLI.</text>
+  <text x="1140" y="516" fill="#9ece6a" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">iOS simulator app builds without signing.</text>
+
+  <rect x="130" y="650" width="720" height="270" rx="8" fill="#1e202e" stroke="#565f89" stroke-width="2"/>
+  <text x="170" y="702" fill="#c0caf5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="26" font-weight="700">Linux local check</text>
+  <text x="170" y="758" fill="#f7768e" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">cargo tauri --help</text>
+  <path d="M180 805 H800" stroke="#3d4666" stroke-width="7" stroke-linecap="round"/>
+  <circle cx="230" cy="805" r="25" fill="#7aa2f7"/>
+  <circle cx="490" cy="805" r="25" fill="#e0af68"/>
+  <circle cx="750" cy="805" r="25" fill="#f7768e"/>
+  <text x="178" y="865" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="21">CLI</text>
+  <text x="420" y="865" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="21">no ios subcommand</text>
+  <text x="700" y="865" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="21">blocked</text>
+
+  <rect x="1150" y="650" width="720" height="270" rx="8" fill="#1e202e" stroke="#565f89" stroke-width="2"/>
+  <text x="1190" y="702" fill="#c0caf5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="26" font-weight="700">macOS workflow path</text>
+  <text x="1190" y="758" fill="#9ece6a" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">ios init -> ios build --no-sign</text>
+  <path d="M1200 805 H1820" stroke="#3d4666" stroke-width="7" stroke-linecap="round"/>
+  <circle cx="1250" cy="805" r="25" fill="#7aa2f7"/>
+  <circle cx="1510" cy="805" r="25" fill="#e0af68"/>
+  <circle cx="1770" cy="805" r="25" fill="#9ece6a"/>
+  <text x="1202" y="865" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="21">check</text>
+  <text x="1462" y="865" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="21">gen/apple</text>
+  <text x="1712" y="865" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="21">sim app</text>
+
+  <rect x="1060" y="990" width="850" height="76" rx="8" fill="#1e202e" stroke="#e0af68" stroke-width="2"/>
+  <text x="1102" y="1038" fill="#c0caf5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">Non-required lane; normal PRs keep moving.</text>
+
+  <text x="55" y="1172" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="22">Scope: simulator build only; device signing, APNs entitlements, archive export, and TestFlight remain release-track work.</text>
+</svg>

--- a/.github/workflows/mobile-ios.yml
+++ b/.github/workflows/mobile-ios.yml
@@ -17,7 +17,6 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  TAURI_CLI_VERSION: '2.11.4'
 
 jobs:
   ios-simulator-build:
@@ -60,21 +59,11 @@ jobs:
         working-directory: mobile
         run: npm ci
 
-      - name: Cache tauri-cli binary
-        id: cache-tauri-cli
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/bin/cargo-tauri
-          key: ${{ runner.os }}-cargo-tauri-${{ env.TAURI_CLI_VERSION }}
-
-      - name: Install tauri-cli v2
-        if: steps.cache-tauri-cli.outputs.cache-hit != 'true'
-        run: cargo install tauri-cli --version "${{ env.TAURI_CLI_VERSION }}" --locked
-
       - name: Verify tauri-cli iOS support
+        working-directory: mobile
         run: |
-          cargo tauri --version
-          cargo tauri --help | grep -q 'ios'
+          npx tauri --version
+          npx tauri --help | grep -q 'ios'
 
       # Fast-fail on the mobile crate before generating and archiving the
       # Xcode project. This catches Rust/iOS target regressions with cleaner
@@ -84,8 +73,8 @@ jobs:
 
       - name: Initialize iOS project
         working-directory: mobile
-        run: cargo tauri ios init --ci
+        run: npx tauri ios init --ci
 
       - name: Build simulator app
         working-directory: mobile
-        run: cargo tauri ios build --debug --target "$TAURI_IOS_TARGET" --no-sign
+        run: npx tauri ios build --debug --target "$TAURI_IOS_TARGET" --no-sign

--- a/.github/workflows/mobile-ios.yml
+++ b/.github/workflows/mobile-ios.yml
@@ -1,0 +1,91 @@
+# Additive, NON-required workflow: builds the Tauri iOS simulator app on PRs
+# that touch mobile/. It is intentionally NOT part of the `pr-to-main` ruleset's
+# required job set. The lane gives us macOS/Xcode coverage without making normal
+# product PRs depend on Apple runner availability.
+name: Mobile iOS
+
+on:
+  pull_request:
+    paths:
+      - 'mobile/**'
+      - '.github/workflows/mobile-ios.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  TAURI_CLI_VERSION: '2.11.4'
+
+jobs:
+  ios-simulator-build:
+    name: iOS Simulator App
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so build.rs commit-count version is real (#1096)
+
+      - name: Select iOS simulator target
+        run: |
+          if [ "$(uname -m)" = "arm64" ]; then
+            echo "TAURI_IOS_TARGET=aarch64-sim" >> "$GITHUB_ENV"
+            echo "IOS_RUST_TARGET=aarch64-apple-ios-sim" >> "$GITHUB_ENV"
+          else
+            echo "TAURI_IOS_TARGET=x86_64" >> "$GITHUB_ENV"
+            echo "IOS_RUST_TARGET=x86_64-apple-ios" >> "$GITHUB_ENV"
+          fi
+
+      - name: Install Rust (iOS simulator)
+        uses: dtolnay/rust-toolchain@1.96.0
+        with:
+          targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: mobile-ios
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: mobile/package-lock.json
+
+      - name: Install mobile npm dependencies
+        working-directory: mobile
+        run: npm ci
+
+      - name: Cache tauri-cli binary
+        id: cache-tauri-cli
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-tauri
+          key: ${{ runner.os }}-cargo-tauri-${{ env.TAURI_CLI_VERSION }}
+
+      - name: Install tauri-cli v2
+        if: steps.cache-tauri-cli.outputs.cache-hit != 'true'
+        run: cargo install tauri-cli --version "${{ env.TAURI_CLI_VERSION }}" --locked
+
+      - name: Verify tauri-cli iOS support
+        run: |
+          cargo tauri --version
+          cargo tauri --help | grep -q 'ios'
+
+      # Fast-fail on the mobile crate before generating and archiving the
+      # Xcode project. This catches Rust/iOS target regressions with cleaner
+      # logs than xcodebuild's wrapper output.
+      - name: Check mobile crate (iOS simulator)
+        run: cargo check -p agent-portal-mobile --target "$IOS_RUST_TARGET"
+
+      - name: Initialize iOS project
+        working-directory: mobile
+        run: cargo tauri ios init --ci
+
+      - name: Build simulator app
+        working-directory: mobile
+        run: cargo tauri ios build --debug --target "$TAURI_IOS_TARGET" --no-sign

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -288,13 +288,14 @@ sources enabled).
 What the iOS lane does, in order:
 
 1. Runs on `macos-latest`, installs the pinned Rust toolchain plus iOS device
-   and simulator targets, and installs the pinned `cargo-tauri` CLI.
+   and simulator targets, and uses the npm-provided Tauri CLI from
+   `@tauri-apps/cli`.
 2. Chooses the simulator target from the runner architecture: `aarch64-sim` on
    Apple Silicon, `x86_64` on Intel.
 3. Runs `cargo check -p agent-portal-mobile --target <ios-simulator-triple>` as
    a fast-fail Rust/iOS gate.
-4. Runs `cargo tauri ios init --ci` to generate `gen/apple`.
-5. Runs `cargo tauri ios build --debug --target <simulator-target> --no-sign`.
+4. Runs `npx tauri ios init --ci` to generate `gen/apple`.
+5. Runs `npx tauri ios build --debug --target <simulator-target> --no-sign`.
 
 The iOS lane intentionally stops at an unsigned simulator build. Device
 installation, APNs entitlements, archive export, and TestFlight upload need the

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -28,6 +28,11 @@ Install the local CLI dependencies from this directory:
 npm install
 ```
 
+The Tauri iOS subcommand is only compiled into the CLI on macOS. On Linux,
+`npm run ios:init` / `cargo tauri ios ...` will report that `ios` is not a
+recognized subcommand even when the same Tauri version is installed; use a Mac
+with Xcode or the macOS CI lane below for the full iOS build.
+
 ## Remote URL
 
 Two config keys are in play, and they do **different** jobs — conflating them
@@ -252,16 +257,19 @@ the whole set from a single source PNG rather than hand-editing individual sizes
 ## CI
 
 `.github/workflows/mobile-android.yml` (job **Android Debug APK**) builds an
-unsigned debug APK. It runs on:
+unsigned debug APK. `.github/workflows/mobile-ios.yml` (job **iOS Simulator
+App**) builds an unsigned iOS simulator app on a macOS runner. They run on:
 
 - **Pull requests** that touch `mobile/**` or the workflow file itself.
-- **Manual dispatch** (Actions tab → "Mobile Android" → "Run workflow").
+- **Manual dispatch** (Actions tab → "Mobile Android" or "Mobile iOS" → "Run
+  workflow").
 
-It is an **additive, non-required** lane: it is deliberately kept out of the
-`pr-to-main` branch-protection ruleset, so a mobile build failure never blocks a
-merge (and, conversely, do not rename its job into a required lane — see #1217).
+Both lanes are **additive, non-required** lanes: they are deliberately kept out
+of the `pr-to-main` branch-protection ruleset, so a mobile build failure never
+blocks a merge (and, conversely, do not rename their jobs into a required lane —
+see #1217).
 
-What the lane does, in order:
+What the Android lane does, in order:
 
 1. Installs the pinned Rust toolchain with the `aarch64-linux-android` target,
    Java 17 (Temurin), and the Android SDK cmdline-tools + a pinned NDK (26.x).
@@ -276,3 +284,18 @@ What the lane does, in order:
 `agent-portal-android-debug`. It contains the unsigned `*-debug.apk`, installable
 on a device or emulator with `adb install <file>.apk` (developer mode / unknown
 sources enabled).
+
+What the iOS lane does, in order:
+
+1. Runs on `macos-latest`, installs the pinned Rust toolchain plus iOS device
+   and simulator targets, and installs the pinned `cargo-tauri` CLI.
+2. Chooses the simulator target from the runner architecture: `aarch64-sim` on
+   Apple Silicon, `x86_64` on Intel.
+3. Runs `cargo check -p agent-portal-mobile --target <ios-simulator-triple>` as
+   a fast-fail Rust/iOS gate.
+4. Runs `cargo tauri ios init --ci` to generate `gen/apple`.
+5. Runs `cargo tauri ios build --debug --target <simulator-target> --no-sign`.
+
+The iOS lane intentionally stops at an unsigned simulator build. Device
+installation, APNs entitlements, archive export, and TestFlight upload need the
+signing/cert/profile work from the release track before they can run in CI.


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/97b1ef080a2d99df8d4c081d07c6a817f7932079/.0-pr-viz/001968.svg)

## Summary
- add a non-required macOS workflow for the Tauri iOS simulator build
- select the correct simulator target for Apple Silicon vs Intel runners
- document the macOS-only Tauri iOS subcommand and the new mobile CI lane

## Tests
- cargo fmt --check
- python3 YAML parse for .github/workflows/mobile-ios.yml
- python3 /tmp/tmp.DB2IssLqgB/check_svg.py --style .github/visual-pr/style.json .0-pr-viz/001968.svg
- rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
- cargo check -p agent-portal-mobile --target aarch64-apple-ios-sim (reaches expected Linux xcrun boundary)