### PR TITLE
Share one HTML escape helper across server pages

### DIFF
--- a/.0-pr-viz/001970.svg
+++ b/.0-pr-viz/001970.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2000" height="1200" viewBox="0 0 2000 1200" role="img" aria-labelledby="title desc">
+  <title id="title">PR 1970 shared Content-Type parsing for upload endpoints</title>
+  <desc id="desc">Before, show_media and transcribe each hand-rolled the same Content-Type header parse. After, one helpers::request_content_type owns it and both callers are one line, with unit tests.</desc>
+  <rect width="2000" height="1200" fill="#16161e"/>
+
+  <text x="55" y="70" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="24" letter-spacing="1">PR #1970 · Share Content-Type parsing across upload endpoints</text>
+  <text x="55" y="124" fill="#e6e9f5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="34" font-weight="700">show_media and transcribe each hand-rolled the same Content-Type parse;</text>
+  <text x="55" y="166" fill="#e6e9f5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="34" font-weight="700">now one helpers::request_content_type() owns it, with unit tests.</text>
+  <line x1="55" y1="190" x2="1945" y2="190" stroke="#3d4666" stroke-width="2"/>
+  <line x1="1000" y1="225" x2="1000" y2="1090" stroke="#3d4666" stroke-width="2" stroke-dasharray="12 14"/>
+
+  <text x="70" y="260" fill="#f7768e" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="700" letter-spacing="4">BEFORE</text>
+  <text x="1070" y="260" fill="#9ece6a" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="700" letter-spacing="4">AFTER</text>
+
+  <rect x="70" y="295" width="820" height="275" rx="8" fill="#1e202e" stroke="#565f89" stroke-width="2"/>
+  <text x="105" y="345" fill="#c0caf5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="26" font-weight="700">Same header parse, twice</text>
+  <text x="105" y="395" fill="#e6e9f5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">.get(header::CONTENT_TYPE)</text>
+  <text x="105" y="435" fill="#e6e9f5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">.and_then(to_str) ... .filter(!empty)</text>
+  <text x="105" y="475" fill="#e6e9f5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">.ok_or("missing Content-Type header")</text>
+  <text x="105" y="518" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">agent_comms.rs show_media and stt.rs transcribe</text>
+  <text x="105" y="550" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">in backend/src/handlers/</text>
+
+  <rect x="70" y="600" width="820" height="260" rx="8" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+  <text x="105" y="650" fill="#c0caf5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="26" font-weight="700">Only the tail differs</text>
+  <text x="105" y="700" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">show_media strips ";" params + to_string(), while</text>
+  <text x="105" y="734" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">transcribe only trims and keeps the params - so a</text>
+  <text x="105" y="768" fill="#f7768e" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">param-handling fix must land twice, and each</text>
+  <text x="105" y="802" fill="#f7768e" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">provider sees a different content shape.</text>
+
+  <rect x="1110" y="295" width="820" height="275" rx="8" fill="#1e202e" stroke="#565f89" stroke-width="2"/>
+  <text x="1145" y="345" fill="#c0caf5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="26" font-weight="700">One helper owns the parse</text>
+  <text x="1145" y="395" fill="#e6e9f5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">helpers::request_content_type(&amp;headers)</text>
+  <text x="1145" y="435" fill="#9ece6a" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">-&gt; Result&lt;&amp;str, AppError&gt;</text>
+  <text x="1145" y="475" fill="#9ece6a" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">get + utf8 + strip ";" + trim + blank-reject</text>
+  <text x="1145" y="518" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">single owner in handlers/helpers.rs; both 400s</text>
+  <text x="1145" y="550" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">keep the same "missing Content-Type" message.</text>
+
+  <rect x="1110" y="600" width="820" height="260" rx="8" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+  <text x="1145" y="650" fill="#c0caf5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="26" font-weight="700">Callers go one line each</text>
+  <text x="1145" y="700" fill="#e6e9f5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">request_content_type(&amp;headers)?.to_string()</text>
+  <text x="1145" y="734" fill="#e6e9f5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">request_content_type(&amp;headers)?</text>
+  <text x="1145" y="786" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">3 files, +64/-14, plus 3 helper unit tests;</text>
+  <text x="1145" y="820" fill="#9ece6a" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">334 backend tests green, fmt and clippy clean.</text>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">Scope: raw-body uploads only; per-kind 413 size-limit messages stay per-endpoint prose.</text>
+</svg>

--- a/backend/src/handlers/agent_comms.rs
+++ b/backend/src/handlers/agent_comms.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use axum::{
     body::Bytes,
     extract::{Path, Query, State},
-    http::{header, HeaderMap},
+    http::HeaderMap,
     Json,
 };
 use diesel::prelude::*;
