### PR TITLE
Add signed iOS release lane

### DIFF
--- a/.0-pr-viz/001969.svg
+++ b/.0-pr-viz/001969.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2000" height="1200" viewBox="0 0 2000 1200" role="img" aria-labelledby="title desc">
+  <title id="title">PR 1969 signed iOS release lane</title>
+  <desc id="desc">Before, iOS CI stopped at an unsigned simulator build. After, a manual signed IPA workflow validates Apple credentials, builds a device IPA, and can upload to TestFlight.</desc>
+  <rect width="2000" height="1200" fill="#16161e"/>
+
+  <text x="55" y="70" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="24" letter-spacing="1">PR #1969 · Add signed iOS release lane</text>
+  <text x="55" y="124" fill="#e6e9f5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="34" font-weight="700">iOS simulator builds are green;</text>
+  <text x="55" y="166" fill="#e6e9f5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="34" font-weight="700">this adds the signed device/TestFlight path.</text>
+  <line x1="55" y1="190" x2="1945" y2="190" stroke="#3d4666" stroke-width="2"/>
+  <line x1="1000" y1="225" x2="1000" y2="1088" stroke="#3d4666" stroke-width="2" stroke-dasharray="12 14"/>
+
+  <text x="70" y="260" fill="#f7768e" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="700" letter-spacing="4">BEFORE</text>
+  <text x="1070" y="260" fill="#9ece6a" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="700" letter-spacing="4">AFTER</text>
+
+  <rect x="80" y="320" width="820" height="260" rx="8" fill="#1e202e" stroke="#565f89" stroke-width="2"/>
+  <text x="120" y="372" fill="#c0caf5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="26" font-weight="700">CI release surface</text>
+  <text x="120" y="426" fill="#7aa2f7" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">mobile-ios.yml</text>
+  <text x="120" y="474" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">macOS runner built only the simulator app.</text>
+  <text x="120" y="518" fill="#f7768e" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">No signed IPA artifact or TestFlight switch.</text>
+
+  <rect x="1100" y="320" width="820" height="260" rx="8" fill="#1e202e" stroke="#565f89" stroke-width="2"/>
+  <text x="1140" y="372" fill="#c0caf5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="26" font-weight="700">Manual release workflow</text>
+  <text x="1140" y="426" fill="#7aa2f7" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">mobile-ios-release.yml</text>
+  <text x="1140" y="474" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">Validates Apple secrets before Xcode work.</text>
+  <text x="1140" y="518" fill="#9ece6a" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">Exports a signed device IPA artifact.</text>
+
+  <rect x="130" y="660" width="720" height="265" rx="8" fill="#1e202e" stroke="#565f89" stroke-width="2"/>
+  <text x="170" y="712" fill="#c0caf5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="26" font-weight="700">Generated project gap</text>
+  <text x="170" y="768" fill="#f7768e" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">gen/apple/*.entitlements</text>
+  <path d="M180 815 H800" stroke="#3d4666" stroke-width="7" stroke-linecap="round"/>
+  <circle cx="230" cy="815" r="25" fill="#7aa2f7"/>
+  <circle cx="490" cy="815" r="25" fill="#e0af68"/>
+  <circle cx="750" cy="815" r="25" fill="#f7768e"/>
+  <text x="178" y="875" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="21">init</text>
+  <text x="420" y="875" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="21">empty file</text>
+  <text x="682" y="875" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="21">manual risk</text>
+
+  <rect x="1150" y="660" width="720" height="265" rx="8" fill="#1e202e" stroke="#565f89" stroke-width="2"/>
+  <text x="1190" y="712" fill="#c0caf5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="26" font-weight="700">Regeneration-safe hook</text>
+  <text x="1190" y="768" fill="#9ece6a" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">build.rs injects aps-environment</text>
+  <path d="M1200 815 H1820" stroke="#3d4666" stroke-width="7" stroke-linecap="round"/>
+  <circle cx="1250" cy="815" r="25" fill="#7aa2f7"/>
+  <circle cx="1510" cy="815" r="25" fill="#e0af68"/>
+  <circle cx="1770" cy="815" r="25" fill="#9ece6a"/>
+  <text x="1198" y="875" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="21">build</text>
+  <text x="1440" y="875" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="21">APNs entitlement</text>
+  <text x="1700" y="875" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="21">signed IPA</text>
+
+  <rect x="1060" y="990" width="850" height="76" rx="8" fill="#1e202e" stroke="#e0af68" stroke-width="2"/>
+  <text x="1102" y="1038" fill="#c0caf5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">TestFlight upload is opt-in on manual dispatch.</text>
+
+  <text x="55" y="1172" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="22">Scope: release machinery and docs; Apple account, certificate, provisioning profile, and APNs key secrets still gate the first signed run.</text>
+</svg>

--- a/.github/workflows/mobile-ios-release.yml
+++ b/.github/workflows/mobile-ios-release.yml
@@ -82,6 +82,8 @@ jobs:
           key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY}.p8"
           printf '%s' "$APPLE_API_KEY_P8" > "$key_path"
           chmod 600 "$key_path"
+          mkdir -p "$HOME/.appstoreconnect/private_keys"
+          cp "$key_path" "$HOME/.appstoreconnect/private_keys/"
           echo "APPLE_API_KEY_PATH=$key_path" >> "$GITHUB_ENV"
 
       - name: Select build number
