### PR TITLE
Share trimmed-non-blank helper for optional inputs

### DIFF
--- a/.0-pr-viz/001971.svg
+++ b/.0-pr-viz/001971.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2000" height="1200" viewBox="0 0 2000 1200" role="img" aria-labelledby="title desc">
+  <title id="title">PR 1971 shared trimmed-non-blank helper for optional inputs</title>
+  <desc id="desc">Before, four call sites each hand-rolled the same trim-and-reject-blank chain on optional inputs. After, one shared::strings::trimmed_non_blank owns it and the callers shrink to one line.</desc>
+  <rect width="2000" height="1200" fill="#16161e"/>
+
+  <text x="55" y="70" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="24" letter-spacing="1">PR #1971 · Share trimmed-non-blank helper for optional inputs</text>
+  <text x="55" y="124" fill="#e6e9f5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="34" font-weight="700">Four call sites hand-rolled the same trim-and-reject-blank chain;</text>
+  <text x="55" y="166" fill="#e6e9f5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="34" font-weight="700">now shared::strings::trimmed_non_blank() owns it, still borrowed.</text>
+  <line x1="55" y1="190" x2="1945" y2="190" stroke="#3d4666" stroke-width="2"/>
+  <line x1="1000" y1="225" x2="1000" y2="1090" stroke="#3d4666" stroke-width="2" stroke-dasharray="12 14"/>
+
+  <text x="70" y="260" fill="#f7768e" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="700" letter-spacing="4">BEFORE</text>
+  <text x="1070" y="260" fill="#9ece6a" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="700" letter-spacing="4">AFTER</text>
+
+  <rect x="70" y="295" width="820" height="275" rx="8" fill="#1e202e" stroke="#565f89" stroke-width="2"/>
+  <text x="105" y="345" fill="#c0caf5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="26" font-weight="700">Same chain, four times</text>
+  <text x="105" y="395" fill="#e6e9f5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">.map(str::trim)</text>
+  <text x="105" y="435" fill="#e6e9f5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">.filter(|s| !s.is_empty())</text>
+  <text x="105" y="475" fill="#e6e9f5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">.map(str::to_string) / .unwrap_or(...)</text>
+  <text x="105" y="518" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">profile nickname, show_media filename,</text>
+  <text x="105" y="550" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">normalize_custom_name, fork direction</text>
+
+  <rect x="70" y="600" width="820" height="260" rx="8" fill="#1e202e" stroke="#f7768e" stroke-width="2"/>
+  <text x="105" y="650" fill="#c0caf5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="26" font-weight="700">Only the tail differs</text>
+  <text x="105" y="700" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">three sites map to owned String, one falls back</text>
+  <text x="105" y="734" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">to a default - yet the trim/filter pair above</text>
+  <text x="105" y="768" fill="#f7768e" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">is copied each time: a whitespace-rule fix</text>
+  <text x="105" y="802" fill="#f7768e" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">must land in four places at once.</text>
+
+  <rect x="1110" y="295" width="820" height="275" rx="8" fill="#1e202e" stroke="#565f89" stroke-width="2"/>
+  <text x="1145" y="345" fill="#c0caf5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="26" font-weight="700">One helper owns the chain</text>
+  <text x="1145" y="395" fill="#e6e9f5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">strings::trimmed_non_blank(value)</text>
+  <text x="1145" y="435" fill="#9ece6a" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">-&gt; Option&lt;&amp;str&gt;</text>
+  <text x="1145" y="475" fill="#9ece6a" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">trim + reject blank, still borrowed</text>
+  <text x="1145" y="518" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">std-only in shared/strings.rs, next to</text>
+  <text x="1145" y="550" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">is_non_blank; ships its own unit test.</text>
+
+  <rect x="1110" y="600" width="820" height="260" rx="8" fill="#1e202e" stroke="#9ece6a" stroke-width="2"/>
+  <text x="1145" y="650" fill="#c0caf5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="26" font-weight="700">Callers shrink to one line</text>
+  <text x="1145" y="700" fill="#e6e9f5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">trimmed_non_blank(x).map(str::to_string)</text>
+  <text x="1145" y="734" fill="#e6e9f5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24">trimmed_non_blank(x).unwrap_or(default)</text>
+  <text x="1145" y="786" fill="#a9b1d6" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">4 files, +25/-18, behavior identical;</text>
+  <text x="1145" y="820" fill="#9ece6a" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">334 backend tests green, clippy clean.</text>
+
+  <text x="55" y="1172" font-size="22" fill="#565f89">Scope: split-iterator adapters (config fingerprints, forward_proxy filters) keep their own inline chains.</text>
+</svg>