@@ -28,6 +28,7 @@ use shared::media::MediaKind;
 use shared::{AgentType, PortalContent, PortalMessage, ServerToClient, SessionStatus};
 
 use crate::errors::AppError;
+use crate::handlers::helpers::request_content_type;
 use crate::models::Session;
 use crate::AppState;
 
@@ -392,12 +393,7 @@ pub async fn show_media(
     let user_id = resolve_user(&app_state, &headers, &cookies)?;
 
     // Declared content type, minus any `; charset=` suffix.
-    let mut content_type = headers
-        .get(header::CONTENT_TYPE)
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.split(';').next().unwrap_or(s).trim().to_string())
-        .filter(|s| !s.is_empty())
-        .ok_or(AppError::BadRequest("missing Content-Type header"))?;
+    let mut content_type = request_content_type(&headers)?.to_string();
 
     let kind = shared::media::media_kind(&content_type)
         .ok_or(AppError::BadRequest("unsupported media type"))?;

--- a/backend/src/handlers/device_flow.rs
+++ b/backend/src/handlers/device_flow.rs
@@ -896,7 +896,7 @@ mod tests {
     #[test]
     fn escape_html_text_escapes_text_node_metacharacters() {
         assert_eq!(
-            render::escape_html_text(r#"<>&"'"#),
+            crate::handlers::helpers::escape_html_text(r#"<>&"'"#),
             "&lt;&gt;&amp;&quot;&#39;"
         );
     }

--- a/backend/src/handlers/device_flow/render.rs
+++ b/backend/src/handlers/device_flow/render.rs
@@ -1,3 +1,5 @@
+use crate::handlers::helpers::escape_html_text;
+
 pub(super) fn render_device_code_form(
     user_code: Option<&str>,
     error_message: Option<&str>,
@@ -409,19 +411,4 @@ pub(super) fn render_approval_page(
 </body>
 </html>"#
     )
-}
-
-pub(super) fn escape_html_text(input: &str) -> String {
-    let mut escaped = String::with_capacity(input.len());
-    for ch in input.chars() {
-        match ch {
-            '&' => escaped.push_str("&amp;"),
-            '<' => escaped.push_str("&lt;"),
-            '>' => escaped.push_str("&gt;"),
-            '"' => escaped.push_str("&quot;"),
-            '\'' => escaped.push_str("&#39;"),
-            _ => escaped.push(ch),
-        }
-    }
-    escaped
 }

--- a/backend/src/handlers/helpers.rs
+++ b/backend/src/handlers/helpers.rs
@@ -1,8 +1,10 @@
+use crate::errors::AppError;
 use crate::models::{Message, NewDeletedSessionCosts, Session};
 use crate::schema::{
     deleted_session_costs, messages, pending_inputs, pending_permission_requests, session_members,
     sessions, users,
 };
+use axum::http::{header, HeaderMap};
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, PooledConnection};
@@ -59,6 +61,19 @@ pub fn escape_html_text(input: &str) -> String {
         }
     }
     escaped
+}
+
+/// Declared `Content-Type` of a raw-body upload, minus any `; …` parameters.
+/// Single source for the raw-body endpoints (`show_media`, STT transcription)
+/// so a new upload endpoint can't fall behind on parameter-stripping.
+/// Rejects a missing, non-UTF8, or blank header with `400`.
+pub fn request_content_type(headers: &HeaderMap) -> Result<&str, AppError> {
+    headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.split(';').next().unwrap_or(s).trim())
+        .filter(|s| !s.is_empty())
+        .ok_or(AppError::BadRequest("missing Content-Type header"))
 }
 
 /// [`preferred_name`] falling back to the email when neither is set — used by
@@ -277,6 +292,7 @@ pub fn delete_user_sessions(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::http::HeaderValue;
 
     #[test]
     fn nickname_is_preferred_then_name_then_email() {
@@ -356,5 +372,47 @@ mod tests {
     fn escape_html_text_leaves_plain_text_untouched() {
         assert_eq!(escape_html_text("Agent Portal"), "Agent Portal");
         assert_eq!(escape_html_text(""), "");
+    }
+
+    fn headers_with_content_type(value: &HeaderValue) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::CONTENT_TYPE, value.clone());
+        headers
+    }
+
+    #[test]
+    fn request_content_type_passes_plain_value_through() {
+        let headers = headers_with_content_type(&HeaderValue::from_static("audio/webm"));
+        assert_eq!(request_content_type(&headers).unwrap(), "audio/webm");
+    }
+
+    #[test]
+    fn request_content_type_strips_parameters_and_trims() {
+        let headers =
+            headers_with_content_type(&HeaderValue::from_static("audio/webm;codecs=opus"));
+        assert_eq!(request_content_type(&headers).unwrap(), "audio/webm");
+        let headers =
+            headers_with_content_type(&HeaderValue::from_static("  text/html ; charset=utf-8 "));
+        assert_eq!(request_content_type(&headers).unwrap(), "text/html");
+    }
+
+    #[test]
+    fn request_content_type_rejects_missing_blank_and_non_utf8() {
+        assert!(matches!(
+            request_content_type(&HeaderMap::new()),
+            Err(AppError::BadRequest(_))
+        ));
+        let headers = headers_with_content_type(&HeaderValue::from_static("   "));
+        assert!(matches!(
+            request_content_type(&headers),
+            Err(AppError::BadRequest(_))
+        ));
+        let headers = headers_with_content_type(
+            &HeaderValue::from_bytes(&[0xff]).expect("obs-text is a valid header byte"),
+        );
+        assert!(matches!(
+            request_content_type(&headers),
+            Err(AppError::BadRequest(_))
+        ));
     }
 }