@@ -149,6 +151,17 @@ jobs:
             --target aarch64 \
             --export-method "${{ inputs.export_method }}" \
             --build-number "$IOS_BUILD_NUMBER"
+
+      - name: Verify iOS entitlements
+        working-directory: mobile
+        run: |
+          entitlements="$(find src-tauri/gen/apple -name '*_iOS.entitlements' -print -quit)"
+          if [ -z "$entitlements" ]; then
+            echo "No generated iOS entitlements file found" >&2
+            exit 1
+          fi
+          /usr/libexec/PlistBuddy -c 'Print :aps-environment' "$entitlements" | grep -qx 'production'
+          /usr/libexec/PlistBuddy -c 'Print :com.apple.developer.associated-domains:0' "$entitlements" | grep -qx 'applinks:txcl.io'
 
       - name: Collect IPA
         run: |

--- a/.github/workflows/mobile-ios-release.yml
+++ b/.github/workflows/mobile-ios-release.yml
@@ -1,0 +1,179 @@
+# Manual, signed iOS release lane. This is intentionally separate from the
+# additive PR simulator lane: it needs Apple credentials, provisioning, and a
+# real device/App Store Connect signing target.
+name: Mobile iOS Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      export_method:
+        description: "Xcode export method"
+        required: true
+        default: "app-store-connect"
+        type: choice
+        options:
+          - app-store-connect
+          - release-testing
+          - debugging
+      shell_url:
+        description: "Portal URL baked into the mobile shell"
+        required: true
+        default: "https://txcl.io"
+      build_number:
+        description: "CFBundleVersion suffix; defaults to the workflow run number"
+        required: false
+      upload_testflight:
+        description: "Upload the signed IPA to App Store Connect for TestFlight"
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  signed-ipa:
+    name: Signed iOS IPA
+    runs-on: macos-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate Apple signing secrets
+        env:
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          APPLE_DEVELOPMENT_TEAM: ${{ secrets.APPLE_DEVELOPMENT_TEAM }}
+          IOS_CERTIFICATE: ${{ secrets.IOS_CERTIFICATE }}
+          IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
+          IOS_MOBILE_PROVISION: ${{ secrets.IOS_MOBILE_PROVISION }}
+        run: |
+          missing=()
+          for name in \
+            APPLE_API_KEY \
+            APPLE_API_ISSUER \
+            APPLE_API_KEY_P8 \
+            APPLE_DEVELOPMENT_TEAM \
+            IOS_CERTIFICATE \
+            IOS_CERTIFICATE_PASSWORD \
+            IOS_MOBILE_PROVISION
+          do
+            if [ -z "${!name}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ "${#missing[@]}" -ne 0 ]; then
+            printf 'Missing required signing secret(s): %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+      - name: Prepare App Store Connect API key
+        env:
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+        run: |
+          key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY}.p8"
+          printf '%s' "$APPLE_API_KEY_P8" > "$key_path"
+          chmod 600 "$key_path"
+          echo "APPLE_API_KEY_PATH=$key_path" >> "$GITHUB_ENV"
+
+      - name: Select build number
+        env:
+          REQUESTED_BUILD_NUMBER: ${{ inputs.build_number }}
+        run: |
+          if [ -n "$REQUESTED_BUILD_NUMBER" ]; then
+            echo "IOS_BUILD_NUMBER=$REQUESTED_BUILD_NUMBER" >> "$GITHUB_ENV"
+          else
+            echo "IOS_BUILD_NUMBER=$GITHUB_RUN_NUMBER" >> "$GITHUB_ENV"
+          fi
+
+      - name: Install Rust (iOS device)
+        uses: dtolnay/rust-toolchain@1.96.0
+        with:
+          targets: aarch64-apple-ios
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: mobile-ios-release
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: mobile/package-lock.json
+
+      - name: Install mobile npm dependencies
+        working-directory: mobile
+        run: npm ci
+
+      - name: Verify tauri-cli iOS support
+        working-directory: mobile
+        run: |
+          npx tauri --version
+          npx tauri --help | grep -q 'ios'
+
+      - name: Check mobile crate (iOS device)
+        run: cargo check -p agent-portal-mobile --target aarch64-apple-ios
+
+      - name: Initialize iOS project
+        working-directory: mobile
+        run: npx tauri ios init --ci
+
+      - name: Build signed IPA
+        working-directory: mobile
+        env:
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_DEVELOPMENT_TEAM: ${{ secrets.APPLE_DEVELOPMENT_TEAM }}
+          IOS_CERTIFICATE: ${{ secrets.IOS_CERTIFICATE }}
+          IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
+          IOS_MOBILE_PROVISION: ${{ secrets.IOS_MOBILE_PROVISION }}
+          PORTAL_SHELL_URL: ${{ inputs.shell_url }}
+          PORTAL_IOS_APS_ENVIRONMENT: production
+        run: |
+          npx tauri ios build \
+            --ci \
+            --target aarch64 \
+            --export-method "${{ inputs.export_method }}" \
+            --build-number "$IOS_BUILD_NUMBER"
+
+      - name: Collect IPA
+        run: |
+          mkdir -p artifacts/ios
+          ipa="$(find mobile/src-tauri/gen/apple -name '*.ipa' -print -quit)"
+          if [ -z "$ipa" ]; then
+            echo "No IPA produced under mobile/src-tauri/gen/apple" >&2
+            find mobile/src-tauri/gen/apple -maxdepth 6 -type f >&2 || true
+            exit 1
+          fi
+          cp "$ipa" artifacts/ios/
+          echo "IPA_PATH=artifacts/ios/$(basename "$ipa")" >> "$GITHUB_ENV"
+
+      - name: Upload signed IPA
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-portal-ios-signed-ipa
+          path: ${{ env.IPA_PATH }}
+          if-no-files-found: error
+
+      - name: Upload to App Store Connect
+        if: inputs.upload_testflight
+        env:
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+        run: |
+          xcrun altool \
+            --upload-app \
+            --type ios \
+            --file "$IPA_PATH" \
+            --apiKey "$APPLE_API_KEY" \
+            --apiIssuer "$APPLE_API_ISSUER"

--- a/.github/workflows/mobile-ios-release.yml
+++ b/.github/workflows/mobile-ios-release.yml
@@ -128,6 +128,10 @@ jobs:
         working-directory: mobile
         run: npx tauri ios init --ci
 
+      - name: Clean generated iOS build output
+        working-directory: mobile
+        run: rm -rf src-tauri/gen/apple/build
+
       - name: Build signed IPA
         working-directory: mobile
         env:

--- a/.github/workflows/mobile-ios.yml
+++ b/.github/workflows/mobile-ios.yml
@@ -75,6 +75,10 @@ jobs:
         working-directory: mobile
         run: npx tauri ios init --ci
 
+      - name: Clean generated iOS build output
+        working-directory: mobile
+        run: rm -rf src-tauri/gen/apple/build
+
       - name: Build simulator app
         working-directory: mobile
         run: npx tauri ios build --debug --target "$TAURI_IOS_TARGET" --no-sign

--- a/.github/workflows/mobile-ios.yml
+++ b/.github/workflows/mobile-ios.yml
@@ -82,3 +82,14 @@ jobs:
       - name: Build simulator app
         working-directory: mobile
         run: npx tauri ios build --debug --target "$TAURI_IOS_TARGET" --no-sign
+
+      - name: Verify iOS entitlements
+        working-directory: mobile
+        run: |
+          entitlements="$(find src-tauri/gen/apple -name '*_iOS.entitlements' -print -quit)"
+          if [ -z "$entitlements" ]; then
+            echo "No generated iOS entitlements file found" >&2
+            exit 1
+          fi
+          /usr/libexec/PlistBuddy -c 'Print :aps-environment' "$entitlements"
+          /usr/libexec/PlistBuddy -c 'Print :com.apple.developer.associated-domains:0' "$entitlements" | grep -qx 'applinks:txcl.io'

--- a/.github/workflows/visual-pr.yml
+++ b/.github/workflows/visual-pr.yml
@@ -37,7 +37,7 @@ jobs:
           path: pr-head
           sparse-checkout: .0-pr-viz
 
-      - uses: meawoppl/visual-pr@v3
+      - uses: meawoppl/visual-pr@v3.0.0
         with:
           head-path: pr-head
           style: .github/visual-pr/style.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,6 @@ name = "agent-portal-mobile"
 version = "2.14.11"
 dependencies = [
  "agent-portal-mobile-status-notification",
- "plist",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,7 @@ name = "agent-portal-mobile"
 version = "2.14.11"
 dependencies = [
  "agent-portal-mobile-status-notification",
+ "plist",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,12 +126,14 @@ name = "agent-portal-mobile"
 version = "2.14.11"
 dependencies = [
  "agent-portal-mobile-status-notification",
+ "plist",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "shared",
  "tauri",
  "tauri-build",
+ "tauri-plugin",
  "tauri-plugin-deep-link",
  "tauri-plugin-opener",
  "tauri-plugin-store",

--- a/docs/MOBILE_APPS_PLAN.md
+++ b/docs/MOBILE_APPS_PLAN.md
@@ -609,7 +609,7 @@ tab suppresses the same push.
 | ID | Deliverable | Files | Size | Depends on |
 |---|---|---|---|---|
 | F1 | Android CI lane: SDK/NDK setup, `tauri android build` on PRs touching `mobile/`, debug APK artifact | `.github/workflows/` | S–M | E1 |
-| F2 | iOS CI lanes: PR simulator build, plus manual signed device IPA export with optional TestFlight upload once Apple secrets are configured | `.github/workflows/` | M | E1, F3 |
+| F2 | iOS CI lanes: PR simulator build, plus manual signed device IPA export with optional TestFlight upload once Apple secrets are configured; custom XcodeGen template keeps `libapp.a` out of the `.app` bundle | `.github/workflows/`, `mobile/src-tauri/templates/ios/` | M | E1, F3 |
 | F3 | **Ops, not code**: Play Console + App Store Connect accounts, bundle IDs, keystore + fastlane match cert repo, APNs p8 key, FCM service account, GH secrets | — | S (elapsed days) | — |
 
 ### Track G / H — launch prerequisites

--- a/docs/MOBILE_APPS_PLAN.md
+++ b/docs/MOBILE_APPS_PLAN.md
@@ -609,7 +609,7 @@ tab suppresses the same push.
 | ID | Deliverable | Files | Size | Depends on |
 |---|---|---|---|---|
 | F1 | Android CI lane: SDK/NDK setup, `tauri android build` on PRs touching `mobile/`, debug APK artifact | `.github/workflows/` | S–M | E1 |
-| F2 | iOS CI lane: macOS runner, cert/profile injection, `tauri ios build`, TestFlight upload on dispatch/tag | `.github/workflows/` | M | E1, F3 |
+| F2 | iOS CI lanes: PR simulator build, plus manual signed device IPA export with optional TestFlight upload once Apple secrets are configured | `.github/workflows/` | M | E1, F3 |
 | F3 | **Ops, not code**: Play Console + App Store Connect accounts, bundle IDs, keystore + fastlane match cert repo, APNs p8 key, FCM service account, GH secrets | — | S (elapsed days) | — |
 
 ### Track G / H — launch prerequisites

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -220,9 +220,11 @@ The APNs registration bridge lives in [`ios/`](ios/) —
 Xcode project when wiring push (requires the Push Notifications entitlement
 and, in CI, the F2/F3 signing prerequisites).
 
-`mobile/src-tauri/build.rs` injects the `aps-environment` entitlement during
-iOS builds so it survives `gen/apple` regeneration. Local/debug builds default
-to `development`; the signed release workflow sets
+`mobile/src-tauri/build.rs` refreshes generated iOS entitlements during every
+iOS app build so they survive `gen/apple` regeneration and Cargo dependency
+build-script caching. It writes `aps-environment` and mirrors the configured
+deep-link app links into `com.apple.developer.associated-domains`.
+Local/debug builds default to `development`; the signed release workflow sets
 `PORTAL_IOS_APS_ENVIRONMENT=production`.
 
 ## Development
@@ -349,6 +351,10 @@ that `Externals` is not listed as a target source: `libapp.a` is still linked
 through the template's dependency entry, but it is not copied into
 `Agent Portal.app` as a resource. App Store Connect rejects bundles containing
 that standalone static library.
+
+Tauri resolves the template path relative to the command's current working
+directory, not relative to `tauri.conf.json`. The committed path expects the
+usual `mobile/` working directory used by npm scripts and CI.
 
 Before the first TestFlight upload, confirm in Apple Developer/App Store
 Connect that:

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -300,7 +300,8 @@ What the iOS lane does, in order:
 3. Runs `cargo check -p agent-portal-mobile --target <ios-simulator-triple>` as
    a fast-fail Rust/iOS gate.
 4. Runs `npx tauri ios init --ci` to generate `gen/apple`.
-5. Runs `npx tauri ios build --debug --target <simulator-target> --no-sign`.
+5. Clears `src-tauri/gen/apple/build` so reruns don't trip over a stale archive.
+6. Runs `npx tauri ios build --debug --target <simulator-target> --no-sign`.
 
 The iOS lane intentionally stops at an unsigned simulator build. Device
 installation, APNs entitlements, archive export, and TestFlight upload need the
@@ -340,6 +341,14 @@ Manual run inputs:
 - `upload_testflight`: when true, runs `xcrun altool --upload-app` after the
   signed IPA artifact is collected. Leave this off until the first signed IPA is
   known-good and the App Store Connect app record exists.
+
+The app uses a custom XcodeGen template at
+[`src-tauri/templates/ios/project.yml`](src-tauri/templates/ios/project.yml)
+rather than Tauri's built-in iOS template. The only intentional difference is
+that `Externals` is not listed as a target source: `libapp.a` is still linked
+through the template's dependency entry, but it is not copied into
+`Agent Portal.app` as a resource. App Store Connect rejects bundles containing
+that standalone static library.
 
 Before the first TestFlight upload, confirm in Apple Developer/App Store
 Connect that:

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -220,6 +220,11 @@ The APNs registration bridge lives in [`ios/`](ios/) —
 Xcode project when wiring push (requires the Push Notifications entitlement
 and, in CI, the F2/F3 signing prerequisites).
 
+`mobile/src-tauri/build.rs` injects the `aps-environment` entitlement during
+iOS builds so it survives `gen/apple` regeneration. Local/debug builds default
+to `development`; the signed release workflow sets
+`PORTAL_IOS_APS_ENVIRONMENT=production`.
+
 ## Development
 
 Start the backend first (see [Remote URL](#remote-url) — `*:dev` waits on
@@ -300,3 +305,53 @@ What the iOS lane does, in order:
 The iOS lane intentionally stops at an unsigned simulator build. Device
 installation, APNs entitlements, archive export, and TestFlight upload need the
 signing/cert/profile work from the release track before they can run in CI.
+
+## iOS release lane
+
+`.github/workflows/mobile-ios-release.yml` (job **Signed iOS IPA**) is a manual
+workflow for the signed device/App Store path. It does not run on PRs because it
+requires Apple credentials and provisioning. It builds `aarch64-apple-ios`,
+exports a signed IPA, and uploads that IPA as the
+`agent-portal-ios-signed-ipa` workflow artifact. When `upload_testflight` is
+enabled on the manual dispatch, it also uploads the IPA to App Store Connect for
+TestFlight processing.
+
+Required GitHub Actions secrets:
+
+| Secret | Purpose |
+|---|---|
+| `APPLE_API_KEY` | App Store Connect API key id, passed to Tauri/Xcode as `APPLE_API_KEY`. |
+| `APPLE_API_ISSUER` | App Store Connect issuer id, passed as `APPLE_API_ISSUER`. |
+| `APPLE_API_KEY_P8` | Raw `.p8` App Store Connect API key contents; CI writes it to `APPLE_API_KEY_PATH`. |
+| `APPLE_DEVELOPMENT_TEAM` | Apple Developer Team ID for generated Xcode signing settings. |
+| `IOS_CERTIFICATE` | Base64 distribution signing certificate consumed by Tauri's iOS signing support. |
+| `IOS_CERTIFICATE_PASSWORD` | Password for `IOS_CERTIFICATE`. |
+| `IOS_MOBILE_PROVISION` | Base64 mobile provisioning profile for `io.txcl.agentportal`. |
+
+Manual run inputs:
+
+- `export_method`: `app-store-connect` for App Store/TestFlight export,
+  `release-testing` for ad-hoc distribution, or `debugging` for development
+  signing.
+- `shell_url`: portal origin baked into the shell via `PORTAL_SHELL_URL`
+  (defaults to `https://txcl.io`).
+- `build_number`: optional `CFBundleVersion` suffix; when blank, CI uses the
+  workflow run number.
+- `upload_testflight`: when true, runs `xcrun altool --upload-app` after the
+  signed IPA artifact is collected. Leave this off until the first signed IPA is
+  known-good and the App Store Connect app record exists.
+
+Before the first TestFlight upload, confirm in Apple Developer/App Store
+Connect that:
+
+1. Bundle ID `io.txcl.agentportal` exists.
+2. The provisioning profile includes the Push Notifications and Associated
+   Domains capabilities used by the mobile shell.
+3. App Store Connect has an app record for the bundle ID.
+4. Backend env is set for link verification and APNs delivery:
+   `PORTAL_MOBILE_APPLE_TEAM_ID`, `PORTAL_MOBILE_BUNDLE_ID`,
+   `PORTAL_APNS_KEY_P8_PATH`, `PORTAL_APNS_KEY_ID`, `PORTAL_APNS_TEAM_ID`, and
+   `PORTAL_APNS_BUNDLE_ID`.
+
+The APNs Swift bridge still has to be added to the generated Xcode project and
+connected to the shell's mobile JWT before iOS push registration is live.

--- a/mobile/src-tauri/Cargo.toml
+++ b/mobile/src-tauri/Cargo.toml
@@ -9,6 +9,7 @@ name = "agent_portal_mobile_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
+plist = "1"
 serde = { workspace = true, features = ["derive"] }
 tauri-build = { version = "2", features = [] }
 tauri-plugin = { version = "2.5", features = ["build"] }

--- a/mobile/src-tauri/Cargo.toml
+++ b/mobile/src-tauri/Cargo.toml
@@ -9,11 +9,9 @@ name = "agent_portal_mobile_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
+serde = { workspace = true, features = ["derive"] }
 tauri-build = { version = "2", features = [] }
 tauri-plugin = { version = "2.5", features = ["build"] }
-
-[target.'cfg(target_os = "macos")'.build-dependencies]
-plist = "1"
 
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/mobile/src-tauri/Cargo.toml
+++ b/mobile/src-tauri/Cargo.toml
@@ -10,6 +10,10 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
+tauri-plugin = { version = "2.5", features = ["build"] }
+
+[target.'cfg(target_os = "macos")'.build-dependencies]
+plist = "1"
 
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/mobile/src-tauri/build.rs
+++ b/mobile/src-tauri/build.rs
@@ -46,14 +46,18 @@ fn configure_ios_entitlements() {
 }
 
 #[cfg(target_os = "macos")]
-fn ios_associated_domains() -> Vec<String> {
+fn ios_associated_domains() -> Vec<plist::Value> {
     tauri_plugin::plugin_config::<DeepLinkConfig>("deep-link")
         .map(|config| {
             config
                 .mobile
                 .into_iter()
                 .filter(|domain| domain.is_app_link())
-                .filter_map(|domain| domain.host.map(|host| format!("applinks:{host}")))
+                .filter_map(|domain| {
+                    domain
+                        .host
+                        .map(|host| plist::Value::from(format!("applinks:{host}")))
+                })
                 .collect()
         })
         .unwrap_or_default()

--- a/mobile/src-tauri/build.rs
+++ b/mobile/src-tauri/build.rs
@@ -1,11 +1,35 @@
 fn main() {
     println!("cargo:rerun-if-env-changed=PORTAL_SHELL_URL");
+    println!("cargo:rerun-if-env-changed=PORTAL_IOS_APS_ENVIRONMENT");
     if let Ok(shell_url) = std::env::var("PORTAL_SHELL_URL") {
         println!("cargo:rustc-env=PORTAL_SHELL_URL={shell_url}");
     }
 
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    if target_os == "ios" {
+        configure_ios_entitlements();
+    }
     if matches!(target_os.as_str(), "android" | "ios") {
         tauri_build::build();
     }
 }
+
+#[cfg(target_os = "macos")]
+fn configure_ios_entitlements() {
+    let aps_environment =
+        std::env::var("PORTAL_IOS_APS_ENVIRONMENT").unwrap_or_else(|_| "development".to_string());
+    let aps_environment = match aps_environment.as_str() {
+        "development" | "production" => aps_environment,
+        other => panic!(
+            "PORTAL_IOS_APS_ENVIRONMENT must be \"development\" or \"production\", got {other:?}"
+        ),
+    };
+
+    tauri_plugin::mobile::update_entitlements(|entitlements| {
+        entitlements.insert("aps-environment".into(), aps_environment.into());
+    })
+    .expect("failed to update iOS APNs entitlement");
+}
+
+#[cfg(not(target_os = "macos"))]
+fn configure_ios_entitlements() {}

--- a/mobile/src-tauri/build.rs
+++ b/mobile/src-tauri/build.rs
@@ -1,6 +1,7 @@
 fn main() {
     println!("cargo:rerun-if-env-changed=PORTAL_SHELL_URL");
     println!("cargo:rerun-if-env-changed=PORTAL_IOS_APS_ENVIRONMENT");
+    println!("cargo:rerun-if-env-changed=TAURI_DEEP_LINK_PLUGIN_CONFIG");
     if let Ok(shell_url) = std::env::var("PORTAL_SHELL_URL") {
         println!("cargo:rustc-env=PORTAL_SHELL_URL={shell_url}");
     }
@@ -24,11 +25,74 @@ fn configure_ios_entitlements() {
             "PORTAL_IOS_APS_ENVIRONMENT must be \"development\" or \"production\", got {other:?}"
         ),
     };
+    let associated_domains = ios_associated_domains();
 
+    // The deep-link plugin normally writes associated-domains from its own
+    // build script, but Cargo can cache dependency build scripts across a
+    // regenerated Xcode project. Own both mobile entitlement keys here so every
+    // iOS app build deterministically refreshes the generated plist.
     tauri_plugin::mobile::update_entitlements(|entitlements| {
         entitlements.insert("aps-environment".into(), aps_environment.into());
+        if associated_domains.is_empty() {
+            entitlements.remove("com.apple.developer.associated-domains");
+        } else {
+            entitlements.insert(
+                "com.apple.developer.associated-domains".into(),
+                associated_domains.into(),
+            );
+        }
     })
-    .expect("failed to update iOS APNs entitlement");
+    .expect("failed to update iOS entitlements");
+}
+
+#[cfg(target_os = "macos")]
+fn ios_associated_domains() -> Vec<String> {
+    tauri_plugin::plugin_config::<DeepLinkConfig>("deep-link")
+        .map(|config| {
+            config
+                .mobile
+                .into_iter()
+                .filter(|domain| domain.is_app_link())
+                .filter_map(|domain| domain.host.map(|host| format!("applinks:{host}")))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(target_os = "macos")]
+#[derive(serde::Deserialize)]
+struct DeepLinkConfig {
+    #[serde(default)]
+    mobile: Vec<AssociatedDomain>,
+}
+
+#[cfg(target_os = "macos")]
+#[derive(serde::Deserialize)]
+struct AssociatedDomain {
+    #[serde(default = "default_schemes")]
+    scheme: Vec<String>,
+    host: Option<String>,
+    #[serde(default, rename = "appLink", alias = "app-link")]
+    app_link: Option<bool>,
+}
+
+#[cfg(target_os = "macos")]
+impl AssociatedDomain {
+    fn is_app_link(&self) -> bool {
+        self.app_link
+            .unwrap_or_else(|| self.is_web_link() && self.host.is_some())
+    }
+
+    fn is_web_link(&self) -> bool {
+        self.scheme
+            .iter()
+            .any(|scheme| scheme == "https" || scheme == "http")
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn default_schemes() -> Vec<String> {
+    vec!["https".to_string(), "http".to_string()]
 }
 
 #[cfg(not(target_os = "macos"))]

--- a/mobile/src-tauri/tauri.conf.json
+++ b/mobile/src-tauri/tauri.conf.json
@@ -39,6 +39,9 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all"
+    "targets": "all",
+    "iOS": {
+      "template": "templates/ios/project.yml"
+    }
   }
 }

--- a/mobile/src-tauri/tauri.conf.json
+++ b/mobile/src-tauri/tauri.conf.json
@@ -41,7 +41,7 @@
     "active": true,
     "targets": "all",
     "iOS": {
-      "template": "templates/ios/project.yml"
+      "template": "src-tauri/templates/ios/project.yml"
     }
   }
 }

--- a/mobile/src-tauri/templates/ios/project.yml
+++ b/mobile/src-tauri/templates/ios/project.yml
@@ -1,0 +1,171 @@
+name: {{app.name}}
+options:
+  bundleIdPrefix: {{app.identifier}}
+  deploymentTarget:
+    iOS: {{apple.ios-version}}
+fileGroups: [{{join file-groups}}]
+configs:
+  debug: debug
+  release: release
+settingGroups:
+  app:
+    base:
+      PRODUCT_NAME: {{app.stylized-name}}
+      PRODUCT_BUNDLE_IDENTIFIER: {{app.identifier}}
+      {{#if apple.development-team}}
+      DEVELOPMENT_TEAM: {{apple.development-team}}
+      {{/if}}
+targetTemplates:
+  app:
+    type: application
+    sources:
+      - path: Sources
+    scheme:
+      environmentVariables:
+        RUST_BACKTRACE: full
+        RUST_LOG: info
+    settings:
+      groups: [app]
+targets:
+  {{app.name}}_iOS:
+    type: application
+    platform: iOS
+    sources:
+      - path: Sources
+      - path: Assets.xcassets
+      # Keep Externals out of target sources. Tauri still links libapp.a via the
+      # dependency below; listing Externals here makes Xcode copy libapp.a into
+      # the .app bundle as a resource, which App Store Connect rejects.
+      - path: {{app.name}}_iOS
+      - path: {{app.asset-dir}}
+        buildPhase: resources
+        type: folder
+      {{~#each asset-catalogs}}
+      - {{prefix-path this}}{{/each}}
+      {{~#each ios-additional-targets}}
+      - path: {{prefix-path this}}{{/each}}
+      - path: LaunchScreen.storyboard
+    info:
+      path: {{app.name}}_iOS/Info.plist
+      properties:
+        LSRequiresIPhoneOS: true
+        UILaunchStoryboardName: LaunchScreen
+        UIRequiredDeviceCapabilities: [arm64, metal]
+        UISupportedInterfaceOrientations:
+          - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationLandscapeLeft
+          - UIInterfaceOrientationLandscapeRight
+        UISupportedInterfaceOrientations~ipad:
+          - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationPortraitUpsideDown
+          - UIInterfaceOrientationLandscapeLeft
+          - UIInterfaceOrientationLandscapeRight
+        CFBundleShortVersionString: {{apple.bundle-version-short}}
+        CFBundleVersion: "{{apple.bundle-version}}"
+        {{~#each apple.plist-pairs}}
+        {{this.key}}: {{this.value}}{{/each}}
+    entitlements:
+      path: {{app.name}}_iOS/{{app.name}}_iOS.entitlements
+    scheme:
+      environmentVariables:
+        RUST_BACKTRACE: full
+        RUST_LOG: info
+      {{~#if ios-command-line-arguments}}
+      commandLineArguments:
+      {{~#each ios-command-line-arguments}}
+        "{{this}}": true
+      {{/each}}{{~/if}}
+    settings:
+      base:
+        ENABLE_BITCODE: false
+        ARCHS: [{{join ios-valid-archs}}]
+        VALID_ARCHS: {{~#each ios-valid-archs}} {{this}} {{/each}}
+        LIBRARY_SEARCH_PATHS[arch=x86_64]: $(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)
+        LIBRARY_SEARCH_PATHS[arch=arm64]: $(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)
+        ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES: true
+        EXCLUDED_ARCHS[sdk=iphoneos*]: x86_64
+      groups: [app]
+    dependencies:
+      - framework: {{ lib-output-file-name }}
+        embed: false
+      {{~#each ios-libraries}}
+      - framework: {{this}}
+        embed: false{{/each}}{{#if ios-vendor-frameworks}}{{~#each ios-vendor-frameworks}}
+      - framework: {{this}}{{/each}}{{/if}}{{#if ios-vendor-sdks}}{{~#each ios-vendor-sdks}}
+      - sdk: {{prefix-path this}}{{/each}}{{/if}}
+      - sdk: CoreGraphics.framework
+      - sdk: Metal.framework
+      - sdk: MetalKit.framework
+      - sdk: QuartzCore.framework
+      - sdk: Security.framework
+      - sdk: UIKit.framework{{#if this.ios-frameworks}}{{~#each ios-frameworks}}
+      - sdk: {{this}}.framework{{/each}}{{/if}}
+      - sdk: WebKit.framework
+    preBuildScripts:
+      {{~#each ios-pre-build-scripts}}{{#if this.path}}
+      - path {{this.path}}{{/if}}{{#if this.script}}
+      - script: {{this.script}}{{/if}}{{#if this.name}}
+        name: {{this.name}}{{/if}}{{#if this.input-files}}
+        inputFiles: {{~#each this.input-files}}
+          - {{this}}{{/each}}{{/if}}{{#if this.output-files}}
+        outputFiles: {{~#each this.output-files}}
+          - {{this}}{{/each}}{{/if}}{{#if this.input-file-lists}}
+        inputFileLists: {{~#each this.output-files}}
+          - {{this}}{{/each}}{{/if}}{{#if this.output-file-lists}}
+        outputFileLists: {{~#each this.output-files}}
+          - {{this}}{{/each}}{{/if}}{{#if this.shell}}
+        shell: {{this.shell}}{{/if}}{{#if this.show-env-vars}}
+        showEnvVars: {{this.show_env_vars}}{{/if}}{{#if this.run-only-when-installing}}
+        runOnlyWhenInstalling: {{this.run-only-when-installing}}{{/if}}{{#if this.based-on-dependency-analysis}}
+        basedOnDependencyAnalysis: {{this.based-on-dependency-analysis}}{{/if}}{{#if this.discovered-dependency-file}}
+        discoveredDependencyFile: {{this.discovered-dependency-file}}{{/if}}
+      {{~/each}}
+
+      - script: {{ tauri-binary }} {{ tauri-binary-args-str }} -v --platform ${PLATFORM_DISPLAY_NAME:?} --sdk-root ${SDKROOT:?} --framework-search-paths "${FRAMEWORK_SEARCH_PATHS:?}" --header-search-paths "${HEADER_SEARCH_PATHS:?}" --gcc-preprocessor-definitions "${GCC_PREPROCESSOR_DEFINITIONS:-}" --configuration ${CONFIGURATION:?} ${FORCE_COLOR} ${ARCHS:?}
+        name: Build Rust Code
+        basedOnDependencyAnalysis: false
+        outputFiles:
+          - $(SRCROOT)/Externals/x86_64/${CONFIGURATION}/{{ lib-output-file-name }}
+          - $(SRCROOT)/Externals/arm64/${CONFIGURATION}/{{ lib-output-file-name }}
+    {{~#if ios-post-compile-scripts}}
+    postCompileScripts:
+      {{~#each ios-post-compile-scripts}}{{#if this.path}}
+      - path {{this.path}}{{/if}}{{#if this.script}}
+      - script: {{this.script}}{{/if}}{{#if this.name}}
+        name: {{this.name}}{{/if}}{{#if this.input-files}}
+        inputFiles: {{~#each this.input-files}}
+          - {{this}}{{/each}}{{/if}}{{#if this.output-files}}
+        outputFiles: {{~#each this.output-files}}
+          - {{this}}{{/each}}{{/if}}{{#if this.input-file-lists}}
+        inputFileLists: {{~#each this.output-files}}
+          - {{this}}{{/each}}{{/if}}{{#if this.output-file-lists}}
+        outputFileLists: {{~#each this.output-files}}
+          - {{this}}{{/each}}{{/if}}{{#if this.shell}}
+        shell: {{this.shell}}{{/if}}{{#if this.show-env-vars}}
+        showEnvVars: {{this.show_env_vars}}{{/if}}{{#if this.run-only-when-installing}}
+        runOnlyWhenInstalling: {{this.run-only-when-installing}}{{/if}}{{#if this.based-on-dependency-analysis}}
+        basedOnDependencyAnalysis: {{this.based-on-dependency-analysis}}{{/if}}{{#if this.discovered-dependency-file}}
+        discoveredDependencyFile: {{this.discovered-dependency-file}}{{/if}}
+      {{~/each~}}
+    {{~/if~}}
+    {{~#if ios-post-build-scripts}}
+    postBuildScripts:
+      {{~#each ios-post-build-scripts}}{{#if this.path}}
+      - path {{this.path}}{{/if}}{{#if this.script}}
+      - script: {{this.script}}{{/if}}{{#if this.name}}
+        name: {{this.name}}{{/if}}{{#if this.input-files}}
+        inputFiles: {{~#each this.input-files}}
+          - {{this}}{{/each}}{{/if}}{{#if this.output-files}}
+        outputFiles: {{~#each this.output-files}}
+          - {{this}}{{/each}}{{/if}}{{#if this.input-file-lists}}
+        inputFileLists: {{~#each this.output-files}}
+          - {{this}}{{/each}}{{/if}}{{#if this.output-file-lists}}
+        outputFileLists: {{~#each this.output-files}}
+          - {{this}}{{/each}}{{/if}}{{#if this.shell}}
+        shell: {{this.shell}}{{/if}}{{#if this.show-env-vars}}
+        showEnvVars: {{this.show_env_vars}}{{/if}}{{#if this.run-only-when-installing}}
+        runOnlyWhenInstalling: {{this.run-only-when-installing}}{{/if}}{{#if this.based-on-dependency-analysis}}
+        basedOnDependencyAnalysis: {{this.based-on-dependency-analysis}}{{/if}}{{#if this.discovered-dependency-file}}
+        discoveredDependencyFile: {{this.discovered-dependency-file}}{{/if}}
+      {{~/each~}}
+    {{~/if}}


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/8ab1baa1c8fcb7c88c9263bb13d65244f2542231/.0-pr-viz/001969.svg)

## Summary
- Add a manual signed iOS IPA workflow with Apple signing secret validation, monotonic build-number input/defaulting, IPA artifact upload, and optional TestFlight upload.
- Inject deterministic iOS entitlements from `mobile/src-tauri/build.rs`: `aps-environment` plus `com.apple.developer.associated-domains` mirrored from the deep-link config.
- Vendor a Tauri iOS XcodeGen template that keeps `Externals` out of target sources so `libapp.a` is linked but not copied into `Agent Portal.app`.
- Clean stale generated iOS archive output before simulator/release builds, verify generated entitlements in CI, place the App Store Connect key where `altool` expects it, and document the iOS release lane prerequisites.

## Mac verification from companion session
- `npm ci` passed.
- `npx tauri ios init --ci` passed after correcting the CWD-relative template path.
- Unsigned simulator build passed on macOS/Xcode.
- `cargo check -p agent-portal-mobile --target aarch64-apple-ios-sim` passed.
- Confirmed the custom template removes bundled `libapp.a` from `Agent Portal.app` while preserving linking.
- Confirmed no Apple Developer team/signing identities/profiles are installed on that Mac, so signed TestFlight/device export remains blocked on F3 Apple ops/secrets rather than repo code.

## Local verification
- `cargo fmt --check`
- `cargo check -p agent-portal-mobile`
- JSON/YAML parse check for `mobile/src-tauri/tauri.conf.json`, `.github/workflows/mobile-ios.yml`, and `.github/workflows/mobile-ios-release.yml`
- Visual PR SVG validation with `.github/visual-pr/style.json`