--- a/backend/src/handlers/agent_comms.rs
+++ b/backend/src/handlers/agent_comms.rs
@@ -436,12 +436,8 @@ pub async fn show_media(
         .first(&mut conn)
         .map_err(|_| AppError::NotFound("session"))?;
 
-    let mut filename = query
-        .filename
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string);
+    let mut filename =
+        shared::strings::trimmed_non_blank(query.filename.as_deref()).map(str::to_string);
     let mut body = body;
     if content_type == shared::media::PORTABLE_FIGURE_HTML_TYPE {
         (body, filename) = unwrap_portable_figure_html(body, filename)?;

--- a/backend/src/handlers/launchers.rs
+++ b/backend/src/handlers/launchers.rs
@@ -151,9 +151,7 @@ pub async fn launch_session(
 /// Trim a caller-supplied session name, returning `None` when it is absent or
 /// blank so callers fall back to the directory-basename default.
 fn normalize_custom_name(name: Option<&str>) -> Option<String> {
-    name.map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string)
+    shared::strings::trimmed_non_blank(name).map(str::to_string)
 }
 
 /// Timestamped default branch/name for an unnamed worktree launch. Built from
@@ -430,9 +428,7 @@ fn fork_child_notice(
     source_id: Uuid,
     divergence_prompt: Option<&str>,
 ) -> String {
-    let direction = divergence_prompt
-        .map(str::trim)
-        .filter(|prompt| !prompt.is_empty())
+    let direction = shared::strings::trimmed_non_blank(divergence_prompt)
         .unwrap_or("Please await new directions from the user.");
     format!(
         "This session was forked from Agent Portal session \"{source_name}\" ({source_id}). \

--- a/backend/src/handlers/profile.rs
+++ b/backend/src/handlers/profile.rs
@@ -26,12 +26,7 @@ pub async fn update_profile(
 ) -> Result<EmptyResponse, AppError> {
     // Trim and treat blank as "clear" — a whitespace-only nickname would render
     // as an invisible label, which is worse than falling back to the name.
-    let nickname = body
-        .nickname
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string);
+    let nickname = shared::strings::trimmed_non_blank(body.nickname.as_deref()).map(str::to_string);
 
     if let Some(ref n) = nickname {
         if n.chars().count() > MAX_NICKNAME_LEN {

--- a/shared/src/strings.rs
+++ b/shared/src/strings.rs
@@ -10,6 +10,14 @@ pub fn is_non_blank(s: &str) -> bool {
     !s.trim().is_empty()
 }
 
+/// The trimmed text when `value` holds non-whitespace text; `None` when it is
+/// absent or blank. Single home for the repeated
+/// `.map(str::trim).filter(|s| !s.is_empty())` chain on optional inputs.
+#[must_use]
+pub fn trimmed_non_blank(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|s| !s.is_empty())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -20,5 +28,17 @@ mod tests {
         assert!(!is_non_blank("   "));
         assert!(!is_non_blank("\t\n "));
         assert!(is_non_blank("  hi  "));
+    }
+
+    #[test]
+    fn trimmed_non_blank_trims_or_rejects() {
+        assert_eq!(
+            trimmed_non_blank(Some("  api-refactor  ")),
+            Some("api-refactor")
+        );
+        assert_eq!(trimmed_non_blank(Some("hi")), Some("hi"));
+        assert_eq!(trimmed_non_blank(Some("   ")), None);
+        assert_eq!(trimmed_non_blank(Some("")), None);
+        assert_eq!(trimmed_non_blank(None), None);
     }
 }


### PR DESCRIPTION
![Visual summary](https://raw.githubusercontent.com/meawoppl/agent-portal/06917d9b6f40f3c2c35e7db6f7f2c43e72e64afa/.0-pr-viz/001971.svg)

Four backend call sites hand-rolled the same trim-and-reject-blank chain on optional inputs. Adds shared::strings::trimmed_non_blank as the single borrowed home (next to is_non_blank) plus a unit test, and switches profile nickname, show_media filename, normalize_custom_name, and the fork notice direction to it. Behavior identical.