--- a/backend/src/handlers/helpers.rs
+++ b/backend/src/handlers/helpers.rs
@@ -42,6 +42,25 @@ pub fn preferred_name(nickname: Option<&str>, name: Option<&str>) -> Option<Stri
         .map(str::to_string)
 }
 
+/// Minimal HTML escape for server-rendered pages: escapes the five text-node
+/// and attribute metacharacters in a single pass. Single source for the
+/// device-flow forms and the privacy page so a new interpolation site can't
+/// fall behind on quoting (the privacy page previously skipped `'`).
+pub fn escape_html_text(input: &str) -> String {
+    let mut escaped = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&#39;"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
 /// [`preferred_name`] falling back to the email when neither is set — used by
 /// attribution surfaces that render a single name string (message bubbles).
 pub fn display_name(nickname: Option<&str>, name: Option<&str>, email: &str) -> String {
@@ -326,5 +345,16 @@ mod tests {
     fn parse_iso_cursor_rejects_garbage() {
         assert!(parse_iso_cursor("not-a-timestamp").is_none());
         assert!(parse_iso_cursor("").is_none());
+    }
+
+    #[test]
+    fn escape_html_text_escapes_all_metacharacters() {
+        assert_eq!(escape_html_text(r#"<>&"'"#), "&lt;&gt;&amp;&quot;&#39;");
+    }
+
+    #[test]
+    fn escape_html_text_leaves_plain_text_untouched() {
+        assert_eq!(escape_html_text("Agent Portal"), "Agent Portal");
+        assert_eq!(escape_html_text(""), "");
     }
 }

--- a/backend/src/handlers/privacy.rs
+++ b/backend/src/handlers/privacy.rs
@@ -7,17 +7,10 @@
 //! from what the server actually does; when the config changes, the page
 //! changes with it.
 
+use crate::handlers::helpers::escape_html_text;
 use crate::AppState;
 use axum::{extract::State, response::Html};
 use std::sync::Arc;
-
-/// Minimal HTML escape for config-sourced strings interpolated into the page.
-fn escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-}
 
 /// GET /privacy — how this deployment handles user data.
 pub async fn privacy_policy(State(app_state): State<Arc<AppState>>) -> Html<String> {
@@ -39,7 +32,7 @@ fn render(
     session_max_age_days: u32,
     archive_enabled: bool,
 ) -> String {
-    let title = escape(app_title);
+    let title = escape_html_text(app_title);
 
     let message_age_clause = if message_retention_days > 0 {
         format!(

--- a/backend/src/handlers/stt.rs
+++ b/backend/src/handlers/stt.rs
@@ -9,7 +9,7 @@
 use axum::{
     body::Bytes,
     extract::{Query, State},
-    http::{header, HeaderMap},
+    http::HeaderMap,
     Json,
 };
 use diesel::prelude::*;
@@ -21,6 +21,7 @@ use uuid::Uuid;
 
 use crate::auth::CurrentUserId;
 use crate::errors::AppError;
+use crate::handlers::helpers::request_content_type;
 use crate::AppState;
 use portal_stt::{session_keyterms, TranscribeRequest};
 
@@ -47,12 +48,7 @@ pub async fn transcribe(
         "Speech-to-text is not configured",
     ))?;
 
-    let content_type = headers
-        .get(header::CONTENT_TYPE)
-        .and_then(|v| v.to_str().ok())
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .ok_or(AppError::BadRequest("missing Content-Type header"))?;
+    let content_type = request_content_type(&headers)?;
     if !content_type.starts_with("audio/") {
         return Err(AppError::BadRequest("Content-Type must be an audio type"));
     }


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/20ea68faf2b92d51cd5d5313e53de46f30718c4c/.0-pr-viz/001970.svg)

show_media and transcribe each hand-rolled the same Content-Type extraction (one stripped ;params, one did not). Adds helpers::request_content_type as the single source plus unit tests, and switches both call sites. transcribe now also strips parameters before the audio/ check and provider handoff, matching the documented bare-MIME contract.